### PR TITLE
introducing scientific notation for histogram stats and plot

### DIFF
--- a/packages/libs/components/src/plots/Histogram.tsx
+++ b/packages/libs/components/src/plots/Histogram.tsx
@@ -337,44 +337,43 @@ const Histogram = makePlotlyPlotComponent(
       }
     }, [selectingRange, selectedRange, orientation, data.series]);
 
-    const standardIndependentAxisRange:
-      | NumberOrDateRange
-      | undefined = useMemo(() => {
-      if (binSummaries.length === 0) return undefined;
+    const standardIndependentAxisRange: NumberOrDateRange | undefined =
+      useMemo(() => {
+        if (binSummaries.length === 0) return undefined;
 
-      // If independentAxisRange (x-axis) is provided
-      // adjust the min of the range to the binStart of the bin that contains that value.
-      // Likewise, adjust the max of the range to the binEnd of the bin that contains it.
-      // This avoids partial bins being displayed.
-      return {
-        min:
-          independentAxisRange?.min != null
-            ? (
-                findLast(binSummaries, (bs) =>
-                  binStartType === 'inclusive'
-                    ? independentAxisRange?.min >= bs.binStart
-                    : independentAxisRange?.min > bs.binStart
-                ) ?? { binStart: independentAxisRange?.min }
-              )?.binStart
-            : first(binSummaries)?.binStart,
-        max:
-          independentAxisRange?.max != null
-            ? (
-                find(binSummaries, (bs) =>
-                  binEndType === 'inclusive'
-                    ? independentAxisRange?.max <= bs.binEnd
-                    : independentAxisRange?.max < bs.binEnd
-                ) ?? { binEnd: independentAxisRange?.max }
-              )?.binEnd
-            : last(binSummaries)?.binEnd,
-      } as NumberOrDateRange;
-    }, [
-      data?.binWidthSlider?.valueType,
-      independentAxisRange,
-      binSummaries,
-      binStartType,
-      binEndType,
-    ]);
+        // If independentAxisRange (x-axis) is provided
+        // adjust the min of the range to the binStart of the bin that contains that value.
+        // Likewise, adjust the max of the range to the binEnd of the bin that contains it.
+        // This avoids partial bins being displayed.
+        return {
+          min:
+            independentAxisRange?.min != null
+              ? (
+                  findLast(binSummaries, (bs) =>
+                    binStartType === 'inclusive'
+                      ? independentAxisRange?.min >= bs.binStart
+                      : independentAxisRange?.min > bs.binStart
+                  ) ?? { binStart: independentAxisRange?.min }
+                )?.binStart
+              : first(binSummaries)?.binStart,
+          max:
+            independentAxisRange?.max != null
+              ? (
+                  find(binSummaries, (bs) =>
+                    binEndType === 'inclusive'
+                      ? independentAxisRange?.max <= bs.binEnd
+                      : independentAxisRange?.max < bs.binEnd
+                  ) ?? { binEnd: independentAxisRange?.max }
+                )?.binEnd
+              : last(binSummaries)?.binEnd,
+        } as NumberOrDateRange;
+      }, [
+        data?.binWidthSlider?.valueType,
+        independentAxisRange,
+        binSummaries,
+        binStartType,
+        binEndType,
+      ]);
 
     // truncation axis range
     const extendedIndependentAxisRange = extendAxisRangeForTruncations(
@@ -447,6 +446,11 @@ const Histogram = makePlotlyPlotComponent(
         numBins != null && numBins <= SMALL_NUMBER_OF_BINS
           ? numBins + 1
           : undefined,
+      ...tickSettings(
+        false,
+        extendedIndependentAxisRange,
+        data?.binWidthSlider?.valueType
+      ),
     };
 
     // if at least one bin.count is 0 < x < 1 then these are probably fractions/proportions
@@ -472,32 +476,31 @@ const Histogram = makePlotlyPlotComponent(
     ) as NumberRange | undefined;
 
     // make rectangular layout shapes for truncated axis/missing data
-    const truncatedAxisHighlighting:
-      | Partial<Shape>[]
-      | undefined = useMemo(() => {
-      if (data.series.length > 0) {
-        const filteredTruncationLayoutShapes = truncationLayoutShapes(
-          orientation,
-          standardIndependentAxisRange,
-          standardDependentAxisRange,
-          extendedIndependentAxisRange,
-          extendedDependentAxisRange,
-          axisTruncationConfig
-        );
+    const truncatedAxisHighlighting: Partial<Shape>[] | undefined =
+      useMemo(() => {
+        if (data.series.length > 0) {
+          const filteredTruncationLayoutShapes = truncationLayoutShapes(
+            orientation,
+            standardIndependentAxisRange,
+            standardDependentAxisRange,
+            extendedIndependentAxisRange,
+            extendedDependentAxisRange,
+            axisTruncationConfig
+          );
 
-        return filteredTruncationLayoutShapes;
-      } else {
-        return [];
-      }
-    }, [
-      standardIndependentAxisRange,
-      standardDependentAxisRange,
-      extendedIndependentAxisRange,
-      extendedDependentAxisRange,
-      orientation,
-      data.series,
-      axisTruncationConfig,
-    ]);
+          return filteredTruncationLayoutShapes;
+        } else {
+          return [];
+        }
+      }, [
+        standardIndependentAxisRange,
+        standardDependentAxisRange,
+        extendedIndependentAxisRange,
+        extendedDependentAxisRange,
+        orientation,
+        data.series,
+        axisTruncationConfig,
+      ]);
 
     const dependentAxisLayout: Layout['yaxis'] | Layout['xaxis'] = {
       type: dependentAxisLogScale ? 'log' : 'linear',

--- a/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
@@ -71,13 +71,8 @@ export const UIState = intersection([
 ]);
 
 export function HistogramFilter(props: Props) {
-  const {
-    variable,
-    entity,
-    analysisState,
-    studyMetadata,
-    totalEntityCount,
-  } = props;
+  const { variable, entity, analysisState, studyMetadata, totalEntityCount } =
+    props;
   const { setFilters } = analysisState;
   const filters = analysisState.analysis?.descriptor.subset.descriptor;
   const otherFilters = useDeepValue(
@@ -194,13 +189,15 @@ export function HistogramFilter(props: Props) {
         variable.type,
         dataParams.independentAxisRange
       );
-      const binWidthRange = (NumberVariable.is(variable)
-        ? { min, max }
-        : {
-            min,
-            max,
-            unit: (binWidth as TimeDelta).unit,
-          }) as NumberOrTimeDeltaRange;
+      const binWidthRange = (
+        NumberVariable.is(variable)
+          ? { min, max }
+          : {
+              min,
+              max,
+              unit: (binWidth as TimeDelta).unit,
+            }
+      ) as NumberOrTimeDeltaRange;
       const binWidthStep = step || 0.1;
 
       const hasDataEntitiesCount =
@@ -430,14 +427,10 @@ function HistogramPlotWithControls({
   ...histogramProps
 }: HistogramPlotWithControlsProps) {
   // set the state of truncation warning message
-  const [
-    truncatedIndependentAxisWarning,
-    setTruncatedIndependentAxisWarning,
-  ] = useState<string>('');
-  const [
-    truncatedDependentAxisWarning,
-    setTruncatedDependentAxisWarning,
-  ] = useState<string>('');
+  const [truncatedIndependentAxisWarning, setTruncatedIndependentAxisWarning] =
+    useState<string>('');
+  const [truncatedDependentAxisWarning, setTruncatedDependentAxisWarning] =
+    useState<string>('');
 
   const handleBinWidthChange = useCallback(
     (newBinWidth: NumberOrTimeDelta) => {
@@ -852,10 +845,7 @@ function formatStatValue(
   if (value == null) return 'N/A';
   return type === 'date'
     ? String(value).replace(/T.*$/, '')
-    : Number(value).toLocaleString(undefined, {
-        maximumFractionDigits: 4,
-        useGrouping: !(Number(value) >= 1900 && Number(value) <= 2100),
-      });
+    : Number(value).toExponential(4);
 }
 
 function computeBinSlider(

--- a/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
@@ -838,6 +838,7 @@ function tidyBinLabel(
 //
 // TODO [2022-08-10] - Consider using numberSignificantFiguresRoundUp/Down
 //                     (but the date exception thing is useful)
+// UPDATE [2023-04-04] - Introduced scientific notation, Handling year variable
 function formatStatValue(
   value: string | number | undefined,
   type: HistogramVariable['type']
@@ -845,6 +846,11 @@ function formatStatValue(
   if (value == null) return 'N/A';
   return type === 'date'
     ? String(value).replace(/T.*$/, '')
+    : // check a possible year variable
+    type === 'integer' && Number(value) >= 1900 && Number(value) <= 2100
+    ? Number.isInteger(value)
+      ? Number(value)
+      : Number(value).toFixed(4)
     : Number(value).toExponential(4);
 }
 


### PR DESCRIPTION
This will resolve https://github.com/VEuPathDB/web-eda/issues/1677 (stats) and https://github.com/VEuPathDB/EdaNewIssues/issues/603 (plot). Currently significant figures are set to be 5.

A screenshot is attached here (same example used at https://github.com/VEuPathDB/web-eda/issues/1677#issuecomment-1454240302 is utilized here for a better comparison):


![histogram-filter-segnis1](https://user-images.githubusercontent.com/12802305/228958108-7dcadd0f-6cfb-4cb5-b918-de4a48818640.png)

