### PR TITLE
Adjust specificity for breakpoint within question form header

### DIFF
--- a/packages/libs/web-common/src/styles/default-layout.scss
+++ b/packages/libs/web-common/src/styles/default-layout.scss
@@ -61,7 +61,7 @@ body.vpdb-Body {
     top: $collapsed-header-height;
 
     @media screen and (max-width: $hamburger-width) {
-      top: 0;
+      top: 0 !important;
     }
   }
 }


### PR DESCRIPTION
Resolves issue with question headers breaking when viewport width is below 1013px.

This screencast demonstrates the break:
https://user-images.githubusercontent.com/69446567/232842242-a85e3d8d-98e6-4bec-b87a-77a3d64550f5.mov

And this screencast demonstrates the small change:
https://user-images.githubusercontent.com/69446567/232842690-56e5b7b0-1117-4cd6-b6b0-b0719c7da7e4.mov