### PR TITLE
Ensure side navigation doesn't render multiple scrollbars constantly 

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MapSideNavigation.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapSideNavigation.tsx
@@ -63,6 +63,7 @@ export function MapSideNavigation({
         // ensure that the side menu sits atop the map.
         zIndex: 10,
         display: 'flex',
+        overflow: 'scroll',
       }}
     >
       <button
@@ -113,29 +114,19 @@ export function MapSideNavigation({
           position: 'relative',
           // Ensures that the div takes up all the available height.
           height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
         }}
       >
         <div
           style={{
-            // Ensures that these children nav items are contained to
-            // 70% of the navigation, leaving 30% for the navigation
-            // footer items.
-            height: '70%',
-            overflow: 'scroll',
+            flex: 2,
+            flexShrink: 1,
           }}
         >
           {children}
         </div>
-        <hr
-          style={{
-            // Styles for the <hr />
-            backgroundColor: `rgba(0, 0, 0,0.15)`,
-            border: 0,
-            height: '2px',
-            marginBottom: '1.5rem',
-            width: '50%',
-          }}
-        />
+
         <div
           className={isExpanded ? '' : 'screenReaderOnly'}
           style={{
@@ -147,8 +138,19 @@ export function MapSideNavigation({
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'flex-end',
+            flex: 1,
           }}
         >
+          <hr
+            style={{
+              // Styles for the <hr />
+              backgroundColor: `rgba(0, 0, 0,0.15)`,
+              border: 0,
+              height: '2px',
+              marginBottom: '1.5rem',
+              width: '50%',
+            }}
+          />
           {/* For now these are more for demonstration purposes. */}
           <ul style={{ margin: 0, padding: 0, listStyleType: 'none' }}>
             <li>
@@ -175,7 +177,6 @@ export function MapSideNavigation({
         style={{
           minWidth: activeNavigationMenu ? 285 : 0,
           borderLeft: activeNavigationMenu ? mapNavigationBorder : 'unset',
-          overflow: 'scroll',
         }}
         className={isExpanded ? '' : 'screenReaderOnly'}
       >


### PR DESCRIPTION
**Before**:

![image](https://user-images.githubusercontent.com/24446573/233205444-601edd6b-ce8d-44c7-82c0-050c4edcdf17.png)

Certain browsers + OSs will render scrollbars all the time. Scrollbars are a major accessibility concern and browser rendering engines and OSs disagree as to how and when they should be rendered.

**After**:

This PR removes needless `overflow: scroll`s thereby resolving this UI bug.