### PR TITLE
Computing range

### DIFF
--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -293,6 +293,7 @@ export const ScatterplotResponseData = array(
     // changed to string array
     seriesX: array(string),
     seriesY: array(string),
+    seriesGradientColorscale: array(string),
     smoothedMeanX: array(string),
     smoothedMeanY: array(number),
     smoothedMeanSE: array(number),

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -515,21 +515,17 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     (vizConfig.valueSpecConfig === 'Smoothed mean with raw' ||
       vizConfig.valueSpecConfig === 'Best fit line with raw');
 
-  // non-zero baseline for continuous overlay variable
-  const defaultOverlayMinMax = useDefaultAxisRange(
-    overlayVariable,
-    undefined,
-    undefined,
-    undefined,
-    vizConfig.dependentAxisLogScale,
-    'Full',
-    // non-zero baseline
-    true
-  );
-
   // If numeric overlay, record the min and max and make a value to color map function
-  const overlayMin: number | undefined = defaultOverlayMinMax?.min as number;
-  const overlayMax: number | undefined = defaultOverlayMinMax?.max as number;
+  // assign 0 to avoid undefined
+  const overlayMin: number | undefined =
+    overlayVariable?.type === 'number' || overlayVariable?.type === 'integer'
+      ? overlayVariable?.distributionDefaults?.rangeMin
+      : 0;
+  const overlayMax: number | undefined =
+    overlayVariable?.type === 'number' || overlayVariable?.type === 'integer'
+      ? overlayVariable?.distributionDefaults?.rangeMax
+      : 0;
+
   // Diverging colorscale, assume 0 is midpoint. Colorscale must be symmetric around the midpoint
   const maxAbsOverlay =
     Math.abs(overlayMin) > overlayMax ? Math.abs(overlayMin) : overlayMax;
@@ -545,7 +541,6 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         ? 'sequential reversed'
         : 'divergent'
       : undefined;
-  let overlayValueToColorMapper: ((a: number) => string) | undefined;
 
   const data = usePromise(
     useCallback(async (): Promise<ScatterPlotDataWithCoverage | undefined> => {
@@ -646,6 +641,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
           filteredCounts.value,
           response.completeCasesTable
         );
+
+      let overlayValueToColorMapper: ((a: number) => string) | undefined;
 
       if (
         response.scatterplot.data.every(

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -172,8 +172,6 @@ export interface ScatterPlotDataWithCoverage extends CoverageStatistics {
   yMinPos: number | string | undefined;
   yMax: number | string | undefined;
   overlayValueToColorMapper: ((a: number) => string) | undefined;
-  overlayMin: number | undefined;
-  overlayMax: number | undefined;
   // add computedVariableMetadata for computation apps such as alphadiv and abundance
   computedVariableMetadata?: VariableMapping[];
 }
@@ -517,6 +515,38 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     (vizConfig.valueSpecConfig === 'Smoothed mean with raw' ||
       vizConfig.valueSpecConfig === 'Best fit line with raw');
 
+  // non-zero baseline for continuous overlay variable
+  const defaultOverlayMinMax = useDefaultAxisRange(
+    overlayVariable,
+    undefined,
+    undefined,
+    undefined,
+    vizConfig.dependentAxisLogScale,
+    'Full',
+    // non-zero baseline
+    true
+  );
+
+  // If numeric overlay, record the min and max and make a value to color map function
+  const overlayMin: number | undefined = defaultOverlayMinMax?.min as number;
+  const overlayMax: number | undefined = defaultOverlayMinMax?.max as number;
+  // Diverging colorscale, assume 0 is midpoint. Colorscale must be symmetric around the midpoint
+  const maxAbsOverlay =
+    Math.abs(overlayMin) > overlayMax ? Math.abs(overlayMin) : overlayMax;
+  const gradientColorscaleType:
+    | 'sequential'
+    | 'sequential reversed'
+    | 'divergent'
+    | undefined =
+    overlayMin != null && overlayMax != null
+      ? overlayMin >= 0 && overlayMax >= 0
+        ? 'sequential'
+        : overlayMin <= 0 && overlayMax <= 0
+        ? 'sequential reversed'
+        : 'divergent'
+      : undefined;
+  let overlayValueToColorMapper: ((a: number) => string) | undefined;
+
   const data = usePromise(
     useCallback(async (): Promise<ScatterPlotDataWithCoverage | undefined> => {
       // If this scatterplot has a computed variable and the compute job is anything but complete, do not proceed with getting data.
@@ -617,16 +647,6 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
           response.completeCasesTable
         );
 
-      // If numeric overlay, record the min and max and make a value to color map function
-      let overlayMin: number | undefined;
-      let overlayMax: number | undefined;
-      let gradientColorscaleType:
-        | 'sequential'
-        | 'sequential reversed'
-        | 'divergent'
-        | undefined;
-      let overlayValueToColorMapper: ((a: number) => string) | undefined;
-
       if (
         response.scatterplot.data.every(
           (series) => 'seriesGradientColorscale' in series
@@ -634,51 +654,11 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         (overlayVariable?.type === 'integer' ||
           overlayVariable?.type === 'number')
       ) {
-        const defaultOverlayMin: number =
-          overlayVariable.distributionDefaults.displayRangeMin ||
-          overlayVariable.distributionDefaults.displayRangeMin === 0
-            ? overlayVariable.distributionDefaults.displayRangeMin
-            : overlayVariable.distributionDefaults.rangeMin;
-
-        const defaultOverlayMax: number = overlayVariable.distributionDefaults
-          .displayRangeMax
-          ? overlayVariable.distributionDefaults.displayRangeMax
-          : overlayVariable.distributionDefaults.rangeMax;
-
-        // Note overlayMin and/or overlayMax could be intentionally 0.
-        gradientColorscaleType =
-          defaultOverlayMin >= 0 && defaultOverlayMax >= 0
-            ? 'sequential'
-            : defaultOverlayMin <= 0 && defaultOverlayMax <= 0
-            ? 'sequential reversed'
-            : 'divergent';
-
-        // Update overlay min and max
-        if (gradientColorscaleType === 'divergent') {
-          overlayMin = -Math.max(
-            Math.abs(defaultOverlayMin),
-            Math.abs(defaultOverlayMax)
-          );
-          overlayMax = Math.max(
-            Math.abs(defaultOverlayMin),
-            Math.abs(defaultOverlayMax)
-          );
-        } else {
-          overlayMin = defaultOverlayMin;
-          overlayMax = defaultOverlayMax;
-        }
-
         // create the value to color mapper (continuous overlay)
         // Initialize normalization function.
         const normalize = scaleLinear();
 
         if (gradientColorscaleType === 'divergent') {
-          // Diverging colorscale, assume 0 is midpoint. Colorscale must be symmetric around the midpoint
-          const maxAbsOverlay =
-            Math.abs(overlayMin) > overlayMax
-              ? Math.abs(overlayMin)
-              : overlayMax;
-
           // For each point, normalize the data to [-1, 1], then retrieve the corresponding color
           normalize.domain([-maxAbsOverlay, maxAbsOverlay]).range([-1, 1]);
           overlayValueToColorMapper = (a) =>
@@ -726,8 +706,6 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
       );
       return {
         ...returnData,
-        overlayMin,
-        overlayMax,
         overlayValueToColorMapper,
       };
     }, [
@@ -823,13 +801,13 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   const gradientLegendProps: PlotLegendGradientProps | undefined =
     useMemo(() => {
       if (
-        data.value?.overlayMax != null &&
-        data.value?.overlayMin != null &&
+        overlayMax != null &&
+        overlayMin != null &&
         data.value?.overlayValueToColorMapper != null
       ) {
         return {
-          legendMax: data.value?.overlayMax,
-          legendMin: data.value?.overlayMin,
+          legendMax: overlayMax,
+          legendMin: overlayMin,
           valueToColorMapper: data.value?.overlayValueToColorMapper,
           // MUST be odd! Probably should be a clever function of the box size
           // and font or something...
@@ -840,7 +818,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
       } else {
         return undefined;
       }
-    }, [data, vizConfig.showMissingness, legendTitle]);
+    }, [data, vizConfig.showMissingness, legendTitle, overlayMin, overlayMax]);
 
   // custom legend list
   const legendItems: LegendItemsProps[] = useMemo(() => {

--- a/packages/libs/eda/src/lib/core/hooks/computeDefaultAxisRange.ts
+++ b/packages/libs/eda/src/lib/core/hooks/computeDefaultAxisRange.ts
@@ -22,7 +22,9 @@ export function useDefaultAxisRange(
   max?: number | string,
   /** are we using a log scale */
   logScale?: boolean,
-  axisRangeSpec = 'Full'
+  axisRangeSpec = 'Full',
+  // check non-zero baseline for continuous overlay variable
+  isNonZeroBaseline: boolean = false
 ): NumberOrDateRange | undefined {
   const defaultAxisRange = useMemo(() => {
     // Check here to make sure number ranges (min, minPos, max) came with number variables
@@ -45,7 +47,8 @@ export function useDefaultAxisRange(
         minPos,
         max,
         logScale,
-        axisRangeSpec
+        axisRangeSpec,
+        isNonZeroBaseline
       );
 
       // 4 significant figures
@@ -59,10 +62,13 @@ export function useDefaultAxisRange(
           typeof defaultRange?.min === 'number' &&
           typeof defaultRange?.max === 'number')
       )
-        return {
-          min: numberSignificantFigures(defaultRange.min, 4, 'down'),
-          max: numberSignificantFigures(defaultRange.max, 4, 'up'),
-        };
+        // check non-zero baseline for continuous overlay variable
+        return isNonZeroBaseline
+          ? defaultRange
+          : {
+              min: numberSignificantFigures(defaultRange.min, 4, 'down'),
+              max: numberSignificantFigures(defaultRange.max, 4, 'up'),
+            };
       else return defaultRange;
     } else if (
       variable == null &&
@@ -86,7 +92,7 @@ export function useDefaultAxisRange(
     } else {
       return undefined;
     }
-  }, [variable, min, minPos, max, logScale, axisRangeSpec]);
+  }, [variable, min, minPos, max, logScale, axisRangeSpec, isNonZeroBaseline]);
   return defaultAxisRange;
 }
 

--- a/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
+++ b/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
@@ -12,7 +12,8 @@ export function numberDateDefaultAxisRange(
   observedMax: number | string | undefined,
   /** are we using a log scale */
   logScale?: boolean,
-  axisRangeSpec = 'Full'
+  axisRangeSpec = 'Full',
+  isNonZeroBaseline: boolean = false
 ): NumberOrDateRange | undefined {
   if (Variable.is(variable)) {
     if (variable.type === 'number' || variable.type === 'integer') {
@@ -20,59 +21,32 @@ export function numberDateDefaultAxisRange(
       if (logScale && observedMinPos == null) return undefined; // return nothing - there will be no plottable data anyway
       // set default range of Custom to be Auto-zoom
       return axisRangeSpec === 'Full'
-        ? defaults.displayRangeMin != null && defaults.displayRangeMax != null
-          ? {
-              min:
-                logScale &&
-                observedMin != null &&
-                (observedMin <= 0 ||
-                  defaults.displayRangeMin <= 0 ||
-                  defaults.rangeMin <= 0)
-                  ? (observedMinPos as number)
-                  : observedMin != null
-                  ? Math.min(
-                      // add zero as an origin
-                      0,
-                      defaults.displayRangeMin,
-                      defaults.rangeMin,
-                      observedMin as number
-                    )
-                  : // add zero as an origin
-                    Math.min(0, defaults.displayRangeMin, defaults.rangeMin),
-              max:
-                observedMax != null
-                  ? Math.max(
-                      defaults.displayRangeMax,
-                      defaults.rangeMax,
-                      observedMax as number
-                    )
-                  : Math.max(defaults.displayRangeMax, defaults.rangeMax),
-            }
-          : {
-              min: logScale
+        ? {
+            min:
+              logScale &&
+              observedMin != null &&
+              (observedMin <= 0 ||
+                (defaults.displayRangeMin != null &&
+                  defaults.displayRangeMin <= 0) ||
+                defaults.rangeMin <= 0)
                 ? (observedMinPos as number)
-                : observedMin != null
-                ? // add zero as an origin
-                  Math.min(0, defaults.rangeMin, observedMin as number)
-                : // add zero as an origin
-                  Math.min(0, defaults.rangeMin),
-              max:
-                observedMax != null
-                  ? Math.max(defaults.rangeMax, observedMax as number)
-                  : defaults.rangeMax,
-            }
+                : (min([
+                    isNonZeroBaseline ? undefined : 0,
+                    defaults.displayRangeMin,
+                    defaults.rangeMin,
+                    observedMin as number,
+                  ]) as number),
+            max: max([
+              defaults.displayRangeMax,
+              defaults.rangeMax,
+              observedMax,
+            ]) as number,
+          }
         : {
             min: logScale
               ? (observedMinPos as number)
-              : observedMin != null
-              ? Math.min(observedMin as number)
-              : // just leave this or set to be undefined
-                Math.min(defaults.rangeMin),
-            max:
-              observedMax != null
-                ? (observedMax as number)
-                : // just leave this or set to be undefined
-                  defaults.rangeMax,
+              : (observedMin as number),
+            max: observedMax as number,
           };
     } else if (variable.type === 'date') {
       const defaults = variable.distributionDefaults;


### PR DESCRIPTION
This PR branched out from the https://github.com/VEuPathDB/web-monorepo/tree/gradient-legend-suggestion (https://github.com/VEuPathDB/web-monorepo/pull/42) to update computation of the range. In addition, some reorganizations are made.

@bobular, can you please check this out? That normalize part may be out of data part as well but I just leave it as is because of the condition to run it, which requires backend response to check. This PR can be merged into your branch or main, but for now its destination is set to be your branch.