### PR TITLE
GitHub action publish

### DIFF
--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -10,17 +10,6 @@ on:
       - 'packages/sites/*/package.json' ## Only run with package.json is updated
 jobs:
 
-  # Cache yarn install command
-  cache-yarn:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14
-          cache: yarn
-      - run: yarn
-
   # Gather the names of the sites directories and store it as an output variable 
   dirs:
     runs-on: ubuntu-latest
@@ -31,6 +20,7 @@ jobs:
       - id: set-matrix
         run: echo "matrix=$(ls packages/sites |  jq -Rsc '. / "\n" - [""]')" >> $GITHUB_OUTPUT
   
+  # Publish sites packages to npm
   publish:
     name: Publish ${{ matrix.dir }}
     needs:

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -36,7 +36,7 @@ jobs:
     name: Publish ${{ matrix.dir }}
     needs:
       - dirs
-      - cache
+      - cache-yarn
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -46,8 +46,9 @@ jobs:
           node-version: 14
           cache: yarn
       - run: yarn
-      - run: yarn nx run-many --target=build-npm-modules
+      - run: yarn nx bundle:npm @veupathdb/{{matrix.dir}}
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
+          package: packages/sites/${{ matrix.dir }}/package.json

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -4,9 +4,11 @@ name: NPM Publish Sites
 on:
   push:
     branches:
-      - 'main'
+      - main
+
   paths:
       - 'packages/sites/*/package.json'
+
 jobs:
 
   # Gather the names of the sites directories and store it as an output variable 

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -1,0 +1,55 @@
+## Publish packages/sites/** to npm
+
+name: NPM Publish Sites
+on:
+  push:
+    branches:
+      - main
+jobs:
+
+  # Cache yarn install command
+  cache-yarn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: yarn
+      - uses: nrwl/nx-set-shas@v3
+      - run: yarn
+
+  # Gather the names of the sites directories and store it as an output variable 
+  dirs:
+    runs-on: ubuntu-latest
+    outpus:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: set-matrix
+        run: echo "::set-output name=matrix::$(ls packages/sites |  jq -Rsc '. / "\n" - [""]')"
+  
+  publish:
+    name: Publish ${{ matrix.dir }}
+    needs:
+      - dirs
+      - cache
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dir: ${{fromJSON(needs.dirs.outputs.matrix)}}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: yarn
+      - run: yarn
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -44,10 +44,10 @@ jobs:
         with:
           node-version: 14
           cache: yarn
-      - env:
-          NODE_OPTIONS: --max-old-space-size=4096
       - run: yarn
       - run: yarn nx bundle:npm @veupathdb/${{matrix.dir}}
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 14
@@ -30,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: set-matrix
-        run: echo "::set-output name=matrix::$(ls packages/sites |  jq -Rsc '. / "\n" - [""]')"
+        run: echo "matrix=$(ls packages/sites |  jq -Rsc '. / "\n" - [""]')" >> $GITHUB_OUTPUT
   
   publish:
     name: Publish ${{ matrix.dir }}
@@ -43,13 +41,12 @@ jobs:
         dir: ${{fromJSON(needs.dirs.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 14
           cache: yarn
       - run: yarn
+      - run: yarn nx run-many --target=build-npm-modules
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -4,7 +4,7 @@ name: NPM Publish Sites
 on:
   push:
     branches:
-      - main
+      - 'main'
   paths:
       - 'packages/sites/*/package.json' ## Only run with package.json is updated
 jobs:

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -25,7 +25,7 @@ jobs:
   # Gather the names of the sites directories and store it as an output variable 
   dirs:
     runs-on: ubuntu-latest
-    outpus:
+    outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -5,13 +5,11 @@ on:
   push:
     branches:
       - main
-
   paths:
-      - 'packages/sites/*/package.json'
+    - 'packages/sites/*/package.json'
 
 jobs:
-
-  # Gather the names of the sites directories and store it as an output variable 
+  # Gather the names of the sites directories and store it as an output variable
   dirs:
     runs-on: ubuntu-latest
     outputs:
@@ -20,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - id: set-matrix
         run: echo "matrix=$(ls packages/sites |  jq -Rsc '. / "\n" - [""]')" >> $GITHUB_OUTPUT
-  
+
   # Publish sites packages to npm
   publish:
     name: Publish ${{ matrix.dir }}

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -25,7 +25,6 @@ jobs:
     name: Publish ${{ matrix.dir }}
     needs:
       - dirs
-      - cache-yarn
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - 'main'
   paths:
-      - 'packages/sites/*/package.json' ## Only run with package.json is updated
+      - 'packages/sites/*/package.json'
 jobs:
 
   # Gather the names of the sites directories and store it as an output variable 

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           node-version: 14
           cache: yarn
+      - env:
+          NODE_OPTIONS: --max-old-space-size=4096
       - run: yarn
       - run: yarn nx bundle:npm @veupathdb/${{matrix.dir}}
       - uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - github-action-publish ## just for testing... delete before merging
 jobs:
 
   # Cache yarn install command

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - github-action-publish ## just for testing... delete before merging
+    paths:
+      - 'packages/sites/*/package.json' ## Only run with package.json is updated
 jobs:
 
   # Cache yarn install command

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           node-version: 14
           cache: yarn
-      - uses: nrwl/nx-set-shas@v3
       - run: yarn
 
   # Gather the names of the sites directories and store it as an output variable 
@@ -46,7 +45,7 @@ jobs:
           node-version: 14
           cache: yarn
       - run: yarn
-      - run: yarn nx bundle:npm @veupathdb/{{matrix.dir}}
+      - run: yarn nx bundle:npm @veupathdb/${{matrix.dir}}
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -5,8 +5,7 @@ on:
   push:
     branches:
       - main
-      - github-action-publish ## just for testing... delete before merging
-    paths:
+  paths:
       - 'packages/sites/*/package.json' ## Only run with package.json is updated
 jobs:
 

--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - main
-  paths:
-    - 'packages/sites/*/package.json'
+    paths:
+      - 'packages/sites/*/package.json'
 
 jobs:
   # Gather the names of the sites directories and store it as an output variable

--- a/nx.json
+++ b/nx.json
@@ -23,10 +23,10 @@
     "start": {
       "dependsOn": ["^build-npm-modules"]
     },
-    "bundle": {
+    "bundle:dev": {
       "dependsOn": ["^build-npm-modules"]
     },
-    "prepack": {
+    "bundle:npm": {
       "dependsOn": ["^build-npm-modules"]
     },
     "storybook": {

--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,9 @@
 {
   "extends": "nx/presets/npm.json",
+  "workspaceLayout": {
+    "appsDir": "packages/sites",
+    "libsDir": "packages/libs"
+  },
   "tasksRunnerOptions": {
     "default": {
       "runner": "nx/tasks-runners/default",

--- a/packages/sites/clinepi-site/package.json
+++ b/packages/sites/clinepi-site/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "veupathdb-react-scripts run-site-dev-server --config webpack.config.local.mjs",
-    "bundle": "rm -rf dist && webpack",
-    "prepack": "rm -rf dist && BROWSERSLIST_ENV=modern webpack --mode=production && BROWSERSLIST_ENV=legacy webpack --mode=production"
+    "bundle:dev": "rm -rf dist && webpack",
+    "bundle:npm": "rm -rf dist && BROWSERSLIST_ENV=modern webpack --mode=production && BROWSERSLIST_ENV=legacy webpack --mode=production"
   },
   "keywords": [],
   "author": "",
@@ -14,7 +14,7 @@
   "browserslist": [
     "extends @veupathdb/browserslist-config"
   ],
-  "dependencies": {
+  "devDependencies": {
     "@emotion/react": "^11.10.0",
     "@emotion/serialize": "^1.0.2",
     "@emotion/styled": "^11.10.0",
@@ -37,9 +37,7 @@
     "react-router-dom": "^5.3.0",
     "redux": "^4.0.0",
     "redux-observable": "^1.2.0",
-    "rxjs": "^6.2.2"
-  },
-  "devDependencies": {
+    "rxjs": "^6.2.2",
     "@babel/cli": "^7.14.8",
     "@babel/core": "^7.17.9",
     "@babel/preset-env": "^7.16.11",
@@ -72,12 +70,6 @@
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4",
     "webpack-merge": "^4.2.1"
-  },
-  "relativeDependencies": {
-    "@veupathdb/eda": "../../web-eda",
-    "@veupathdb/wdk-client": "../../WDKClient/Client",
-    "@veupathdb/web-common": "../../EbrcWebsiteCommon/Client",
-    "@veupathdb/study-data-access": "../../web-study-data-access"
   },
   "files": [
     "dist",

--- a/packages/sites/clinepi-site/package.json
+++ b/packages/sites/clinepi-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/clinepi-site",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/sites/clinepi-site/package.json
+++ b/packages/sites/clinepi-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/clinepi-site",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/sites/genomics-site/package.json
+++ b/packages/sites/genomics-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/genomics-site",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/sites/genomics-site/package.json
+++ b/packages/sites/genomics-site/package.json
@@ -5,13 +5,13 @@
   "license": "MIT",
   "scripts": {
     "start": "veupathdb-react-scripts run-site-dev-server --config webpack.config.local.mjs",
-    "bundle": "rm -rf dist && webpack",
-    "prepack": "rm -rf dist && BROWSERSLIST_ENV=modern webpack --mode=production && BROWSERSLIST_ENV=legacy webpack --mode=production"
+    "bundle:dev": "rm -rf dist && webpack",
+    "bundle:npm": "rm -rf dist && BROWSERSLIST_ENV=modern webpack --mode=production && BROWSERSLIST_ENV=legacy webpack --mode=production"
   },
   "browserslist": [
     "extends @veupathdb/browserslist-config"
   ],
-  "dependencies": {
+  "devDependencies": {
     "@emotion/react": "^11.10.0",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
@@ -42,9 +42,7 @@
     "recoil": "^0.2.0",
     "redux": "^4.0.0",
     "redux-observable": "^1.2.0",
-    "rxjs": "^6.2.2"
-  },
-  "devDependencies": {
+    "rxjs": "^6.2.2",
     "@babel/cli": "^7.14.8",
     "@babel/core": "^7.17.9",
     "@babel/preset-env": "^7.16.11",
@@ -84,10 +82,6 @@
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4",
     "webpack-merge": "^4.2.1"
-  },
-  "relativeDependencies": {
-    "@veupathdb/wdk-client": "../../WDKClient/Client",
-    "@veupathdb/web-common": "../../EbrcWebsiteCommon/Client"
   },
   "files": [
     "dist",

--- a/packages/sites/mbio-site/package.json
+++ b/packages/sites/mbio-site/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "veupathdb-react-scripts run-site-dev-server --config webpack.config.local.mjs",
-    "bundle": "rm -rf dist && webpack",
-    "prepack": "rm -rf dist && BROWSERSLIST_ENV=modern webpack --mode=production && BROWSERSLIST_ENV=legacy webpack --mode=production"
+    "bundle:dev": "rm -rf dist && webpack",
+    "bundle:npm": "rm -rf dist && BROWSERSLIST_ENV=modern webpack --mode=production && BROWSERSLIST_ENV=legacy webpack --mode=production"
   },
   "keywords": [],
   "author": "",
@@ -14,7 +14,7 @@
   "browserslist": [
     "extends @veupathdb/browserslist-config"
   ],
-  "dependencies": {
+  "devDependencies": {
     "@emotion/react": "^11.10.0",
     "@emotion/serialize": "^1.0.2",
     "@emotion/styled": "^11.10.0",
@@ -37,9 +37,7 @@
     "react-router-dom": "^5.3.0",
     "redux": "^4.0.0",
     "redux-observable": "^1.2.0",
-    "rxjs": "^6.2.2"
-  },
-  "devDependencies": {
+    "rxjs": "^6.2.2",
     "@babel/cli": "^7.14.8",
     "@babel/core": "^7.17.9",
     "@babel/preset-env": "^7.16.11",
@@ -72,9 +70,6 @@
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4",
     "webpack-merge": "^4.2.1"
-  },
-  "relativeDependencies": {
-    "@veupathdb/web-common": "../../EbrcWebsiteCommon/Client"
   },
   "files": [
     "dist",

--- a/packages/sites/mbio-site/package.json
+++ b/packages/sites/mbio-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/mbio-site",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/sites/mbio-site/package.json
+++ b/packages/sites/mbio-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/mbio-site",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/packages/sites/ortho-site/package.json
+++ b/packages/sites/ortho-site/package.json
@@ -6,13 +6,13 @@
   "license": "MIT",
   "scripts": {
     "start": "veupathdb-react-scripts run-site-dev-server --config webpack.config.local.mjs",
-    "bundle": "rm -rf dist && webpack",
-    "prepack": "rm -rf dist && BROWSERSLIST_ENV=modern webpack --mode=production && BROWSERSLIST_ENV=legacy webpack --mode=production"
+    "bundle:dev": "rm -rf dist && webpack",
+    "bundle:npm": "rm -rf dist && BROWSERSLIST_ENV=modern webpack --mode=production && BROWSERSLIST_ENV=legacy webpack --mode=production"
   },
   "browserslist": [
     "extends @veupathdb/browserslist-config"
   ],
-  "dependencies": {
+  "devDependencies": {
     "@emotion/react": "^11.10.0",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
@@ -44,9 +44,7 @@
     "react-spring": "^8.0.27",
     "redux": "^4.0.0",
     "redux-observable": "^1.2.0",
-    "rxjs": "^6.2.2"
-  },
-  "devDependencies": {
+    "rxjs": "^6.2.2",
     "@babel/cli": "^7.14.8",
     "@babel/core": "^7.17.9",
     "@babel/preset-env": "^7.16.11",

--- a/packages/sites/ortho-site/package.json
+++ b/packages/sites/ortho-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/ortho-site",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "repository": "https://github.com/VEuPathDB/OrthoMCLClient",
   "license": "MIT",


### PR DESCRIPTION
This PR adds a workflow for publishing npm packages for sites. The workflow will only run when commits are pushed to `main` and changes are made to sites package.json. 

I also cleaned up dependencies in sites package.json so that consumers of the sites npm packages only install the generated bundles.