### PR TITLE
Use CollapsibleSection for large text displays in BLAST

### DIFF
--- a/packages/libs/multi-blast/src/lib/components/BlastWorkspaceResult.tsx
+++ b/packages/libs/multi-blast/src/lib/components/BlastWorkspaceResult.tsx
@@ -2,6 +2,7 @@ import { Fragment, useContext, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router';
 
 import {
+  CollapsibleSection,
   Error as ErrorPage,
   Link,
   Loading,
@@ -46,6 +47,7 @@ interface Props {
 }
 
 const POLLING_INTERVAL = 3000;
+const MAX_DATABASE_STRING_LENGTH = 500;
 
 export function BlastWorkspaceResult(props: Props) {
   useSetDocumentTitle(`BLAST Job ${props.jobId}`);
@@ -308,6 +310,8 @@ function BlastSummary({
     }
   }, [selectedResult]);
 
+  const [showMore, setShowMore] = useState<boolean>(false);
+
   return (
     <div className={blastWorkspaceCx('Result', 'Complete')}>
       <h1>BLAST Job - result</h1>
@@ -351,7 +355,35 @@ function BlastSummary({
           <span className="InlineHeader">
             {databases.length > 1 ? 'Databases' : 'Database'}:
           </span>
-          <span>{databasesStr}</span>
+          <span>
+            {databasesStr.length > MAX_DATABASE_STRING_LENGTH ? (
+              <CollapsibleSection
+                isCollapsed={!showMore}
+                onCollapsedChange={() => setShowMore(!showMore)}
+                headerContent={
+                  <>
+                    {!showMore ? (
+                      <span>
+                        {databasesStr.slice(0, MAX_DATABASE_STRING_LENGTH)}...{' '}
+                        <span className="link">Show more</span>
+                      </span>
+                    ) : (
+                      <div
+                        style={{
+                          height: '2em',
+                        }}
+                      >
+                        <span className="link">Show less</span>
+                      </div>
+                    )}
+                  </>
+                }
+                children={databasesStr}
+              />
+            ) : (
+              databasesStr
+            )}
+          </span>
         </div>
       </div>
       {queryCount > 1 && (

--- a/packages/libs/wdk-client/src/Views/Strategy/StepDetails.tsx
+++ b/packages/libs/wdk-client/src/Views/Strategy/StepDetails.tsx
@@ -338,11 +338,44 @@ function formatDatasetValue(
   parameter: DatasetParam,
   datasetParamItems: Record<string, DatasetItem[]> | undefined
 ) {
-  return !datasetParamItems ? (
-    <IconAlt fa="circle-o-notch" className="fa-spin fa-fw" />
-  ) : (
-    datasetParamItems[parameter.name].map(datasetItemToString).join(', ')
-  );
+  if (!datasetParamItems) {
+    return <IconAlt fa="circle-o-notch" className="fa-spin fa-fw" />;
+  }
+
+  const [showMore, setShowMore] = useState<boolean>(false);
+  const datasetValueString = datasetParamItems[parameter.name]
+    .map(datasetItemToString)
+    .join(', ');
+
+  if (datasetValueString.length > CUTOFF_LENGTH) {
+    return (
+      <CollapsibleSection
+        isCollapsed={!showMore}
+        onCollapsedChange={() => setShowMore(!showMore)}
+        headerContent={
+          <>
+            {!showMore ? (
+              <span>
+                {datasetValueString.slice(0, CUTOFF_LENGTH)}...{' '}
+                <span className="link">Show more</span>
+              </span>
+            ) : (
+              <div
+                style={{
+                  height: '2em',
+                }}
+              >
+                <span className="link">Show less</span>
+              </div>
+            )}
+          </>
+        }
+        children={datasetValueString}
+      />
+    );
+  } else {
+    return datasetValueString;
+  }
 }
 
 function mapDispatchToProps(

--- a/packages/libs/wdk-client/src/Views/Strategy/StepDetails.tsx
+++ b/packages/libs/wdk-client/src/Views/Strategy/StepDetails.tsx
@@ -251,16 +251,47 @@ function formatRangeParameterValue(value: string) {
   }
 }
 
+const CUTOFF_LENGTH = 500;
+
 function formatEnumParameterValue(parameter: EnumParam, value: string) {
   const valueSet = new Set(
     isMultiPick(parameter) ? toMultiValueArray(value) : [value]
   );
   const termDisplayPairs = makeTermDisplayPairs(parameter.vocabulary);
-
-  return termDisplayPairs
+  const finalTermDisplayPairsString = termDisplayPairs
     .filter(([term]) => valueSet.has(term))
     .map(([, display]) => display)
     .join(', ');
+
+  const [showMore, setShowMore] = useState<boolean>(false);
+
+  return finalTermDisplayPairsString.length > CUTOFF_LENGTH ? (
+    <CollapsibleSection
+      isCollapsed={!showMore}
+      onCollapsedChange={() => setShowMore(!showMore)}
+      headerContent={
+        <>
+          {!showMore ? (
+            <span>
+              {finalTermDisplayPairsString.slice(0, CUTOFF_LENGTH)}...{' '}
+              <span className="link">Show more</span>
+            </span>
+          ) : (
+            <div
+              style={{
+                height: '2em',
+              }}
+            >
+              <span className="link">Show less</span>
+            </div>
+          )}
+        </>
+      }
+      children={finalTermDisplayPairsString}
+    />
+  ) : (
+    finalTermDisplayPairsString
+  );
 }
 
 const makeTermDisplayPairs = memoize((vocabulary: EnumParam['vocabulary']): [


### PR DESCRIPTION
Resolves https://redmine.apidb.org/issues/50314

Implemented a `CollapsibleSection` so users can control the wall of text that can be shown. The "cutoff" has been arbitrarily set at 500 characters.

Default view when page loads:
![image](https://user-images.githubusercontent.com/69446567/231290038-53134bdc-d8e0-4321-86bc-e894e935eef4.png)

View when user clicks to "show more":
![image](https://user-images.githubusercontent.com/69446567/231290139-7a37ec1a-a2bd-4d83-a60c-92242113e1db.png)

Similar logic/behavior was added to the `StepDetails`.
