### PR TITLE
update readme and package.json with correct version of node

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 # web-monorepo
 
 ## Prerequisties
-* `Node >=16.17.0`
+* `Node <=16.17.1`
 * A global installation of `yarn >=1.17.0`
 ** With such a version globally installed, all `yarn` commands executed in this repo will be delegated to the "pinned" `yarn@3.3.1` installation included in `.yarn/releases`
 

--- a/package.json
+++ b/package.json
@@ -22,5 +22,11 @@
   "prettier": "@veupathdb/prettier-config",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,css,scss,md}": "prettier --write"
+  },
+  "volta": {
+    "node": "16.17.1"
+  },
+  "engines": {
+    "node": "<=16.17.1"
   }
 }


### PR DESCRIPTION
The version of node listed in the readme is incorrect. This PR fixes that, and also sets the `engines` and `volta` fields.