### PR TITLE
Remove italics from citation

### DIFF
--- a/packages/libs/eda/src/lib/workspace/DownloadTab/StudyCitation.tsx
+++ b/packages/libs/eda/src/lib/workspace/DownloadTab/StudyCitation.tsx
@@ -14,7 +14,6 @@ import {
   stripHTML,
 } from '@veupathdb/wdk-client/lib/Utils/DomUtils';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
-import { makeStyles } from '@material-ui/core';
 
 export type CitationDetails = {
   partialCitationData: {
@@ -51,10 +50,6 @@ export function getCitationString({
   return `${studyContacts}. Dataset: ${studyDisplayName}. ${projectDisplayName}. ${citationDate}, Release ${release.releaseNumber} (${citationUrl})`;
 }
 
-const useStyles = makeStyles(() => ({
-  tooltip: {},
-}));
-
 export default function StudyCitation({
   partialCitationData,
   release,
@@ -89,7 +84,7 @@ export default function StudyCitation({
         textSize="medium"
       >
         <span>
-          <i>{safeHtml(citation)}</i>
+          {safeHtml(citation)}
           <div
             style={{ display: 'inline-block', position: 'relative', top: 3 }}
           >


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/web-eda/issues/1510

After more prototyping, [we agreed that option 2 (no styling, no space)](https://github.com/VEuPathDB/web-eda/issues/1510#issuecomment-1508624152) was the best option for now. The screenshot below reflects these changes.

![image](https://user-images.githubusercontent.com/69446567/232600994-2951fa17-9353-45ad-aad3-561b46bcf5f2.png)
