### PR TITLE
add scatterplot marker opacity to legend

### DIFF
--- a/packages/libs/components/src/components/plotControls/PlotListLegend.tsx
+++ b/packages/libs/components/src/components/plotControls/PlotListLegend.tsx
@@ -19,6 +19,7 @@ export interface PlotListLegendProps {
   onCheckedLegendItemsChange?: (checkedLegendItems: string[]) => void;
   // add a condition to show legend for single overlay data
   showOverlayLegend?: boolean;
+  markerBodyOpacity?: number;
 }
 
 export default function PlotListLegend({
@@ -26,6 +27,7 @@ export default function PlotListLegend({
   checkedLegendItems,
   onCheckedLegendItemsChange,
   showOverlayLegend = false,
+  markerBodyOpacity = 1,
 }: PlotListLegendProps) {
   // change checkbox state by click
   const handleLegendCheckboxClick = (checked: boolean, id: string) => {
@@ -133,8 +135,9 @@ export default function PlotListLegend({
                       }}
                     />
                   )}
-                  {/* for scatter plot: marker */}
-                  {item.marker === 'circle' && (
+                  {/* for scatter plot marker and lineplot 0/0 case */}
+                  {(item.marker === 'circle' ||
+                    item.marker === 'circleZero') && (
                     <div style={{ width: scatterMarkerSpace }}>
                       <div
                         style={{
@@ -144,7 +147,23 @@ export default function PlotListLegend({
                           borderWidth: '0.15em',
                           borderStyle: 'solid',
                           borderRadius: '0.6em',
-                          borderColor: item.markerColor,
+                          borderColor:
+                            item.marker === 'circleZero'
+                              ? item.markerColor
+                              : markerBodyOpacity === 0
+                              ? item.markerColor
+                              : 'transparent',
+                          backgroundColor:
+                            item.marker === 'circleZero'
+                              ? ''
+                              : markerBodyOpacity === 0
+                              ? 'transparent'
+                              : ColorMath.evaluate(
+                                  item.markerColor +
+                                    ' @a ' +
+                                    (markerBodyOpacity * 100).toString() +
+                                    '%'
+                                ).result.css(),
                         }}
                       />
                     </div>

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -790,7 +790,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
               // maing marker info appropriately
               marker:
                 dataItem.seriesType === 'zeroOverZero'
-                  ? 'circle'
+                  ? 'circleZero'
                   : 'lineWithCircleFilled',
               // set marker colors appropriately
               markerColor:

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -1843,7 +1843,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         legendTitle={legendTitle}
         showOverlayLegend={showOverlayLegend}
         // pass markerBodyOpacity to PlotLegend to control legend color opacity
-        // markerBodyOpacity={vizConfig.markerBodyOpacity}
+        markerBodyOpacity={vizConfig.markerBodyOpacity}
       />
     ));
 


### PR DESCRIPTION
Hi @chowington While I am reviewing your codes, I realized that you did (temporarily) block scatterplot's marker opacity part, perhaps because of the conflict with Lineplot's 0/0 case. Thus, I tried to activate both cases here. I don't know you already did similar stuff but wish this would be helpful for you 😃 

Just in case, this is branched out from your lineplot-zero-over-zero branch