### PR TITLE
Implement new genomics download page

### DIFF
--- a/packages/libs/coreui/tsconfig.json
+++ b/packages/libs/coreui/tsconfig.json
@@ -5,6 +5,8 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     // "isolatedModules": true,
+    "sourceMap": true,
+    "declarationMap": true,
     "outDir": "dist",
     "esModuleInterop": true,
     "strict": true,

--- a/packages/libs/wdk-client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
+++ b/packages/libs/wdk-client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
@@ -2,9 +2,10 @@ import { isEqual, partition, groupBy } from 'lodash';
 import { Seq } from '../../../../Utils/IterableUtils';
 import { preorder } from '../../../../Utils/TreeUtils';
 import { combineEpics, Epic } from 'redux-observable';
-import { concat, empty, from, merge, Observable, of } from 'rxjs';
+import { concat, EMPTY, empty, from, merge, Observable, of } from 'rxjs';
 import {
   debounceTime,
+  delay,
   filter,
   map,
   mergeMap,
@@ -22,6 +23,10 @@ import {
   UnloadQuestionAction,
   UpdateDependentParamsAction,
   paramError,
+  InitParamAction,
+  INIT_PARAM,
+  initParam,
+  updateParamValue,
 } from '../../../../Actions/QuestionActions';
 import {
   State,
@@ -58,10 +63,14 @@ import {
   invalidateOntologyTerms,
   updateFieldState,
   summaryCountsLoaded,
+  updateFilters,
 } from '../../../../Actions/FilterParamActions';
 import {
   Filter,
+  MemberFilter,
   MultiFilter,
+  RangeField,
+  RangeFilter,
 } from '../../../../Components/AttributeFilter/Types';
 import { Action } from '../../../../Actions';
 import {
@@ -91,20 +100,74 @@ type LoadDeps = {
   loadSummaryFor: string | null;
 };
 
+const observeInitialParamData: Observer = (action$, state$, services) => {
+  return action$.pipe(
+    filter((action): action is InitParamAction => action.type === INIT_PARAM),
+    mergeMap((action) => {
+      const { initialParamData, parameter, paramValues, searchName } =
+        action.payload;
+      if (parameter.type !== 'filter') return EMPTY;
+      // look for keys that inidicate a shorthand filter
+      const filterKeyPrefix = `${parameter.name}.`;
+      const filters: Filter[] = [];
+      for (const key in initialParamData) {
+        if (key.startsWith(filterKeyPrefix)) {
+          const fieldName = key.replace(filterKeyPrefix, '');
+          const field = parameter.ontology.find(
+            (entry) => entry.term === fieldName
+          );
+          if (field?.type == null) return EMPTY;
+          const filterValueRaw = initialParamData[key];
+          const value = (() => {
+            if (field.isRange) {
+              const [min, max] = filterValueRaw
+                .split('..')
+                .map((v) => (field.type === 'number' ? Number(v) : v));
+              return { min, max };
+            } else {
+              return filterValueRaw
+                .split(/\s*,\s*/)
+                .map((v) => (field.type === 'number' ? Number(v) : v));
+            }
+          })();
+          filters.push({
+            field: fieldName,
+            includeUnknown: false,
+            isRange: field.isRange,
+            type: field.type,
+            value: value,
+          } as Filter);
+        }
+      }
+      return of(
+        updateParamValue({
+          paramValue: JSON.stringify({ filters }),
+          paramValues,
+          parameter,
+          searchName,
+        }),
+        updateFilters({
+          prevFilters: [],
+          filters,
+          paramValues,
+          parameter,
+          searchName,
+        })
+      );
+    })
+  );
+};
+
 /**
  * When a Question is loaded, listen for parameter-specific actions and load data as needed.
  */
-const observeInit: Observer = (action$, state$, services) =>
+const observeQuestionLoaded: Observer = (action$, state$, services) =>
   action$.pipe(
-    filter(
-      (action): action is QuestionLoadedAction =>
-        action.type === QUESTION_LOADED
-    ),
+    filter((action): action is InitParamAction => action.type === INIT_PARAM),
     mergeMap((action) => {
-      const { searchName } = action.payload;
+      const { searchName, parameter } = action.payload;
       const questionState = getQuestionState(state$.value, searchName);
-      if (questionState == null) return empty();
-      const { question, paramValues } = questionState;
+      if (questionState == null || !isType(parameter)) return empty();
       const isVisible = (paramName: string) => {
         const state = getQuestionState(state$.value, searchName);
         if (state == null) return false;
@@ -113,179 +176,160 @@ const observeInit: Observer = (action$, state$, services) =>
         return state.groupUIState[parameter.group].isVisible;
       };
 
-      // Create an observable per filter param to load ontology term summaries
-      // and counts when an active ontology term is changed, or when a param
-      // value changes, but only if its group is visible.
-      return from(question.parameters).pipe(
-        filter(isType),
-        map((parameter) => ({
-          paramName: parameter.name,
-          groupName: parameter.group,
-        })),
-        mergeMap(({ paramName, groupName }) => {
-          // Create an Observable<FilterParamNew> based on actions
-          const valueChangedParameter$: Observable<LoadDeps> = action$.pipe(
-            filter(
-              (action): action is UpdateFiltersAction =>
-                action.type === UPDATE_FILTERS &&
-                action.payload.searchName === searchName &&
-                action.payload.parameter.name === paramName
-            ),
-            mergeMap((action) => {
-              const { prevFilters, filters } = action.payload;
-              const questionState = getQuestionState(state$.value, searchName);
-              if (questionState == null) return empty() as Observable<LoadDeps>;
+      const paramName = parameter.name;
+      const groupName = parameter.group;
 
-              const { activeOntologyTerm, fieldStates } =
-                questionState.paramUIState[paramName];
-              const loadSummary =
-                activeOntologyTerm != null &&
-                (fieldStates[activeOntologyTerm]?.summary == null ||
-                  !isEqual(
-                    prevFilters.filter((f) => f.field != activeOntologyTerm),
-                    filters.filter((f) => f.field !== activeOntologyTerm)
-                  ));
+      // Create an Observable<FilterParamNew> based on actions
+      const valueChangedParameter$: Observable<LoadDeps> = action$.pipe(
+        filter(
+          (action): action is UpdateFiltersAction =>
+            action.type === UPDATE_FILTERS &&
+            action.payload.searchName === searchName &&
+            action.payload.parameter.name === paramName
+        ),
+        mergeMap((action) => {
+          const { prevFilters, filters } = action.payload;
+          const questionState = getQuestionState(state$.value, searchName);
+          if (questionState == null) return empty() as Observable<LoadDeps>;
 
+          const { activeOntologyTerm, fieldStates } =
+            questionState.paramUIState[paramName];
+          const loadSummary =
+            activeOntologyTerm != null &&
+            (fieldStates[activeOntologyTerm]?.summary == null ||
+              !isEqual(
+                prevFilters.filter((f) => f.field != activeOntologyTerm),
+                filters.filter((f) => f.field !== activeOntologyTerm)
+              ));
+
+          return of({
+            paramName,
+            loadCounts: true,
+            loadSummaryFor: loadSummary ? activeOntologyTerm : null,
+          });
+        }),
+        debounceTime(1000)
+      );
+
+      const activeOntologyTermChangedParameter$: Observable<LoadDeps> =
+        action$.pipe(
+          filter(
+            (action): action is SetActiveFieldAction =>
+              action.type === SET_ACTIVE_FIELD
+          ),
+          filter(
+            (action) =>
+              action.payload.searchName === searchName &&
+              action.payload.parameter.name === paramName
+          ),
+          mergeMap(() => {
+            const questionState = getQuestionState(state$.value, searchName);
+            if (questionState == null) return empty() as Observable<LoadDeps>;
+
+            const { activeOntologyTerm, fieldStates }: FilterParamState =
+              questionState.paramUIState[paramName];
+            if (
+              activeOntologyTerm != null &&
+              (fieldStates[activeOntologyTerm]?.summary == null ||
+                fieldStates[activeOntologyTerm]?.invalid)
+            ) {
               return of({
                 paramName,
                 loadCounts: true,
-                loadSummaryFor: loadSummary ? activeOntologyTerm : null,
+                loadSummaryFor:
+                  questionState.paramUIState[paramName].activeOntologyTerm,
               });
-            }),
-            debounceTime(1000)
-          );
+            }
+            return empty() as Observable<LoadDeps>;
+          })
+        );
 
-          const activeOntologyTermChangedParameter$: Observable<LoadDeps> =
-            action$.pipe(
-              filter(
-                (action): action is SetActiveFieldAction =>
-                  action.type === SET_ACTIVE_FIELD
-              ),
-              filter(
-                (action) =>
-                  action.payload.searchName === searchName &&
-                  action.payload.parameter.name === paramName
-              ),
-              mergeMap(() => {
-                const questionState = getQuestionState(
-                  state$.value,
-                  searchName
-                );
-                if (questionState == null)
-                  return empty() as Observable<LoadDeps>;
+      const groupVisibilityChangeParameter$: Observable<LoadDeps> =
+        action$.pipe(
+          filter(
+            (action): action is ChangeGroupVisibilityAction =>
+              action.type === CHANGE_GROUP_VISIBILITY
+          ),
+          filter(
+            (action) =>
+              action.payload.searchName === searchName &&
+              action.payload.groupName === groupName
+          ),
+          mergeMap(() => {
+            const questionState = getQuestionState(state$.value, searchName);
+            if (questionState == null) return empty() as Observable<LoadDeps>;
 
-                const { activeOntologyTerm, fieldStates }: FilterParamState =
-                  questionState.paramUIState[paramName];
-                if (
-                  activeOntologyTerm != null &&
-                  (fieldStates[activeOntologyTerm]?.summary == null ||
-                    fieldStates[activeOntologyTerm]?.invalid)
-                ) {
-                  return of({
-                    paramName,
-                    loadCounts: true,
-                    loadSummaryFor:
-                      questionState.paramUIState[paramName].activeOntologyTerm,
-                  });
-                }
-                return empty() as Observable<LoadDeps>;
-              })
-            );
+            const { activeOntologyTerm, fieldStates }: FilterParamState =
+              questionState.paramUIState[paramName];
+            if (
+              activeOntologyTerm != null &&
+              (fieldStates[activeOntologyTerm]?.summary == null ||
+                fieldStates[activeOntologyTerm]?.invalid)
+            ) {
+              return of({
+                paramName,
+                loadCounts: true,
+                loadSummaryFor: activeOntologyTerm,
+              });
+            }
+            return empty() as Observable<LoadDeps>;
+          })
+        );
 
-          const groupVisibilityChangeParameter$: Observable<LoadDeps> =
-            action$.pipe(
-              filter(
-                (action): action is ChangeGroupVisibilityAction =>
-                  action.type === CHANGE_GROUP_VISIBILITY
-              ),
-              filter(
-                (action) =>
-                  action.payload.searchName === searchName &&
-                  action.payload.groupName === groupName
-              ),
-              mergeMap(() => {
-                const questionState = getQuestionState(
-                  state$.value,
-                  searchName
-                );
-                if (questionState == null)
-                  return empty() as Observable<LoadDeps>;
-
-                const { activeOntologyTerm, fieldStates }: FilterParamState =
-                  questionState.paramUIState[paramName];
-                if (
-                  activeOntologyTerm != null &&
-                  (fieldStates[activeOntologyTerm]?.summary == null ||
-                    fieldStates[activeOntologyTerm]?.invalid)
-                ) {
-                  return of({
-                    paramName,
-                    loadCounts: true,
-                    loadSummaryFor: activeOntologyTerm,
-                  });
-                }
-                return empty() as Observable<LoadDeps>;
-              })
-            );
-
-          const parameter$ = merge(
-            valueChangedParameter$,
-            activeOntologyTermChangedParameter$,
-            groupVisibilityChangeParameter$
-          ).pipe(
-            filter(({ paramName }) => isVisible(paramName)),
-            switchMap(({ paramName, loadCounts, loadSummaryFor }) => {
-              const questionState = getQuestionState(state$.value, searchName);
-              if (questionState == null) return empty() as Observable<LoadDeps>;
-              return merge(
-                loadCounts
-                  ? getSummaryCounts(
-                      services.wdkService,
-                      paramName,
-                      questionState
-                    )
-                  : empty(),
-                loadSummaryFor
-                  ? getOntologyTermSummary(
-                      services.wdkService,
-                      paramName,
-                      questionState,
-                      loadSummaryFor
-                    )
-                  : empty()
-              ) as Observable<Action>;
-            })
-          );
-
-          const filters = getFilters(paramValues[paramName]);
-          const activeField =
-            filters.length === 0
-              ? getFilterFields(
-                  getFilterParamNewFromState(
-                    getQuestionState(state$.value, searchName),
-                    paramName
-                  )
-                ).first()?.term
-              : filters[0].field;
-
-          // The order here is important. We want to first merge the child
-          // observers. THEN we want to merge the Observable of
-          // ActiveFieldSetAction. This will ensure that child observers
-          // receives that action.
+      const parameter$ = merge(
+        valueChangedParameter$,
+        activeOntologyTermChangedParameter$,
+        groupVisibilityChangeParameter$
+      ).pipe(
+        filter(({ paramName }) => isVisible(paramName)),
+        switchMap(({ paramName, loadCounts, loadSummaryFor }) => {
+          const questionState = getQuestionState(state$.value, searchName);
+          if (questionState == null) return empty() as Observable<LoadDeps>;
           return merge(
-            parameter$,
-            of(
-              setActiveField({
-                searchName,
-                parameter: getFilterParamNewFromState(questionState, paramName),
-                paramValues,
-                activeField,
-              })
-            )
+            loadCounts
+              ? getSummaryCounts(services.wdkService, paramName, questionState)
+              : empty(),
+            loadSummaryFor
+              ? getOntologyTermSummary(
+                  services.wdkService,
+                  paramName,
+                  questionState,
+                  loadSummaryFor
+                )
+              : empty()
           ) as Observable<Action>;
         }),
         takeUntil(getUnloadQuestionStream(action$, searchName))
       );
+
+      const filters = getFilters(
+        getQuestionState(state$.value, searchName).paramValues[paramName]
+      );
+      const activeField =
+        filters.length === 0
+          ? getFilterFields(
+              getFilterParamNewFromState(
+                getQuestionState(state$.value, searchName),
+                paramName
+              )
+            ).first()?.term
+          : filters[0].field;
+
+      // The order here is important. We want to first merge the child
+      // observers. THEN we want to merge the Observable of
+      // ActiveFieldSetAction. This will ensure that child observers
+      // receives that action.
+      return merge(
+        parameter$,
+        of(
+          setActiveField({
+            searchName,
+            parameter: getFilterParamNewFromState(questionState, paramName),
+            paramValues: getQuestionState(state$.value, searchName).paramValues,
+            activeField,
+          })
+        )
+      ) as Observable<Action>;
     })
   );
 
@@ -372,8 +416,9 @@ function getAllDependencies(
 
 const observeParam: Epic<Action, Action, State, EpicDependencies> =
   combineEpics<Epic<Action, Action, State>>(
-    observeInit,
-    observeUpdateDependentParamsActiveField
+    observeQuestionLoaded,
+    observeUpdateDependentParamsActiveField,
+    observeInitialParamData
   );
 
 export default observeParam;

--- a/packages/libs/wdk-client/src/Views/ResultTableSummaryView/Types.ts
+++ b/packages/libs/wdk-client/src/Views/ResultTableSummaryView/Types.ts
@@ -1,11 +1,17 @@
-import { AttributeSortingSpec, PrimaryKey } from '../../Utils/WdkModel';
+import {
+  AttributeSortingSpec,
+  PrimaryKey,
+  RecordInstance,
+} from '../../Utils/WdkModel';
 import { ResultType } from '../../Utils/WdkResult';
 import { BasketPatchIdsOperation } from '../../Service/Mixins/BasketsService';
 
 // Types that are shared by ResultTableSummaryView Components
 
 export interface Action {
-  element: React.ReactType | ((selection: string[]) => React.ReactType);
+  element:
+    | React.ReactElement
+    | ((selection: RecordInstance[]) => React.ReactElement);
 }
 
 export type BasketStatus = 'yes' | 'no' | 'loading';

--- a/packages/sites/genomics-site/.babelrc
+++ b/packages/sites/genomics-site/.babelrc
@@ -1,4 +1,4 @@
 {
   "extends": "@veupathdb/site-babel-config",
-  "ignore": [ "cytoscapeweb.min.js" ]
+  "ignore": [ "cytoscapeweb.min.js", "vendored/**" ]
 }

--- a/packages/sites/genomics-site/.eslintrc
+++ b/packages/sites/genomics-site/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "../../WDKClient/Client/.eslintrc"
+  "extends": "@veupathdb"
 }

--- a/packages/sites/genomics-site/package.json
+++ b/packages/sites/genomics-site/package.json
@@ -34,6 +34,7 @@
     "@veupathdb/components": "workspace:^",
     "@veupathdb/coreui": "workspace:^",
     "@veupathdb/eda": "workspace:^",
+    "@veupathdb/eslint-config": "workspace:^",
     "@veupathdb/http-utils": "workspace:^",
     "@veupathdb/multi-blast": "workspace:^",
     "@veupathdb/preferred-organisms": "workspace:^",

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
@@ -1,0 +1,5 @@
+.Downloads {
+  .filter-param .DataTable-Body {
+    max-height: 20vh !important;
+  }
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
@@ -1,16 +1,31 @@
 .Downloads {
+  h1 {
+    padding: 0;
+  }
+
   &-Instructions {
-    font-size: 1.4em;
+    font-size: 1.2em;
+    margin: 0.5em 0;
+    color: #444;
   }
 
   &-Filter-Container {
     outline: 2px solid #acacac;
-    margin: 3em auto 4em;
+    margin: 2em auto 3em;
     width: 60vw;
     border-radius: 8px;
-    height: 30em;
+    // height: 25em;
 
     .filter-param {
+      h3 {
+        padding: 0.25em 0;
+      }
+      .membership-actions {
+        display: none;
+      }
+      .membership-filter {
+        margin-top: 1.5em;
+      }
       .DataTable-Body {
         height: 14em;
       }
@@ -18,6 +33,9 @@
         &:nth-child(1),
         &:nth-child(2) {
           display: none;
+        }
+        &:nth-child(3) {
+          margin-top: 4em !important;
         }
       }
 
@@ -35,6 +53,24 @@
       .filters-server-side {
         min-height: auto;
       }
+    }
+  }
+
+  .ResultTableSummaryView > .MesaComponent {
+    .ActionToolbar {
+      flex-direction: row-reverse;
+      order: -1;
+      margin-right: auto;
+    }
+
+    .TableToolbar {
+      display: none;
+    }
+
+    .Toolbar + .PaginationMenu {
+      order: -2;
+      margin-right: auto;
+      margin-right: 3em;
     }
   }
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
@@ -1,5 +1,40 @@
 .Downloads {
-  .filter-param .DataTable-Body {
-    max-height: 20vh !important;
+  &-Instructions {
+    font-size: 1.4em;
+  }
+
+  &-Filter-Container {
+    outline: 2px solid #acacac;
+    margin: 3em auto 4em;
+    width: 60vw;
+    border-radius: 8px;
+    height: 30em;
+
+    .filter-param {
+      .DataTable-Body {
+        height: 14em;
+      }
+      .field-list > * {
+        &:nth-child(1),
+        &:nth-child(2) {
+          display: none;
+        }
+      }
+
+      .HeadingRow .HeadingCell,
+      .DataRow .DataCell {
+        &:nth-child(3),
+        &:nth-child(4),
+        &:nth-child(5),
+        &:nth-child(6) {
+          display: none;
+        }
+      }
+
+      .filters,
+      .filters-server-side {
+        min-height: auto;
+      }
+    }
   }
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import { useHistory, useLocation, useRouteMatch } from 'react-router';
+import { parseQueryString } from '@veupathdb/wdk-client/lib/Core/RouteEntry';
 import { SearchConfig } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { DownloadsFilter } from './DownloadsFilter';
 import { DownloadsTable } from './DownloadsTable';
@@ -10,6 +12,13 @@ const BULK_QUESTION_NAME = 'GetFileRecordsByID';
 
 export function Downloads() {
   const [searchConfig, setSearchConfig] = useState<SearchConfig>();
+  const location = useLocation();
+  const history = useHistory();
+  const match = useRouteMatch();
+  const initialParamData = useMemo(
+    () => parseQueryString({ location, history, match }),
+    [history, location, match]
+  );
 
   return (
     <div className="Downloads">
@@ -23,6 +32,7 @@ export function Downloads() {
           recordName={RECORD_NAME}
           questionName={TABLE_QUESTION_NAME}
           onChange={setSearchConfig}
+          initialParamData={initialParamData}
         />
       </div>
       {searchConfig && (

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
@@ -1,9 +1,4 @@
 import React, { useState } from 'react';
-import { colors, ExpandablePanel } from '@veupathdb/coreui';
-import {
-  ExpandablePanelStyleSpec,
-  EXPANDABLE_PANEL_PRESET_STYLES,
-} from '@veupathdb/coreui/dist/components/containers/ExpandablePanel/stylePresets';
 import { SearchConfig } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { DownloadsFilter } from './DownloadsFilter';
 import { DownloadsTable } from './DownloadsTable';
@@ -13,37 +8,23 @@ const RECORD_NAME = 'dfile';
 const TABLE_QUESTION_NAME = 'GetAllFileRecords';
 const BULK_QUESTION_NAME = 'GetFileRecordsByID';
 
-const expandablePanelStyleOverride: Partial<ExpandablePanelStyleSpec> = {
-  open: {
-    ...EXPANDABLE_PANEL_PRESET_STYLES.default.open,
-    content: {
-      divider: {
-        color: colors.gray[400],
-        thickness: 2,
-      },
-      backgroundColor: colors.white,
-    },
-  },
-};
-
 export function Downloads() {
   const [searchConfig, setSearchConfig] = useState<SearchConfig>();
 
   return (
     <div className="Downloads">
       <h1>Download Data Files</h1>
-      <ExpandablePanel
-        state={'open'}
-        title="Filter files"
-        subTitle="Filter the files displayed in the table below"
-        styleOverrides={expandablePanelStyleOverride}
-      >
+      <p className="Downloads-Instructions">
+        Use the filters to reduce the table below. Use the table to select the
+        files to download.
+      </p>
+      <div className="Downloads-Filter-Container">
         <DownloadsFilter
           recordName={RECORD_NAME}
           questionName={TABLE_QUESTION_NAME}
           onChange={setSearchConfig}
         />
-      </ExpandablePanel>
+      </div>
       {searchConfig && (
         <DownloadsTable
           tableSearchName={TABLE_QUESTION_NAME}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
@@ -1,0 +1,49 @@
+import { SubmissionMetadata } from '@veupathdb/wdk-client/lib/Actions/QuestionActions';
+import {
+  QuestionController,
+  ResultTableSummaryViewController,
+} from '@veupathdb/wdk-client/lib/Controllers';
+import { ResultType } from '@veupathdb/wdk-client/lib/Utils/WdkResult';
+import { NewStepSpec } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
+import React, { useMemo, useState } from 'react';
+
+const RECORD_NAME = 'dfile';
+const QUESTION_NAME = 'GetAllFileRecords';
+
+export function Downloads() {
+  const [resultType, setResultType] = useState<ResultType>();
+
+  const submissionMetadata: SubmissionMetadata = useMemo(
+    () => ({
+      type: 'submit-custom-form',
+      onStepSubmitted: (wdkService, submissionSpec) => {
+        setResultType({
+          type: 'answerSpec',
+          displayName: 'Download Files',
+          answerSpec: {
+            searchName: submissionSpec.searchName,
+            searchConfig: submissionSpec.searchConfig,
+          },
+        });
+      },
+    }),
+    []
+  );
+
+  return (
+    <div>
+      <h1>Downloads Page</h1>
+      <QuestionController
+        question={QUESTION_NAME}
+        recordClass={RECORD_NAME}
+        submissionMetadata={submissionMetadata}
+      />
+      {resultType && (
+        <ResultTableSummaryViewController
+          viewId="DownloadPage"
+          resultType={resultType}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
@@ -1,14 +1,30 @@
-import { ExpandablePanel } from '@veupathdb/coreui';
-import { SearchConfig } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import React, { useState } from 'react';
+import { colors, ExpandablePanel } from '@veupathdb/coreui';
+import {
+  ExpandablePanelStyleSpec,
+  EXPANDABLE_PANEL_PRESET_STYLES,
+} from '@veupathdb/coreui/dist/components/containers/ExpandablePanel/stylePresets';
+import { SearchConfig } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { DownloadsFilter } from './DownloadsFilter';
 import { DownloadsTable } from './DownloadsTable';
-
 import './Downloads.scss';
 
 const RECORD_NAME = 'dfile';
 const TABLE_QUESTION_NAME = 'GetAllFileRecords';
 const BULK_QUESTION_NAME = 'GetFileRecordsByID';
+
+const expandablePanelStyleOverride: Partial<ExpandablePanelStyleSpec> = {
+  open: {
+    ...EXPANDABLE_PANEL_PRESET_STYLES.default.open,
+    content: {
+      divider: {
+        color: colors.gray[400],
+        thickness: 2,
+      },
+      backgroundColor: colors.white,
+    },
+  },
+};
 
 export function Downloads() {
   const [searchConfig, setSearchConfig] = useState<SearchConfig>();
@@ -20,6 +36,7 @@ export function Downloads() {
         state={'open'}
         title="Filter files"
         subTitle="Filter the files displayed in the table below"
+        styleOverrides={expandablePanelStyleOverride}
       >
         <DownloadsFilter
           recordName={RECORD_NAME}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
@@ -1,39 +1,36 @@
 import { ExpandablePanel } from '@veupathdb/coreui';
-import { CollapsibleSection } from '@veupathdb/wdk-client/lib/Components';
 import { SearchConfig } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import React, { useState } from 'react';
 import { DownloadsFilter } from './DownloadsFilter';
 import { DownloadsTable } from './DownloadsTable';
 
+import './Downloads.scss';
+
 const RECORD_NAME = 'dfile';
-const QUESTION_NAME = 'GetAllFileRecords';
+const TABLE_QUESTION_NAME = 'GetAllFileRecords';
+const BULK_QUESTION_NAME = 'GetFileRecordsByID';
 
 export function Downloads() {
   const [searchConfig, setSearchConfig] = useState<SearchConfig>();
-  const [filtersCollapsed, setFiltersCollapsed] = useState(true);
-
-  console.log({ searchConfig });
 
   return (
-    <div>
-      <h1>Data files</h1>
+    <div className="Downloads">
+      <h1>Download Data Files</h1>
       <ExpandablePanel
-        state={filtersCollapsed ? 'closed' : 'open'}
-        onStateChange={(state) => setFiltersCollapsed(state === 'closed')}
+        state={'open'}
         title="Filter files"
         subTitle="Filter the files displayed in the table below"
-        // headerComponent="h2"
-        // forceRender
       >
         <DownloadsFilter
           recordName={RECORD_NAME}
-          questionName={QUESTION_NAME}
+          questionName={TABLE_QUESTION_NAME}
           onChange={setSearchConfig}
         />
       </ExpandablePanel>
       {searchConfig && (
         <DownloadsTable
-          searchName={QUESTION_NAME}
+          tableSearchName={TABLE_QUESTION_NAME}
+          bulkSearchName={BULK_QUESTION_NAME}
           searchConfig={searchConfig}
         />
       )}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.tsx
@@ -1,47 +1,40 @@
-import { SubmissionMetadata } from '@veupathdb/wdk-client/lib/Actions/QuestionActions';
-import {
-  QuestionController,
-  ResultTableSummaryViewController,
-} from '@veupathdb/wdk-client/lib/Controllers';
-import { ResultType } from '@veupathdb/wdk-client/lib/Utils/WdkResult';
-import { NewStepSpec } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
-import React, { useMemo, useState } from 'react';
+import { ExpandablePanel } from '@veupathdb/coreui';
+import { CollapsibleSection } from '@veupathdb/wdk-client/lib/Components';
+import { SearchConfig } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import React, { useState } from 'react';
+import { DownloadsFilter } from './DownloadsFilter';
+import { DownloadsTable } from './DownloadsTable';
 
 const RECORD_NAME = 'dfile';
 const QUESTION_NAME = 'GetAllFileRecords';
 
 export function Downloads() {
-  const [resultType, setResultType] = useState<ResultType>();
+  const [searchConfig, setSearchConfig] = useState<SearchConfig>();
+  const [filtersCollapsed, setFiltersCollapsed] = useState(true);
 
-  const submissionMetadata: SubmissionMetadata = useMemo(
-    () => ({
-      type: 'submit-custom-form',
-      onStepSubmitted: (wdkService, submissionSpec) => {
-        setResultType({
-          type: 'answerSpec',
-          displayName: 'Download Files',
-          answerSpec: {
-            searchName: submissionSpec.searchName,
-            searchConfig: submissionSpec.searchConfig,
-          },
-        });
-      },
-    }),
-    []
-  );
+  console.log({ searchConfig });
 
   return (
     <div>
-      <h1>Downloads Page</h1>
-      <QuestionController
-        question={QUESTION_NAME}
-        recordClass={RECORD_NAME}
-        submissionMetadata={submissionMetadata}
-      />
-      {resultType && (
-        <ResultTableSummaryViewController
-          viewId="DownloadPage"
-          resultType={resultType}
+      <h1>Data files</h1>
+      <ExpandablePanel
+        state={filtersCollapsed ? 'closed' : 'open'}
+        onStateChange={(state) => setFiltersCollapsed(state === 'closed')}
+        title="Filter files"
+        subTitle="Filter the files displayed in the table below"
+        // headerComponent="h2"
+        // forceRender
+      >
+        <DownloadsFilter
+          recordName={RECORD_NAME}
+          questionName={QUESTION_NAME}
+          onChange={setSearchConfig}
+        />
+      </ExpandablePanel>
+      {searchConfig && (
+        <DownloadsTable
+          searchName={QUESTION_NAME}
+          searchConfig={searchConfig}
         />
       )}
     </div>

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsFilter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsFilter.tsx
@@ -9,6 +9,7 @@ import { useSelector } from 'react-redux';
 interface Props {
   recordName: string;
   questionName: string;
+  initialParamData: Record<string, string>;
   onChange: (searchConfig: SearchConfig) => void;
 }
 
@@ -18,7 +19,7 @@ const submissionMetadata: SubmissionMetadata = {
 };
 
 export function DownloadsFilter(props: Props) {
-  const { recordName, questionName, onChange } = props;
+  const { recordName, questionName, initialParamData, onChange } = props;
   const paramValues = useSelector(
     (state: RootState) => state.question.questions[questionName]?.paramValues
   );
@@ -36,6 +37,7 @@ export function DownloadsFilter(props: Props) {
       recordClass={recordName}
       submissionMetadata={submissionMetadata}
       FormComponent={FormComponent}
+      initialParamData={initialParamData}
     />
   );
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsFilter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsFilter.tsx
@@ -1,0 +1,46 @@
+import { SubmissionMetadata } from '@veupathdb/wdk-client/lib/Actions/QuestionActions';
+import { QuestionController } from '@veupathdb/wdk-client/lib/Controllers';
+import { RootState } from '@veupathdb/wdk-client/lib/Core/State/Types';
+import { SearchConfig } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import { Props as FormProps } from '@veupathdb/wdk-client/lib/Views/Question/DefaultQuestionForm';
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+interface Props {
+  recordName: string;
+  questionName: string;
+  onChange: (searchConfig: SearchConfig) => void;
+}
+
+const submissionMetadata: SubmissionMetadata = {
+  type: 'submit-custom-form',
+  onStepSubmitted: () => {},
+};
+
+export function DownloadsFilter(props: Props) {
+  const { recordName, questionName, onChange } = props;
+  const paramValues = useSelector(
+    (state: RootState) => state.question.questions[questionName]?.paramValues
+  );
+  useEffect(() => {
+    if (paramValues) {
+      onChange({
+        parameters: paramValues,
+      });
+    }
+  }, [paramValues, onChange]);
+
+  return (
+    <QuestionController
+      question={questionName}
+      recordClass={recordName}
+      submissionMetadata={submissionMetadata}
+      FormComponent={FormComponent}
+    />
+  );
+}
+
+function FormComponent(props: FormProps) {
+  const { parameterElements } = props;
+  return <>{Object.values(parameterElements)}</>;
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsTable.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsTable.tsx
@@ -12,28 +12,46 @@ import React, { useMemo } from 'react';
 
 interface Props {
   searchConfig: SearchConfig;
-  searchName: string;
+  /** Search name used for table */
+  tableSearchName: string;
+  /** Search name used for bulk download */
+  bulkSearchName: string;
 }
 
 export function DownloadsTable(props: Props) {
-  const { searchConfig, searchName } = props;
+  const { searchConfig, tableSearchName, bulkSearchName } = props;
   const { wdkService } = useNonNullableContext(WdkDependenciesContext);
-  const resultType: ResultType = useMemo(
+  const tableResultType: ResultType = useMemo(
     () => ({
       type: 'answerSpec',
       displayName: 'Download Files',
       answerSpec: {
-        searchName,
+        searchName: tableSearchName,
         searchConfig,
       },
     }),
-    [searchConfig, searchName]
+    [searchConfig, tableSearchName]
   );
 
   const tableActions = useMemo((): Action[] => {
     return [
       {
         element: (selectedRecords) => {
+          const resultType: ResultType = {
+            type: 'answerSpec',
+            displayName: 'Zipped Files',
+            answerSpec: {
+              searchName: bulkSearchName,
+              searchConfig: {
+                parameters: {
+                  fileIds: JSON.stringify(
+                    selectedRecords.map((record) => record.id[0].value)
+                  ),
+                },
+              },
+            },
+          };
+
           return (
             <button
               className="btn"
@@ -57,13 +75,14 @@ export function DownloadsTable(props: Props) {
         },
       },
     ];
-  }, [resultType, wdkService]);
+  }, [bulkSearchName, wdkService]);
 
   return (
     <ResultTableSummaryViewController
       tableActions={tableActions}
       viewId="DownloadPage"
-      resultType={resultType}
+      resultType={tableResultType}
+      showIdAttributeColumn={false}
     />
   );
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsTable.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsTable.tsx
@@ -1,0 +1,69 @@
+import Icon from '@veupathdb/wdk-client/lib/Components/Icon/IconAlt';
+import { ResultTableSummaryViewController } from '@veupathdb/wdk-client/lib/Controllers';
+import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
+import { WdkDependenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
+import { SearchConfig } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import {
+  downloadReport,
+  ResultType,
+} from '@veupathdb/wdk-client/lib/Utils/WdkResult';
+import { Action } from '@veupathdb/wdk-client/lib/Views/ResultTableSummaryView/ResultTableSummaryView';
+import React, { useMemo } from 'react';
+
+interface Props {
+  searchConfig: SearchConfig;
+  searchName: string;
+}
+
+export function DownloadsTable(props: Props) {
+  const { searchConfig, searchName } = props;
+  const { wdkService } = useNonNullableContext(WdkDependenciesContext);
+  const resultType: ResultType = useMemo(
+    () => ({
+      type: 'answerSpec',
+      displayName: 'Download Files',
+      answerSpec: {
+        searchName,
+        searchConfig,
+      },
+    }),
+    [searchConfig, searchName]
+  );
+
+  const tableActions = useMemo((): Action[] => {
+    return [
+      {
+        element: (selectedRecords) => {
+          return (
+            <button
+              className="btn"
+              type="button"
+              disabled={selectedRecords.length === 0}
+              onClick={() => {
+                downloadReport(
+                  wdkService,
+                  resultType,
+                  {
+                    format: 'zippedFiles',
+                    formatConfig: {},
+                  },
+                  '_blank'
+                );
+              }}
+            >
+              <Icon fa="download" /> Download selected files
+            </button>
+          );
+        },
+      },
+    ];
+  }, [resultType, wdkService]);
+
+  return (
+    <ResultTableSummaryViewController
+      tableActions={tableActions}
+      viewId="DownloadPage"
+      resultType={resultType}
+    />
+  );
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/index.ts
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/index.ts
@@ -1,0 +1,1 @@
+export { Downloads as default } from './Downloads';

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -654,7 +654,7 @@ const useHeaderMenuItems = (
           key: 'data-files-eupathdb',
           display: 'Download data files',
           type: 'reactRoute',
-          url: '/downloads/',
+          url: '/downloads',
           metadata: {
             exclude: [EuPathDB],
           },

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -10,6 +10,9 @@ import { connect } from 'react-redux';
 
 import { get, memoize } from 'lodash';
 
+// @ts-ignore
+import betaImage from '@veupathdb/wdk-client/lib/Core/Style/images/beta2-30.png';
+
 import makeSnackbarProvider, {
   SnackbarStyleProps,
 } from '@veupathdb/coreui/dist/components/notifications/SnackbarProvider';
@@ -653,6 +656,19 @@ const useHeaderMenuItems = (
         {
           key: 'data-files-eupathdb',
           display: 'Download data files',
+          type: 'externalLink',
+          url: '/common/downloads',
+          metadata: {
+            exclude: [EuPathDB],
+          },
+        },
+        {
+          key: 'data-files-eupathdb-beta',
+          display: (
+            <>
+              Download data files <img alt="BETA" src={betaImage} />
+            </>
+          ),
           type: 'reactRoute',
           url: '/downloads',
           metadata: {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/routes.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/routes.jsx
@@ -19,9 +19,7 @@ import {
   useAvailableOrganisms,
 } from '@veupathdb/preferred-organisms/lib/hooks/preferredOrganisms';
 
-import {
-  useReferenceStrains
-} from '@veupathdb/preferred-organisms/lib/hooks/referenceStrains';
+import { useReferenceStrains } from '@veupathdb/preferred-organisms/lib/hooks/referenceStrains';
 
 import { PageLoading } from './components/common/PageLoading';
 import SampleForm from './components/samples/SampleForm';
@@ -32,10 +30,11 @@ import { blastRoutes } from './blastRoutes';
 import { preferredOrganismsRoutes } from './preferredOrganismRoutes';
 import { userCommentRoutes } from './userCommentRoutes';
 import { userDatasetRoutes } from './userDatasetRoutes';
+import Downloads from './components/Downloads';
 
 // Project id is not needed for these record classes.
 // Matches urlSegment.
-const RECORD_CLASSES_WITHOUT_PROJECT_ID = [ 'dataset', 'sample' ];
+const RECORD_CLASSES_WITHOUT_PROJECT_ID = ['dataset', 'sample'];
 
 const projectRegExp = new RegExp('/' + projectId + '$');
 
@@ -55,7 +54,7 @@ function addProjectIdPkValue(props) {
 
   // Append project id to request
   let params = Object.assign({}, props.match.params, {
-    primaryKey: `${primaryKey}/${projectId}`
+    primaryKey: `${primaryKey}/${projectId}`,
   });
 
   // Create new match object with updated primaryKey segment
@@ -82,30 +81,31 @@ function addProjectIdPkValueWrapper(Route) {
     removeProjectId() {
       if (this.hasProjectId()) {
         // Remove projectId from the url. This is like a redirect.
-        this.props.history.replace(this.props.location.pathname.replace(projectRegExp, ''));
+        this.props.history.replace(
+          this.props.location.pathname.replace(projectRegExp, '')
+        );
       }
     }
     render() {
       if (this.hasProjectId()) return null;
       // Add projectId back to props and call super's loadData
-      return (
-        <Route {...addProjectIdPkValue(this.props)} />
-      )
+      return <Route {...addProjectIdPkValue(this.props)} />;
     }
-  }
+  };
 }
 
 function SiteSearchRouteComponent() {
-  const [ preferredOrganisms ] = usePreferredOrganismsState();
+  const [preferredOrganisms] = usePreferredOrganismsState();
   const availableOrganisms = useAvailableOrganisms();
-  const [ preferredOrganismsEnabled ] = usePreferredOrganismsEnabledState();
+  const [preferredOrganismsEnabled] = usePreferredOrganismsEnabledState();
   const referenceStrains = useReferenceStrains();
-  
+
   /**
    * if user's preferred organisms is less than all available organisms, we can assume the user has
    * set their preferred organisms
    */
-  const hasUserSetPreferredOrganisms = preferredOrganisms.length < Array.from(availableOrganisms).length
+  const hasUserSetPreferredOrganisms =
+    preferredOrganisms.length < Array.from(availableOrganisms).length;
 
   return (
     <SiteSearchController
@@ -120,55 +120,64 @@ function SiteSearchRouteComponent() {
 /**
  * Wrap Ebrc Routes
  */
-export const wrapRoutes = ebrcRoutes => [
+export const wrapRoutes = (ebrcRoutes) => [
+  {
+    path: '/downloads',
+    component: Downloads,
+  },
+
   {
     path: '/record/organism/:id*',
-    component: (props) => <Redirect to={`/record/dataset/${props.match.params.id}`}/>
+    component: (props) => (
+      <Redirect to={`/record/dataset/${props.match.params.id}`} />
+    ),
   },
 
   {
     path: '/fasta-tool',
     exact: false,
-    component: () => <FastaConfigController/>
+    component: () => <FastaConfigController />,
   },
 
   {
     path: '/query-grid',
-    component: () => <QueryGridController/>
+    component: () => <QueryGridController />,
   },
 
   {
     path: '/sample-form',
-    component: () => <SampleForm/>
+    component: () => <SampleForm />,
   },
 
   {
     path: '/',
-    component: () =>
+    component: () => (
       <React.Fragment>
         <FeaturedTools />
         <hr />
         <WorkshopExercises />
       </React.Fragment>
+    ),
   },
 
   {
     path: '/jbrowse',
     component: JBrowseController,
-    rootClassNameModifier: 'jbrowse'
+    rootClassNameModifier: 'jbrowse',
   },
 
   {
     path: '/search',
-    component: () =>
+    component: () => (
       <Suspense fallback={<PageLoading />}>
         <SiteSearchRouteComponent />
       </Suspense>
+    ),
   },
 
   {
     path: '/plasmoap',
-    component: PlasmoApController
+    component: PlasmoApController,
   },
 
   ...blastRoutes,
@@ -177,14 +186,11 @@ export const wrapRoutes = ebrcRoutes => [
 
   ...userCommentRoutes,
 
-  ...(
-    useUserDatasetsWorkspace
-      ? userDatasetRoutes
-      : []
-  ),
+  ...(useUserDatasetsWorkspace ? userDatasetRoutes : []),
 
-  ...ebrcRoutes.map(route => route.path.includes(':primaryKey+')
-    ? { ...route, component: addProjectIdPkValueWrapper(route.component) }
-    : route
-  )
+  ...ebrcRoutes.map((route) =>
+    route.path.includes(':primaryKey+')
+      ? { ...route, component: addProjectIdPkValueWrapper(route.component) }
+      : route
+  ),
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -8226,6 +8226,7 @@ __metadata:
     "@veupathdb/components": "workspace:^"
     "@veupathdb/coreui": "workspace:^"
     "@veupathdb/eda": "workspace:^"
+    "@veupathdb/eslint-config": "workspace:^"
     "@veupathdb/http-utils": "workspace:^"
     "@veupathdb/multi-blast": "workspace:^"
     "@veupathdb/preferred-organisms": "workspace:^"


### PR DESCRIPTION
### Description
This PR implements the new download page for genomics sites.

fixes #29

### Screenshots

![image](https://user-images.githubusercontent.com/365139/231824951-b0194609-09d9-45ec-9004-3c7bb68c7786.png)


### Implementation notes

This page makes use of two existing redux-based features: `QuestionController` and `ResultTableSummarViewController`. This new feature uses the redux state that `QuestionController` produces to derived a `ResultType` that can be passed to `ResultTableSummaryViewController`. We also take advantage of the ability to override some components' rendering to achieve the final result.

---

### TODOs
- [x] Render search form without tabs
- [x] Render results with checkboxes for bulk download
- [x] Render results with a link to download individual files

---

### Testing

- **Checkout the branch:** `git co genomics-download-page`
- **Install dependencies:** `yarn install`
- **Create `packages/sites/genomics-site/.env`**, if necessary
- **Run the dev server:** `yarn nx start @veupathdb/genomics-site`