### PR TITLE
Implement the Notes menu item in standalone map

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -72,6 +72,7 @@ import {
 } from '../../core/types/visualization';
 import DraggableVisualization from './DraggableVisualization';
 import { useUITheme } from '@veupathdb/coreui/dist/components/theming';
+import NotesTab from '../../workspace/NotesTab';
 
 const mapStyle: React.CSSProperties = {
   zIndex: 1,
@@ -399,7 +400,18 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
       {
         labelText: 'Notes',
         icon: <Notes />,
-        renderWithApp: sideNavigationRenderPlaceholder,
+        renderWithApp: (app) => {
+          return (
+            <div
+              style={{
+                // This matches the `marginTop` applied by `<NotesTab />`
+                padding: '0 35px',
+              }}
+            >
+              <NotesTab analysisState={analysisState} />
+            </div>
+          );
+        },
       },
       {
         labelText: 'View Study Details',


### PR DESCRIPTION
**Before**:

<img width="1512" alt="Screenshot 2023-04-12 at 4 09 55 PM" src="https://user-images.githubusercontent.com/24446573/231585870-2bb88aeb-73f6-4153-8046-ddad3031fd0e.png">

**After**: 

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/24446573/231585845-e54f3f1d-4222-49ba-a9ea-3b238a522201.png">

**Note:** we might be interested in adjusting the styling of this notes component. Presently the text is lightly colored and a touch small.