### PR TITLE
Add CSS to jquery-ui containers to indicate resizability

### DIFF
--- a/packages/libs/wdk-client/src/Core/Style/index.scss
+++ b/packages/libs/wdk-client/src/Core/Style/index.scss
@@ -10,3 +10,4 @@
 @import './wdk-SearchTree.scss';
 @import './wdk-Alert.scss';
 @import './wdk-Mesa.scss';
+@import './jquery-ui-overrides.scss';

--- a/packages/libs/wdk-client/src/Core/Style/jquery-ui-overrides.scss
+++ b/packages/libs/wdk-client/src/Core/Style/jquery-ui-overrides.scss
@@ -1,0 +1,14 @@
+/* 
+    Adds the "resize" icon to the jquery container that acts as the resize "handle"
+    Can remove the FoldChange specificity if needed, but be mindful that the FoldChange use-case only resizes vertically
+*/
+.wdk-FoldChangeSampleParameterContainer,
+.wdk-FoldChangeReferenceSample {
+  .ui-resizable {
+    .ui-resizable-handle,
+    .ui-resizable-s {
+      overflow-y: hidden;
+      resize: vertical;
+    }
+  }
+}


### PR DESCRIPTION
Resolves https://redmine.apidb.org/issues/44206?project=true

Notice the "resize" indicators in the bottom right of the **Reference Samples** and **Comparison Samples** containers.
![image](https://user-images.githubusercontent.com/69446567/232841381-48c35b2e-f110-4d5a-a115-6c33019bbaa2.png)