### PR TITLE
Fix broken SearchBox icon placement in Safari

### DIFF
--- a/packages/libs/coreui/src/components/inputs/SearchBox/SearchBox.tsx
+++ b/packages/libs/coreui/src/components/inputs/SearchBox/SearchBox.tsx
@@ -17,8 +17,7 @@ const StyledTooltip = withStyles((theme: Theme) => ({
   },
 }))(Tooltip);
 
-type Props = {
-
+type SearchBoxProps = {
   /** Set the autofocus property of the underlying HTMLTextInputElement */
   autoFocus?: boolean;
 
@@ -41,7 +40,7 @@ type Props = {
   helpText?: string;
 
   styleOverrides?: SearchBoxStyleSpec;
-}
+};
 
 export type SearchBoxStyleSpec = {
   helpIcon?: React.CSSProperties;
@@ -50,23 +49,23 @@ export type SearchBoxStyleSpec = {
   input?: React.CSSProperties;
   container?: React.CSSProperties;
   clearSearchButton?: React.CSSProperties;
-}
+};
 
 const searchIconStyleSpec = {
   width: '0.7em',
   height: '0.7em',
   color: '#999999',
-  position: 'relative',
-  right: '25px',
-  top: '4px',
+  position: 'fixed',
+  right: '5px',
+  top: '2px',
 };
 
 const filterIconStyleSpec = {
   fill: '#999999',
-  position: 'relative',
+  position: 'fixed',
   top: '2px',
   fontSize: '1.5em',
-}
+};
 
 const defaultStyleSpec: SearchBoxStyleSpec = {
   helpIcon: {
@@ -104,11 +103,11 @@ const defaultStyleSpec: SearchBoxStyleSpec = {
     whiteSpace: 'nowrap',
     width: '100%',
     margin: '0 0.5em',
-  }
-}
+  },
+};
 
 /**
- * Consider using 'debounce' to throttle changes in parent component if 
+ * Consider using 'debounce' to throttle changes in parent component if
  * expensive operations are performed (e.g. search) in real time as the
  * user types in the box.
  */
@@ -121,21 +120,26 @@ export default function SearchBox({
   iconName = 'search',
   iconPosition = 'right',
   styleOverrides = {},
-}: Props) {
-
+}: SearchBoxProps) {
   const styleSpec: SearchBoxStyleSpec = useMemo(() => {
     const defaultStyleWithIconSpecs = {
       ...defaultStyleSpec,
       input: {
         ...defaultStyleSpec.input,
-        padding: iconPosition === 'right' ? '0.2em 2em 0.2em 1em' : '0.2em 1em 0.2em 2em',
+        padding:
+          iconPosition === 'right'
+            ? '0.2em 2em 0.2em 1em'
+            : '0.2em 1em 0.2em 2em',
       },
-      optionalIcon: 
-        iconName === 'search' ? {...searchIconStyleSpec} : 
-          iconPosition === 'right' ? {...filterIconStyleSpec, right: '25px'} : {...filterIconStyleSpec, left: '5px'}
-    }
-    return merge({}, defaultStyleWithIconSpecs, styleOverrides)
-  }, [styleOverrides, iconName, iconPosition])
+      optionalIcon:
+        iconName === 'search'
+          ? { ...searchIconStyleSpec }
+          : iconPosition === 'right'
+          ? { ...filterIconStyleSpec, right: '5px' }
+          : { ...filterIconStyleSpec, left: '5px' },
+    };
+    return merge({}, defaultStyleWithIconSpecs, styleOverrides);
+  }, [styleOverrides, iconName, iconPosition]);
 
   function handleSearchTermChange(e: React.ChangeEvent<HTMLInputElement>) {
     let searchTerm = e.currentTarget.value;
@@ -153,35 +157,33 @@ export default function SearchBox({
     onSearchTermChange!('');
   }
 
-  /** 
+  /**
    * At this point we only use two different icons in search bars: 'filter' and 'search'
-  */
-  const optionalIcon = iconName === 'search' ? (
-    <Search style={styleSpec.optionalIcon} />
-  ) : (
-    <Filter style={styleSpec.optionalIcon} />
-  );
+   */
+  const optionalIcon =
+    iconName === 'search' ? (
+      <Search style={styleSpec.optionalIcon} />
+    ) : (
+      <Filter style={styleSpec.optionalIcon} />
+    );
 
   return (
-    <div style={{
-      ...styleSpec.container
-    }}>
-      <label css={{
-        flexGrow: 1,
-      }}>
-        {iconPosition === 'left' && !searchTerm ?
-          <span style={{
-            position: 'absolute',
-            height: 0,
-            width: 0,
-          }}>
-            {optionalIcon}
-          </span>
-          : null
-        }
-        <input 
+    <div
+      style={{
+        ...styleSpec.container,
+      }}
+    >
+      <label
+        css={{
+          flexGrow: 1,
+          // this is a hack to fix the icon's position on the label instead of the viewport
+          transform: 'rotate(0)',
+        }}
+      >
+        {iconPosition === 'left' && !searchTerm ? optionalIcon : null}
+        <input
           style={{
-            ...styleSpec.input, 
+            ...styleSpec.input,
           }}
           type="search"
           autoFocus={autoFocus}
@@ -190,37 +192,26 @@ export default function SearchBox({
           placeholder={placeholderText}
           value={searchTerm}
         />
-        {searchTerm ?
+        {searchTerm ? (
           <button
             style={{
-              ...styleSpec.clearSearchButton
+              ...styleSpec.clearSearchButton,
             }}
-            type="button" 
+            type="button"
             onClick={handleResetClick}
           >
             <Close style={styleSpec.clearSearchIcon} />
-          </button> :
-          iconPosition === 'right' ?
-          <span style={{
-            position: 'absolute',
-            height: 0,
-            width: 0,
-          }}>
-            {optionalIcon}
-          </span>
-          : null
-        }
+          </button>
+        ) : iconPosition === 'right' ? (
+          optionalIcon
+        ) : null}
       </label>
       {/* use safeHtml for helpText to allow italic */}
-      {!helpText ? 
-        null : 
-        <StyledTooltip
-          title={safeHtml(helpText)}
-          interactive
-        >
-          <Help style={styleSpec.helpIcon}/>  
-        </StyledTooltip>}
+      {!helpText ? null : (
+        <StyledTooltip title={safeHtml(helpText)} interactive>
+          <Help style={styleSpec.helpIcon} />
+        </StyledTooltip>
+      )}
     </div>
   );
 }
-

--- a/packages/libs/preferred-organisms/src/lib/components/PreferredOrganismsConfig.tsx
+++ b/packages/libs/preferred-organisms/src/lib/components/PreferredOrganismsConfig.tsx
@@ -61,9 +61,8 @@ export function PreferredOrganismsConfig({
   revertConfigSelection,
   toggleHelpVisible,
 }: Props) {
-  const [showOnlyReferenceOrganisms, setShowOnlyReferenceOrganisms] = useState(
-    false
-  );
+  const [showOnlyReferenceOrganisms, setShowOnlyReferenceOrganisms] =
+    useState(false);
   const toggleShowOnlyReferenceOrganisms = useCallback(() => {
     setShowOnlyReferenceOrganisms((value) => !value);
   }, []);
@@ -250,11 +249,6 @@ export function PreferredOrganismsConfig({
                 container: {
                   justifyContent: 'flex-start',
                   marginLeft: '2em',
-                },
-              },
-              searchBox: {
-                optionalIcon: {
-                  top: '3px',
                 },
               },
             }}

--- a/packages/libs/web-common/src/components/SiteSearch/SiteSearch.tsx
+++ b/packages/libs/web-common/src/components/SiteSearch/SiteSearch.tsx
@@ -594,11 +594,6 @@ function OrganismFilter(
               padding: 0,
             },
           },
-          searchBox: {
-            optionalIcon: {
-              top: '3px',
-            },
-          },
           additionalFilters: {
             container: {
               width: '125px',

--- a/packages/libs/web-common/src/components/homepage/SearchPane.tsx
+++ b/packages/libs/web-common/src/components/homepage/SearchPane.tsx
@@ -85,7 +85,6 @@ const headerMenuItemStyleOverrides: CheckboxTreeStyleSpec = {
     optionalIcon: {
       fontSize: '1.25em',
       cursor: 'text',
-      top: '3px',
     },
   },
   treeSection: {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/OrganismFilter.tsx
@@ -1,17 +1,29 @@
 import React, { Suspense, useState } from 'react';
 import { connect } from 'react-redux';
-import { intersection } from 'lodash/fp'
+import { intersection } from 'lodash/fp';
 import { RootState } from '@veupathdb/wdk-client/lib/Core/State/Types';
-import { QuestionWithParameters, SearchConfig, TreeBoxVocabNode } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import {
+  QuestionWithParameters,
+  SearchConfig,
+  TreeBoxVocabNode,
+} from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import WdkService from '@veupathdb/wdk-client/lib/Service/WdkService';
 import { Step } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 import { requestUpdateStepSearchConfig } from '@veupathdb/wdk-client/lib/Actions/StrategyActions';
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
-import CheckboxTree, { LinksPosition } from '@veupathdb/coreui/dist/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
-import { mapStructure, pruneDescendantNodes } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
+import CheckboxTree, {
+  LinksPosition,
+} from '@veupathdb/coreui/dist/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
+import {
+  mapStructure,
+  pruneDescendantNodes,
+} from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 import { ResultType } from '@veupathdb/wdk-client/lib/Utils/WdkResult';
-import {makeClassNameHelper} from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
-import { areTermsInString, makeSearchHelpText } from '@veupathdb/wdk-client/lib/Utils/SearchUtils';
+import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import {
+  areTermsInString,
+  makeSearchHelpText,
+} from '@veupathdb/wdk-client/lib/Utils/SearchUtils';
 import { useWdkServiceWithRefresh } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 import { makeCommonErrorMessage } from '@veupathdb/wdk-client/lib/Utils/Errors';
 
@@ -19,17 +31,17 @@ import { pruneNodesWithSingleExtendingChild } from '@veupathdb/web-common/lib/ut
 
 import {
   ORGANISM_PROPERTIES_KEY,
-  SHOW_ONLY_PREFERRED_ORGANISMS_PROPERTY
+  SHOW_ONLY_PREFERRED_ORGANISMS_PROPERTY,
 } from '@veupathdb/preferred-organisms/lib/components/OrganismParam';
 
 import {
   usePreferredOrganismsEnabledState,
-  usePreferredOrganismsState
+  usePreferredOrganismsState,
 } from '@veupathdb/preferred-organisms/lib/hooks/preferredOrganisms';
 
 import './OrganismFilter.scss';
 
-const cx = makeClassNameHelper('OrganismFilter')
+const cx = makeClassNameHelper('OrganismFilter');
 
 // constants for service calls
 const ALLOWABLE_RECORD_CLASS_NAME = 'transcript';
@@ -40,13 +52,13 @@ const HISTOGRAM_REPORTER_NAME = 'byValue';
 const HISTOGRAM_FILTER_NAME = 'byValue';
 
 // session storage prop name to hold filter pane expansion preference
-const ORGANISM_FILTER_PANE_EXPANSION_KEY = "defaultOrganismFilterPaneExpansion";
+const ORGANISM_FILTER_PANE_EXPANSION_KEY = 'defaultOrganismFilterPaneExpansion';
 
 // initial values for component state
 const DEFAULT_PANE_EXPANSION = true;
 const DEFAULT_HIDE_ZEROES = false;
 
-const TITLE = "Organism Filter";
+const TITLE = 'Organism Filter';
 
 // props passed into this component by caller
 type OwnProps = {
@@ -66,9 +78,11 @@ type NO_ORGANISM_FILTER_APPLIED = null;
 const NO_ORGANISM_FILTER_APPLIED = null;
 
 // configuration type of the organism (byValue) filter
-type OrgFilterConfig = NO_ORGANISM_FILTER_APPLIED | {
-  values: Array<string>;
-}
+type OrgFilterConfig =
+  | NO_ORGANISM_FILTER_APPLIED
+  | {
+      values: Array<string>;
+    };
 
 type OrgFilterStatistics = {
   subsetSize: number;
@@ -76,18 +90,18 @@ type OrgFilterStatistics = {
   numDistinctValues: number;
   numDistinctEntityRecords: number;
   numMissingCases: number;
-}
+};
 
 // type of the data returned by the filter summary (byValue reporter)
 type OrgFilterSummary = {
-  statistics: OrgFilterStatistics
+  statistics: OrgFilterStatistics;
   histogram: Array<{
     value: number;
     binStart: string;
     binEnd: string;
     binLabel: string;
-  }>
-}
+  }>;
+};
 
 // type of node used to render the org filter checkbox tree
 type TaxonomyNodeWithCount = {
@@ -95,18 +109,20 @@ type TaxonomyNodeWithCount = {
   display: string;
   count: number;
   children: TaxonomyNodeWithCount[];
-}
+};
 
 type ExpansionBarProps = {
   onClick: () => void;
   message: string;
   arrow: string;
-}
+};
 
 function ExpansionBar(props: ExpansionBarProps) {
   return (
     <div className={cx('--ExpansionBar')} onClick={props.onClick}>
-      {props.arrow}<span className={cx('--ExpansionBarText')}>{props.message}</span>{props.arrow}
+      {props.arrow}
+      <span className={cx('--ExpansionBarText')}>{props.message}</span>
+      {props.arrow}
     </div>
   );
 }
@@ -116,11 +132,7 @@ interface ContainerProps {
 }
 
 function Container(props: ContainerProps) {
-  return (
-    <div className={cx()}>
-      {props.children}
-    </div>
-  )
+  return <div className={cx()}>{props.children}</div>;
 }
 
 function OrganismFilter({ resultType, ...otherProps }: Props) {
@@ -133,14 +145,12 @@ function OrganismFilter({ resultType, ...otherProps }: Props) {
 
   return (
     <Suspense
-      fallback={(
+      fallback={
         <Container>
-          <h3 className={cx('--Heading')}>
-            {TITLE}
-          </h3>
+          <h3 className={cx('--Heading')}>{TITLE}</h3>
           <Loading />
         </Container>
-      )}
+      }
     >
       <OrganismFilterForStep step={step} {...otherProps} />
     </Suspense>
@@ -149,51 +159,60 @@ function OrganismFilter({ resultType, ...otherProps }: Props) {
 
 type OrganismFilterForStepProps = { step: Step } & Omit<Props, 'resultType'>;
 
-function OrganismFilterForStep({ step, requestUpdateStepSearchConfig }: OrganismFilterForStepProps) {
-  const [ preferredOrganismsEnabled ] = usePreferredOrganismsEnabledState();
-  const [ preferredOrganisms ] = usePreferredOrganismsState();
+function OrganismFilterForStep({
+  step,
+  requestUpdateStepSearchConfig,
+}: OrganismFilterForStepProps) {
+  const [preferredOrganismsEnabled] = usePreferredOrganismsEnabledState();
+  const [preferredOrganisms] = usePreferredOrganismsState();
 
   // if temporary value assigned, use until user clears or hits apply;
   // else check step for a filter value and if present, use; else use empty string (no filter)
-  let appliedFilterConfig: OrgFilterConfig = findOrganismFilterConfig(step.searchConfig);
+  let appliedFilterConfig: OrgFilterConfig = findOrganismFilterConfig(
+    step.searchConfig
+  );
 
   // whether organism filter pane is expanded vs pushed against left wall of results pane
-  let initialIsExpandedStr = sessionStorage.getItem(ORGANISM_FILTER_PANE_EXPANSION_KEY);
-  let initialIsExpanded = initialIsExpandedStr ? initialIsExpandedStr === "true" : DEFAULT_PANE_EXPANSION;
-  const [ isExpanded, setExpanded ] = useState<boolean>(initialIsExpanded);
+  let initialIsExpandedStr = sessionStorage.getItem(
+    ORGANISM_FILTER_PANE_EXPANSION_KEY
+  );
+  let initialIsExpanded = initialIsExpandedStr
+    ? initialIsExpandedStr === 'true'
+    : DEFAULT_PANE_EXPANSION;
+  const [isExpanded, setExpanded] = useState<boolean>(initialIsExpanded);
 
   // whether to hide leaves with zero records
-  const [ hideZeroes, setHideZeroes ] = useState<boolean>(DEFAULT_HIDE_ZEROES);
+  const [hideZeroes, setHideZeroes] = useState<boolean>(DEFAULT_HIDE_ZEROES);
 
   // previous step prop passed; decides whether we should reload the data below
-  const [ currentStep, setCurrentStep ] = useState<Step | null>(null);
-  let [ searchConfigChangeRequested, setSearchConfigChangeRequested ] = useState<boolean>(false);
+  const [currentStep, setCurrentStep] = useState<Step | null>(null);
+  let [searchConfigChangeRequested, setSearchConfigChangeRequested] =
+    useState<boolean>(false);
 
   const stepQuestion = useWdkServiceWithRefresh(
-    wdkService => wdkService.getQuestionAndParameters(step.searchName),
+    (wdkService) => wdkService.getQuestionAndParameters(step.searchName),
     [step.searchName]
   );
 
   // organism param (including taxonomy data) retrieved from service when component is initially loaded
-  const taxonomyTree = useWdkServiceWithRefresh(
-    fetchTaxonomyTree,
-    []
-  );
+  const taxonomyTree = useWdkServiceWithRefresh(fetchTaxonomyTree, []);
 
   // counts of genes of each organism in the result; retrieved when component is loaded and when step is revised
   const filterSummary = useWdkServiceWithRefresh(
-    wdkService => fetchFilterSummary(wdkService, step.id),
-    [ step ]
+    (wdkService) => fetchFilterSummary(wdkService, step.id),
+    [step]
   );
 
   // current value of filter shown in the tree (will be cleared if applied to the step)
-  let [ temporaryFilterConfig, setTemporaryFilterConfig ] = useState<OrgFilterConfig>(appliedFilterConfig);
+  let [temporaryFilterConfig, setTemporaryFilterConfig] =
+    useState<OrgFilterConfig>(appliedFilterConfig);
 
   // current value of checkbox tree's search box
-  const [ searchTerm, setSearchTerm ] = useState<string>("");
+  const [searchTerm, setSearchTerm] = useState<string>('');
 
   // currently expanded nodes (null indicates user has not yet changed the value)
-  const [ savedExpandedNodeIds, setExpandedNodeIds ] = useState<string[] | null>(null);
+  const [savedExpandedNodeIds, setExpandedNodeIds] =
+    useState<string[] | null>(null);
 
   // clear dependent data if step has changed
   // FIXME: This logic should be moved into an effect
@@ -206,7 +225,10 @@ function OrganismFilterForStep({ step, requestUpdateStepSearchConfig }: Organism
   }
 
   function setExpandedAndPref(isExpanded: boolean) {
-    sessionStorage.setItem(ORGANISM_FILTER_PANE_EXPANSION_KEY, isExpanded.toString());
+    sessionStorage.setItem(
+      ORGANISM_FILTER_PANE_EXPANSION_KEY,
+      isExpanded.toString()
+    );
     setExpanded(isExpanded);
   }
 
@@ -214,35 +236,61 @@ function OrganismFilterForStep({ step, requestUpdateStepSearchConfig }: Organism
   if (!isExpanded) {
     return (
       <div style={{ position: 'relative' }}>
-        <ExpansionBar onClick={() => setExpandedAndPref(true)} message={'Show ' + TITLE} arrow="&dArr;"/>
+        <ExpansionBar
+          onClick={() => setExpandedAndPref(true)}
+          message={'Show ' + TITLE}
+          arrow="&dArr;"
+        />
       </div>
     );
   }
 
   // assign record counts and short display names to tree nodes, and trim zeroes if necessary
-  let taxonomyTreeWithCounts: TaxonomyNodeWithCount | undefined = taxonomyTree && filterSummary?.available && stepQuestion
-    ? createDisplayableTree(taxonomyTree, filterSummary.value, stepQuestion, hideZeroes, preferredOrganismsEnabled, preferredOrganisms)
-    : undefined;
+  let taxonomyTreeWithCounts: TaxonomyNodeWithCount | undefined =
+    taxonomyTree && filterSummary?.available && stepQuestion
+      ? createDisplayableTree(
+          taxonomyTree,
+          filterSummary.value,
+          stepQuestion,
+          hideZeroes,
+          preferredOrganismsEnabled,
+          preferredOrganisms
+        )
+      : undefined;
 
   // org filter config currently applied on the step (if any) - used for cancel button
-  let appliedFilterList = appliedFilterConfig == NO_ORGANISM_FILTER_APPLIED ? undefined : appliedFilterConfig.values;
+  let appliedFilterList =
+    appliedFilterConfig == NO_ORGANISM_FILTER_APPLIED
+      ? undefined
+      : appliedFilterConfig.values;
 
   // only show apply and cancel buttons if user has unsaved changes
-  let showApplyAndCancelButtons: boolean = !searchConfigChangeRequested && !isSameConfig(temporaryFilterConfig, appliedFilterConfig);
+  let showApplyAndCancelButtons: boolean =
+    !searchConfigChangeRequested &&
+    !isSameConfig(temporaryFilterConfig, appliedFilterConfig);
 
   // ids of leaves' boxes to check; if no filter applied, select none
-  let selectedLeaves: Array<string> = temporaryFilterConfig === NO_ORGANISM_FILTER_APPLIED ? [] : temporaryFilterConfig.values;
+  let selectedLeaves: Array<string> =
+    temporaryFilterConfig === NO_ORGANISM_FILTER_APPLIED
+      ? []
+      : temporaryFilterConfig.values;
 
   // if user has not expanded any nodes yet and there is only one top-level child, expand it
-  let expandedNodeIds = savedExpandedNodeIds ? savedExpandedNodeIds :
-      taxonomyTreeWithCounts == null || taxonomyTreeWithCounts.children.length > 1 ? [] :
-      taxonomyTreeWithCounts.children.map(child => child.term);
+  let expandedNodeIds = savedExpandedNodeIds
+    ? savedExpandedNodeIds
+    : taxonomyTreeWithCounts == null ||
+      taxonomyTreeWithCounts.children.length > 1
+    ? []
+    : taxonomyTreeWithCounts.children.map((child) => child.term);
 
   // event handler function to update the step with the user's new org filter config
   function updateSearchConfig() {
     if (step) {
       setSearchConfigChangeRequested(true);
-      let newSearchConfig: SearchConfig = applyOrgFilterConfig(step.searchConfig, temporaryFilterConfig);
+      let newSearchConfig: SearchConfig = applyOrgFilterConfig(
+        step.searchConfig,
+        temporaryFilterConfig
+      );
       requestUpdateStepSearchConfig(step.strategyId, step.id, newSearchConfig);
     }
   }
@@ -252,91 +300,122 @@ function OrganismFilterForStep({ step, requestUpdateStepSearchConfig }: Organism
       <div>
         <h3 className={cx('--Heading')}>
           {TITLE}
-          {searchConfigChangeRequested && (
-            <Loading/>
-          )}
+          {searchConfigChangeRequested && <Loading />}
         </h3>
-        <div className={cx('--Buttons', showApplyAndCancelButtons ? 'visible' : 'hidden')}>
-          <button type="button" className={cx('--ApplyButton') + ' btn'} onClick={() => updateSearchConfig()}>Apply</button>
-          <button type="button" className={cx('--CancelButton') + ' btn'} onClick={() => setTemporaryFilterConfig(appliedFilterConfig)}><i className="fa fa-times"/></button>
+        <div
+          className={cx(
+            '--Buttons',
+            showApplyAndCancelButtons ? 'visible' : 'hidden'
+          )}
+        >
+          <button
+            type="button"
+            className={cx('--ApplyButton') + ' btn'}
+            onClick={() => updateSearchConfig()}
+          >
+            Apply
+          </button>
+          <button
+            type="button"
+            className={cx('--CancelButton') + ' btn'}
+            onClick={() => setTemporaryFilterConfig(appliedFilterConfig)}
+          >
+            <i className="fa fa-times" />
+          </button>
         </div>
-        { taxonomyTreeWithCounts
-        ? (
-            <CheckboxTree<TaxonomyNodeWithCount>
-              tree={taxonomyTreeWithCounts}
-              getNodeId={node => node.term}
-              getNodeChildren={node => node.children}
-              onExpansionChange={expandedNodeIds => setExpandedNodeIds(expandedNodeIds)}
-              shouldExpandDescendantsWithOneChild
-              renderNode={renderTaxonomyNode}
-              expandedList={expandedNodeIds}
-              currentList={appliedFilterList}
-              isSelectable={true}
-              selectedList={selectedLeaves}
-              isMultiPick={true}
-              onSelectionChange={selectedNodeIds => setTemporaryFilterConfig(
-                selectedNodeIds.length == 0 ? NO_ORGANISM_FILTER_APPLIED : { values: selectedNodeIds })}
-              isSearchable={true}
-              searchBoxPlaceholder="Search organisms..."
-              searchBoxHelp={makeSearchHelpText("the organisms below")}
-              searchTerm={searchTerm}
-              onSearchTermChange={term => setSearchTerm(term)}
-              searchPredicate={nodeMeetsSearchCriteria}
-              linksPosition={LinksPosition.Top}
-              additionalActions={[
-                <label style={{fontSize: '0.9em'}}>
-                  <input style={{marginRight: '0.25em'}} type="checkbox" checked={hideZeroes} onChange={() => setHideZeroes(!hideZeroes)}/>
-                  Hide zero counts
-                </label>
-              ]}
-              styleOverrides={{
-                treeLinks: {
-                  container: {
-                    justifyContent: 'flex-start',
-                    padding: 0,
-                    margin: '0.75em 0 0.75em 1.4em',
-                  },
+        {taxonomyTreeWithCounts ? (
+          <CheckboxTree<TaxonomyNodeWithCount>
+            tree={taxonomyTreeWithCounts}
+            getNodeId={(node) => node.term}
+            getNodeChildren={(node) => node.children}
+            onExpansionChange={(expandedNodeIds) =>
+              setExpandedNodeIds(expandedNodeIds)
+            }
+            shouldExpandDescendantsWithOneChild
+            renderNode={renderTaxonomyNode}
+            expandedList={expandedNodeIds}
+            currentList={appliedFilterList}
+            isSelectable={true}
+            selectedList={selectedLeaves}
+            isMultiPick={true}
+            onSelectionChange={(selectedNodeIds) =>
+              setTemporaryFilterConfig(
+                selectedNodeIds.length == 0
+                  ? NO_ORGANISM_FILTER_APPLIED
+                  : { values: selectedNodeIds }
+              )
+            }
+            isSearchable={true}
+            searchBoxPlaceholder="Search organisms..."
+            searchBoxHelp={makeSearchHelpText('the organisms below')}
+            searchTerm={searchTerm}
+            onSearchTermChange={(term) => setSearchTerm(term)}
+            searchPredicate={nodeMeetsSearchCriteria}
+            linksPosition={LinksPosition.Top}
+            additionalActions={[
+              <label style={{ fontSize: '0.9em' }}>
+                <input
+                  style={{ marginRight: '0.25em' }}
+                  type="checkbox"
+                  checked={hideZeroes}
+                  onChange={() => setHideZeroes(!hideZeroes)}
+                />
+                Hide zero counts
+              </label>,
+            ]}
+            styleOverrides={{
+              treeLinks: {
+                container: {
+                  justifyContent: 'flex-start',
+                  padding: 0,
+                  margin: '0.75em 0 0.75em 1.4em',
                 },
-                searchBox: {
-                  optionalIcon: {top: '3px'},
+              },
+              treeSection: {
+                ul: {
+                  padding: '0',
                 },
-                treeSection: {
-                  ul: {
-                    padding: '0',
-                  }
-                },
-              }}
-            />
-            )
-        : filterSummary?.available === false
-        ? <p className={cx('--ErrorMessage')}>
-            {filterSummary.reason}
-          </p>
-        : <Loading />}
+              },
+            }}
+          />
+        ) : filterSummary?.available === false ? (
+          <p className={cx('--ErrorMessage')}>{filterSummary.reason}</p>
+        ) : (
+          <Loading />
+        )}
       </div>
-      <ExpansionBar onClick={() => setExpandedAndPref(false)} message={'Hide ' + TITLE} arrow="&uArr;"/>
+      <ExpansionBar
+        onClick={() => setExpandedAndPref(false)}
+        message={'Hide ' + TITLE}
+        arrow="&uArr;"
+      />
     </Container>
   );
 }
 
 function findOrganismFilterConfig(searchConfig: SearchConfig): OrgFilterConfig {
-  return (
-    searchConfig.columnFilters &&
+  return searchConfig.columnFilters &&
     searchConfig.columnFilters[ORGANISM_COLUMN_NAME] &&
-    searchConfig.columnFilters[ORGANISM_COLUMN_NAME][HISTOGRAM_FILTER_NAME] ?
-    searchConfig.columnFilters[ORGANISM_COLUMN_NAME][HISTOGRAM_FILTER_NAME] : NO_ORGANISM_FILTER_APPLIED
-  );
+    searchConfig.columnFilters[ORGANISM_COLUMN_NAME][HISTOGRAM_FILTER_NAME]
+    ? searchConfig.columnFilters[ORGANISM_COLUMN_NAME][HISTOGRAM_FILTER_NAME]
+    : NO_ORGANISM_FILTER_APPLIED;
 }
 
-function applyOrgFilterConfig(oldSearchConfig: SearchConfig, newFilterConfig: OrgFilterConfig): SearchConfig {
+function applyOrgFilterConfig(
+  oldSearchConfig: SearchConfig,
+  newFilterConfig: OrgFilterConfig
+): SearchConfig {
   // extracting ourselves from type safety for this operation!!
   let configCopy = JSON.parse(JSON.stringify(oldSearchConfig));
 
   if (newFilterConfig === NO_ORGANISM_FILTER_APPLIED) {
     // handle case where new config is no config
     // need to delete some of the existing search config
-    configCopy.columnFilters[ORGANISM_COLUMN_NAME][HISTOGRAM_FILTER_NAME] = undefined;
-    if (Object.keys(configCopy.columnFilters[ORGANISM_COLUMN_NAME]).length == 0) {
+    configCopy.columnFilters[ORGANISM_COLUMN_NAME][HISTOGRAM_FILTER_NAME] =
+      undefined;
+    if (
+      Object.keys(configCopy.columnFilters[ORGANISM_COLUMN_NAME]).length == 0
+    ) {
       // no other organism column filters
       configCopy.columnFilters[ORGANISM_COLUMN_NAME] = undefined;
       if (Object.keys(configCopy.columnFilters).length == 0) {
@@ -344,14 +423,13 @@ function applyOrgFilterConfig(oldSearchConfig: SearchConfig, newFilterConfig: Or
         configCopy.columnFilters = undefined;
       }
     }
-  }
-  else {
+  } else {
     // new config present; may need to build out the structure to supply this config
-    if (!configCopy.columnFilters)
-      configCopy.columnFilters = {};
+    if (!configCopy.columnFilters) configCopy.columnFilters = {};
     if (!configCopy.columnFilters[ORGANISM_COLUMN_NAME])
       configCopy.columnFilters[ORGANISM_COLUMN_NAME] = {};
-    configCopy.columnFilters[ORGANISM_COLUMN_NAME][HISTOGRAM_FILTER_NAME] = newFilterConfig;
+    configCopy.columnFilters[ORGANISM_COLUMN_NAME][HISTOGRAM_FILTER_NAME] =
+      newFilterConfig;
   }
   return configCopy as SearchConfig;
 }
@@ -370,11 +448,13 @@ function createDisplayableTree(
       if (filterSummary && filterSummary.histogram) {
         if (hideZeroes) {
           // don't show children with zeroes if currently hiding zeroes
-          mappedChildren = mappedChildren.filter(child => child.count > 0);
+          mappedChildren = mappedChildren.filter((child) => child.count > 0);
         }
         // leaf nodes try to find their counts in the column reporter result
         if (mappedChildren.length == 0) {
-          let bin = filterSummary.histogram.find(val => val.binLabel === node.data.term);
+          let bin = filterSummary.histogram.find(
+            (val) => val.binLabel === node.data.term
+          );
           count = bin ? bin.value : 0;
         }
         // branch nodes sum the counts of their children
@@ -386,34 +466,30 @@ function createDisplayableTree(
         term: node.data.term,
         display: node.data.display,
         count: count,
-        children: mappedChildren
+        children: mappedChildren,
       };
     },
-    node => node.children,
+    (node) => node.children,
     taxonomyTree
   );
 
-  const hasPreferredOrganismParam = stepQuestion.parameters.some(
-    parameter => (
-      parameter.properties?.[ORGANISM_PROPERTIES_KEY]?.includes(SHOW_ONLY_PREFERRED_ORGANISMS_PROPERTY)
+  const hasPreferredOrganismParam = stepQuestion.parameters.some((parameter) =>
+    parameter.properties?.[ORGANISM_PROPERTIES_KEY]?.includes(
+      SHOW_ONLY_PREFERRED_ORGANISMS_PROPERTY
     )
   );
 
-  if (
-    !hasPreferredOrganismParam ||
-    !preferredOrganismsEnabled
-  ) {
+  if (!hasPreferredOrganismParam || !preferredOrganismsEnabled) {
     return taxonomyTreeWithCount;
   }
 
   const preferredOrganismsSet = new Set(preferredOrganisms);
 
   return pruneDescendantNodes(
-    node => (
+    (node) =>
       node.children.length > 0 ||
       node.count > 0 ||
-      preferredOrganismsSet.has(node.term)
-    ),
+      preferredOrganismsSet.has(node.term),
     taxonomyTreeWithCount
   );
 }
@@ -429,53 +505,70 @@ function isSameConfig(a: OrgFilterConfig, b: OrgFilterConfig): boolean {
   if (a === NO_ORGANISM_FILTER_APPLIED || b === NO_ORGANISM_FILTER_APPLIED) {
     return false;
   }
-  return (a.values.length === b.values.length &&
-          a.values.length === intersection(a.values, b.values).length);
+  return (
+    a.values.length === b.values.length &&
+    a.values.length === intersection(a.values, b.values).length
+  );
 }
 
 function renderTaxonomyNode(node: TaxonomyNodeWithCount) {
   return (
-    <div style={{display: 'flex', marginLeft: '0.25em'}}>
+    <div style={{ display: 'flex', marginLeft: '0.25em' }}>
       <div>{node.display}</div>
-      <div style={{marginLeft: 'auto'}}>{node.count.toLocaleString()}</div>
+      <div style={{ marginLeft: 'auto' }}>{node.count.toLocaleString()}</div>
     </div>
   );
 }
 
 function fetchTaxonomyTree(wdkService: WdkService) {
-  return wdkService.getQuestionAndParameters(TAXON_QUESTION_NAME)
-    .then(question => {
-      let orgParam  = question.parameters.find(p => p.name == ORGANISM_PARAM_NAME);
-      if (orgParam?.type == 'multi-pick-vocabulary' && orgParam?.displayType == 'treeBox') {
+  return wdkService
+    .getQuestionAndParameters(TAXON_QUESTION_NAME)
+    .then((question) => {
+      let orgParam = question.parameters.find(
+        (p) => p.name == ORGANISM_PARAM_NAME
+      );
+      if (
+        orgParam?.type == 'multi-pick-vocabulary' &&
+        orgParam?.displayType == 'treeBox'
+      ) {
         return pruneNodesWithSingleExtendingChild(orgParam.vocabulary);
-      }
-      else {
-        throw new Error(TAXON_QUESTION_NAME + " does not contain treebox enum param " + ORGANISM_PARAM_NAME);
+      } else {
+        throw new Error(
+          TAXON_QUESTION_NAME +
+            ' does not contain treebox enum param ' +
+            ORGANISM_PARAM_NAME
+        );
       }
     });
 }
 
 function fetchFilterSummary(wdkService: WdkService, stepId: number) {
-  return wdkService.getStepColumnReport(stepId, ORGANISM_COLUMN_NAME, HISTOGRAM_REPORTER_NAME, {})
-    .then(filterSummary => {
-      return ({
+  return wdkService
+    .getStepColumnReport(
+      stepId,
+      ORGANISM_COLUMN_NAME,
+      HISTOGRAM_REPORTER_NAME,
+      {}
+    )
+    .then((filterSummary) => {
+      return {
         available: true,
-        value: filterSummary as OrgFilterSummary
-      }) as const;
+        value: filterSummary as OrgFilterSummary,
+      } as const;
     })
-    .catch(error => {
+    .catch((error) => {
       wdkService.submitErrorIfUndelayedAndNot500(error);
 
       return {
         available: false,
-        reason: makeCommonErrorMessage(error)
+        reason: makeCommonErrorMessage(error),
       } as const;
     });
 }
 
 const mapDispatchToProps = {
   // when user clicks Apply, will need to update step with new filter value
-  requestUpdateStepSearchConfig
+  requestUpdateStepSearchConfig,
 };
 
 export default connect<null, typeof mapDispatchToProps, OwnProps, RootState>(


### PR DESCRIPTION
Recent updates to UPenn Macs surfaced an issue in Safari with the icon placement breaking in the `SearchBox` component. A bit of searching revealed that Safari has historically had issues with `position: absolute`. Also worth noting: the misaligned icon actually interferes with the functionality by blocking the "expand" toggle for the top-most item in the tree (`Haemoproteidae` in this case).

I initially used `position: absolute` as a wrapper with no height or width so that I could remove its contents from the document flow and then use `position: relative` on the icon itself. This was working fine cross-browser until this latest update.

I've removed the `position: absolute` wrapper. Instead, I added a "do nothing" `transform: rotate(0)` to the icon's parent container (`<label>`) and applied `positon: fixed` to the icons. The `transform` property changes the container that `position: fixed` is referencing, so the icons will positionally reference the `<label>` instead of the viewport.

Screenshot of the issue:
![image](https://user-images.githubusercontent.com/69446567/230452889-21827909-f08b-4c02-9801-e546db54a97e.png)

Screenshot with this branch applied:
![image](https://user-images.githubusercontent.com/69446567/230453624-27a5b5f6-c82a-4b88-8787-6d2a869c038a.png)