### PR TITLE
formatting stats as power of 10 and add conditions

### DIFF
--- a/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
@@ -43,7 +43,7 @@ import Notification from '@veupathdb/components/lib/components/widgets//Notifica
 // import axis label unit util
 import { variableDisplayWithUnit } from '../../utils/variable-display';
 import { useDefaultAxisRange } from '../../hooks/computeDefaultAxisRange';
-import { min, max } from 'lodash';
+import { min, max, gt, lt } from 'lodash';
 import { useDebounce } from '../../hooks/debouncing';
 import { useDeepValue } from '../../hooks/immutability';
 
@@ -318,6 +318,13 @@ export function HistogramFilter(props: Props) {
     uiState.dependentAxisLogScale
   ) as NumberRange;
 
+  const fgSummaryStatsMin = formatStatValue(fgSummaryStats?.min, variable.type);
+  const fgSummaryStatsMean = formatStatValue(
+    fgSummaryStats?.mean,
+    variable.type
+  );
+  const fgSummaryStatsMax = formatStatValue(fgSummaryStats?.max, variable.type);
+
   // Note use of `key` used with HistogramPlotWithControls. This is a little hack to force
   // the range to be reset if the filter is removed.
   return (
@@ -338,24 +345,10 @@ export function HistogramFilter(props: Props) {
         >
           {fgSummaryStats && (
             <div className="histogram-summary-stats">
-              <>
-                <b>Min:</b> {formatStatValue(fgSummaryStats.min, variable.type)}{' '}
-                &emsp;
-              </>
-              <>
-                <b>Mean:</b>{' '}
-                {formatStatValue(fgSummaryStats.mean, variable.type)} &emsp;
-              </>
-              {/*
-                <>
-                  <b>Median:</b>{' '}
-                  {formatStatValue(fgSummaryStats.median, variable.type)} &emsp;
-                </>
-              */}
-              <>
-                <b>Max:</b> {formatStatValue(fgSummaryStats.max, variable.type)}{' '}
-                &emsp;
-              </>
+              {/* display Min, Mean, and Max stats */}
+              <DisplayStats title={'Min'} stats={fgSummaryStatsMin} />
+              <DisplayStats title={'Mean'} stats={fgSummaryStatsMean} />
+              <DisplayStats title={'Max'} stats={fgSummaryStatsMax} />
             </div>
           )}
           {data.value?.hasDataEntitiesCount != null && (
@@ -842,16 +835,33 @@ function tidyBinLabel(
 function formatStatValue(
   value: string | number | undefined,
   type: HistogramVariable['type']
-) {
+): string | number | string[] {
   if (value == null) return 'N/A';
-  return type === 'date'
-    ? String(value).replace(/T.*$/, '')
-    : // check a possible year variable
-    type === 'integer' && Number(value) >= 1900 && Number(value) <= 2100
-    ? Number.isInteger(value)
+
+  let formattedValue: string | number | string[] =
+    type === 'date'
+      ? String(value).replace(/T.*$/, '')
+      : // check a possible year variable
+      type === 'integer' && Number(value) >= 1900 && Number(value) <= 2100
+      ? Number.isInteger(value)
+        ? Number(value)
+        : Number(value).toFixed(4)
+      : // set conditions similar to plotly
+      gt(Number(value), 100000) ||
+        (Number(value) != 0 && lt(Math.abs(Number(value)), 0.0001))
+      ? Number(value).toExponential(4)
+      : Number.isInteger(value)
       ? Number(value)
-      : Number(value).toFixed(4)
-    : Number(value).toExponential(4);
+      : Number(value).toFixed(4);
+
+  // treating negative exponent
+  if (typeof formattedValue === 'string' && formattedValue.includes('e')) {
+    formattedValue = formattedValue.includes('e-')
+      ? formattedValue.split('e')
+      : formattedValue.split('e+');
+  }
+
+  return formattedValue;
 }
 
 function computeBinSlider(
@@ -894,3 +904,23 @@ function enforceBounds(
     return range;
   }
 }
+
+interface DisplayStatsProps {
+  /* title: Min, Mean, Max */
+  title: string;
+  /* Min, Mean, Max */
+  stats: string | number | string[];
+}
+
+// component for displaying Min, Mean, and Max stats
+const DisplayStats = (props: DisplayStatsProps) => {
+  const { title, stats } = props;
+
+  return (
+    <>
+      <b>{title}:</b> {Array.isArray(stats) ? stats[0] : stats}
+      {Array.isArray(stats) ? <span>&#215;10</span> : ''}
+      {Array.isArray(stats) ? <sup>{stats[1]}</sup> : ''} &emsp;
+    </>
+  );
+};


### PR DESCRIPTION
This will address the feedback from Danica, https://github.com/VEuPathDB/web-eda/issues/1677#issuecomment-1507694481. There is no specific way to display the power of 10 format like plotly, thus made several changes. Also, similar to plotly, some conditions are set to show the power of 10: >10^5 or <0.0001. Some screenshots are demoed in the following:

a) Age (months)
![1490 histogramFilter Age01](https://user-images.githubusercontent.com/12802305/232599052-a90f09bf-f750-4d14-b461-e88575d88dc8.png)

b) Acidobacteriota: since plotly does not show the power of 10, the stats is also shown as floating numbers
![1490 histogramFilter Acidobacteriota01](https://user-images.githubusercontent.com/12802305/232599118-aaa5efa2-13dc-4419-9564-3488a3b7fa43.png)

c) Aggregatibacter segnis: power of 10 format
![1490 histogramFilter segnis](https://user-images.githubusercontent.com/12802305/232599242-f9d111d6-d7e2-4b02-b20a-56f895ed4973.png)

d) date variable: just displaying date as is
![1490 histogramFilter date01](https://user-images.githubusercontent.com/12802305/232599391-77fb6aec-1b03-4106-a7e3-7e89cd81acc7.png)

