### PR TITLE
Use new dataNoun prop in user dataset UI

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -40,12 +40,10 @@ class UserDatasetDetail extends React.Component {
     this.renderHeaderSection = this.renderHeaderSection.bind(this);
     this.renderDatasetActions = this.renderDatasetActions.bind(this);
 
-    this.renderCompatibilitySection = this.renderCompatibilitySection.bind(
-      this
-    );
-    this.getCompatibilityTableColumns = this.getCompatibilityTableColumns.bind(
-      this
-    );
+    this.renderCompatibilitySection =
+      this.renderCompatibilitySection.bind(this);
+    this.getCompatibilityTableColumns =
+      this.getCompatibilityTableColumns.bind(this);
 
     this.openSharingModal = this.openSharingModal.bind(this);
     this.renderFileSection = this.renderFileSection.bind(this);
@@ -310,16 +308,16 @@ class UserDatasetDetail extends React.Component {
     const isOwner = this.isMyDataset();
     return (
       <div className={classify('Actions')}>
-        <button className="btn btn-error" onClick={this.handleDelete}>
-          {isOwner ? 'Delete' : 'Remove'}
-          <Icon fa="trash" className="right-side" />
-        </button>
         {!isOwner ? null : (
           <button className="btn btn-success" onClick={this.openSharingModal}>
-            Share
-            <Icon fa="share-alt" className="right-side" />
+            <Icon fa="share-alt" className="left-side" />
+            Grant Access to {this.props.dataNoun.singular}
           </button>
         )}
+        <button className="btn btn-error" onClick={this.handleDelete}>
+          <Icon fa="trash" className="left-side" />
+          Delete
+        </button>
       </div>
     );
   }
@@ -524,12 +522,8 @@ class UserDatasetDetail extends React.Component {
   }
 
   render() {
-    const {
-      user,
-      userDataset,
-      shareUserDatasets,
-      unshareUserDatasets,
-    } = this.props;
+    const { user, userDataset, shareUserDatasets, unshareUserDatasets } =
+      this.props;
     const AllDatasetsLink = this.renderAllDatasetsLink;
     if (!userDataset)
       return (

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -522,8 +522,13 @@ class UserDatasetDetail extends React.Component {
   }
 
   render() {
-    const { user, userDataset, shareUserDatasets, unshareUserDatasets } =
-      this.props;
+    const {
+      user,
+      userDataset,
+      shareUserDatasets,
+      unshareUserDatasets,
+      dataNoun,
+    } = this.props;
     const AllDatasetsLink = this.renderAllDatasetsLink;
     if (!userDataset)
       return (
@@ -546,6 +551,7 @@ class UserDatasetDetail extends React.Component {
             onClose={this.closeSharingModal}
             shareUserDatasets={shareUserDatasets}
             unshareUserDatasets={unshareUserDatasets}
+            dataNoun={dataNoun}
           />
         )}
       </div>

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -380,8 +380,8 @@ class UserDatasetList extends React.Component<Props, State> {
         callback: (userDatasets: UserDataset[]) => {
           const [noun, pronoun] =
             userDatasets.length === 1
-              ? ['this dataset', 'it']
-              : ['these datasets', 'them'];
+              ? [`this ${this.props.dataNoun.singular.toLowerCase()}`, 'it']
+              : [`these ${this.props.dataNoun.plural.toLowerCase()}`, 'them'];
 
           const affectedUsers: UserDatasetShare[] = userDatasets.reduce(
             (
@@ -600,6 +600,7 @@ class UserDatasetList extends React.Component<Props, State> {
                     shareUserDatasets={shareUserDatasets}
                     unshareUserDatasets={unshareUserDatasets}
                     onClose={this.closeSharingModal}
+                    dataNoun={dataNoun}
                   />
                 ) : null}
                 <SearchBox

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -23,6 +23,7 @@ import { bytesToHuman } from '@veupathdb/wdk-client/lib/Utils/Converters';
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 
 import {
+  DataNoun,
   UserDataset,
   UserDatasetMeta,
   UserDatasetShare,
@@ -59,6 +60,7 @@ interface Props {
   ) => any;
   updateProjectFilter: (filterByProject: boolean) => any;
   quotaSize: number;
+  dataNoun: DataNoun;
 }
 
 interface State {
@@ -105,9 +107,8 @@ class UserDatasetList extends React.Component<Props, State> {
     this.getEventHandlers = this.getEventHandlers.bind(this);
     this.filterAndSortRows = this.filterAndSortRows.bind(this);
     this.onSearchTermChange = this.onSearchTermChange.bind(this);
-    this.onMetaAttributeSaveFactory = this.onMetaAttributeSaveFactory.bind(
-      this
-    );
+    this.onMetaAttributeSaveFactory =
+      this.onMetaAttributeSaveFactory.bind(this);
 
     this.renderOwnerCell = this.renderOwnerCell.bind(this);
     this.renderStatusCell = this.renderStatusCell.bind(this);
@@ -369,7 +370,8 @@ class UserDatasetList extends React.Component<Props, State> {
         },
         element: (
           <button className="btn btn-info">
-            Share Datasets <Icon fa="share-alt right-side" />
+            <Icon fa="share-alt left-side" />
+            Grant Access to {this.props.dataNoun.plural}
           </button>
         ),
         selectionRequired: true,
@@ -417,7 +419,8 @@ class UserDatasetList extends React.Component<Props, State> {
         },
         element: (
           <button className="btn btn-error">
-            Remove <Icon fa="trash-o right-side" />
+            <Icon fa="trash-o left-side" />
+            Delete
           </button>
         ),
         selectionRequired: true,
@@ -546,6 +549,7 @@ class UserDatasetList extends React.Component<Props, State> {
       unshareUserDatasets,
       filterByProject,
       quotaSize,
+      dataNoun,
     } = this.props;
     const { uiState, selectedRows, searchTerm, sharingModalOpen } = this.state;
 
@@ -599,13 +603,15 @@ class UserDatasetList extends React.Component<Props, State> {
                   />
                 ) : null}
                 <SearchBox
-                  placeholderText="Search Datasets"
+                  placeholderText={'Search ' + dataNoun.plural}
                   searchTerm={searchTerm}
                   onSearchTermChange={this.onSearchTermChange}
                 />
                 <div style={{ flex: '0 0 auto', padding: '0 10px' }}>
                   Showing {filteredRows.length} of {rows.length}{' '}
-                  {`data set${rows.length === 1 ? '' : 's'}`}
+                  {rows.length === 1
+                    ? dataNoun.singular.toLowerCase()
+                    : dataNoun.plural.toLowerCase()}
                 </div>
                 {offerProjectToggle && (
                   <div
@@ -620,7 +626,8 @@ class UserDatasetList extends React.Component<Props, State> {
                       onClick={() => toggleProjectScope(!filterByProject)}
                       style={{ display: 'inline-block' }}
                     >
-                      Only show data sets related to <b>{projectName}</b>
+                      Only show {dataNoun.plural.toLowerCase()} related to{' '}
+                      <b>{projectName}</b>
                     </div>
                   </div>
                 )}

--- a/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.jsx
@@ -41,6 +41,7 @@ class UserDatasetSharingModal extends React.Component {
     this.disqualifyRecipient = this.disqualifyRecipient.bind(this);
 
     this.submitShare = this.submitShare.bind(this);
+    this.renderEmptyState = this.renderEmptyState.bind(this);
     this.unshareWithUser = this.unshareWithUser.bind(this);
     this.isRecipientValid = this.isRecipientValid.bind(this);
     this.renderViewContent = this.renderViewContent.bind(this);
@@ -60,7 +61,9 @@ class UserDatasetSharingModal extends React.Component {
   }
 
   getDatasetNoun() {
-    return this.props.datasets.length === 1 ? 'this dataset' : 'these datasets';
+    return this.props.datasets.length === 1
+      ? `this ${this.props.dataNoun.singular.toLowerCase()}`
+      : `these ${this.props.dataNoun.plural.toLowerCase()}`;
   }
 
   verifyRecipient(recipientEmail) {
@@ -99,7 +102,10 @@ class UserDatasetSharingModal extends React.Component {
         if (uid === this.props.user.id) {
           return this.disqualifyRecipient(
             recipientEmail,
-            <span>Sorry, you cannot share a dataset with yourself.</span>
+            <span>
+              Sorry, you cannot share a{' '}
+              {this.props.dataNoun.singular.toLowerCase()} with yourself.
+            </span>
           );
         } else {
           return this.acceptRecipient(recipientEmail, uid);
@@ -187,13 +193,18 @@ class UserDatasetSharingModal extends React.Component {
   }
 
   renderEmptyState() {
-    return <i className="faded">This dataset hasn't been shared yet.</i>;
+    return (
+      <i className="faded">
+        This {this.props.dataNoun.singular.toLowerCase()} hasn't been shared
+        yet.
+      </i>
+    );
   }
 
   unshareWithUser(datasetId, userId) {
     if (
       !window.confirm(
-        'Are you sure you want to stop sharing this dataset with this user?'
+        `Are you sure you want to stop sharing ${this.getDatasetNoun()} with this user?`
       )
     )
       return;
@@ -233,7 +244,7 @@ class UserDatasetSharingModal extends React.Component {
     const { sharedWith, id, meta } = userDataset;
     const { name } = meta;
     const isOwner = this.isMyDataset(userDataset);
-    const { deselectDataset } = this.props;
+    const { deselectDataset, dataNoun } = this.props;
 
     const EmptyState = this.renderEmptyState;
     const ShareList = this.renderShareList;
@@ -251,8 +262,8 @@ class UserDatasetSharingModal extends React.Component {
           <h3>{name}</h3>
           {!isOwner ? (
             <i className="faded danger">
-              This dataset has been shared with you. Only the owner can share
-              it.
+              This {dataNoun.singular.toLowerCase()} has been shared with you.
+              Only the owner can share it.
             </i>
           ) : Array.isArray(sharedWith) && sharedWith.length ? (
             <ShareList userDataset={userDataset} />
@@ -265,7 +276,7 @@ class UserDatasetSharingModal extends React.Component {
           {typeof deselectDataset !== 'function' ? null : (
             <button
               type="button"
-              title="Unselect this dataset for sharing"
+              title={`Unselect this ${dataNoun.singular.toLowerCase()} for sharing`}
               onClick={() => this.unselectDataset(userDataset)}
               className="link removalLink"
             >
@@ -419,7 +430,7 @@ class UserDatasetSharingModal extends React.Component {
           disabled={!recipients.length || !datasets.length}
           onClick={this.submitShare}
         >
-          Share Datasets with {recipients.length} user
+          Share {this.props.dataNoun.plural} with {recipients.length} user
           {recipients.length === 1 ? '' : 's'} <Icon fa="share right-side" />
         </button>
       </div>
@@ -428,7 +439,7 @@ class UserDatasetSharingModal extends React.Component {
 
   renderViewContent() {
     const { recipients, succeeded } = this.state;
-    const { datasets, onClose } = this.props;
+    const { datasets, onClose, dataNoun } = this.props;
     const datasetNoun = this.getDatasetNoun();
 
     const DatasetList = this.renderDatasetList;
@@ -454,9 +465,10 @@ class UserDatasetSharingModal extends React.Component {
         return (
           <div className="UserDataset-SharingModal-StatusView">
             <Icon fa="times-circle danger" />
-            <h2>Error Sharing Datasets.</h2>
+            <h2>Error Sharing {dataNoun.plural}.</h2>
             <p>
-              An error occurred while sharing your datasets. Please try again.
+              An error occurred while sharing your{' '}
+              {dataNoun.plural.toLowerCase()}. Please try again.
             </p>
             <CloseButton />
           </div>

--- a/packages/libs/user-datasets/src/lib/Components/UserDatasetsWorkspace.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UserDatasetsWorkspace.tsx
@@ -9,7 +9,7 @@ import UserDatasetAllUploadsController from '../Controllers/UserDatasetAllUpload
 import UserDatasetListController from '../Controllers/UserDatasetListController';
 import UserDatasetNewUploadController from '../Controllers/UserDatasetNewUploadController';
 
-import { DatasetUploadPageConfig } from '../Utils/types';
+import { DatasetUploadPageConfig, DataNoun } from '../Utils/types';
 
 interface Props {
   baseUrl: string;
@@ -18,6 +18,7 @@ interface Props {
   urlParams: Record<string, string>;
   workspaceTitle: string;
   helpTabContents?: ReactNode;
+  dataNoun: DataNoun;
 }
 
 function UserDatasetsWorkspace(props: Props) {
@@ -27,6 +28,7 @@ function UserDatasetsWorkspace(props: Props) {
     uploadPageConfig,
     workspaceTitle,
     helpTabContents,
+    dataNoun,
   } = props;
 
   return (
@@ -74,6 +76,7 @@ function UserDatasetsWorkspace(props: Props) {
               hasDirectUpload={uploadPageConfig.hasDirectUpload}
               helpRoute={helpRoute}
               workspaceTitle={workspaceTitle}
+              dataNoun={dataNoun}
             />
           )}
           disclaimerProps={{ toDoWhatMessage: 'To view your datasets' }}

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetDetailController.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetDetailController.tsx
@@ -24,6 +24,7 @@ import EmptyState from '../Components/EmptyState';
 import { quotaSize } from '../Components/UserDatasetUtils';
 
 import { StateSlice } from '../StoreModules/types';
+import { DataNoun } from '../Utils/types';
 
 const ActionCreators = {
   showLoginForm,
@@ -47,6 +48,7 @@ type OwnProps = {
     string,
     ComponentType<UserDatasetDetailProps>
   >;
+  dataNoun: DataNoun;
 };
 type MergedProps = {
   ownProps: OwnProps;
@@ -67,9 +69,8 @@ class UserDatasetDetailController extends PageController<MergedProps> {
   };
 
   getTitle() {
-    const entry = this.props.stateProps.userDatasetsById[
-      this.props.ownProps.id
-    ];
+    const entry =
+      this.props.stateProps.userDatasetsById[this.props.ownProps.id];
     if (entry && entry.resource) {
       return `${this.props.ownProps.detailsPageTitle} ${entry.resource.meta.name}`;
     }
@@ -147,12 +148,8 @@ class UserDatasetDetailController extends PageController<MergedProps> {
   }
 
   renderView() {
-    const {
-      baseUrl,
-      detailsPageTitle,
-      id,
-      workspaceTitle,
-    } = this.props.ownProps;
+    const { baseUrl, detailsPageTitle, id, workspaceTitle, dataNoun } =
+      this.props.ownProps;
     const {
       updateUserDatasetDetail,
       shareUserDatasets,
@@ -192,6 +189,7 @@ class UserDatasetDetailController extends PageController<MergedProps> {
       questionMap: keyBy(questions, 'fullName'),
       workspaceTitle,
       detailsPageTitle,
+      dataNoun,
     };
 
     const DetailView = this.getDetailView(

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetListController.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetListController.tsx
@@ -20,7 +20,7 @@ import { quotaSize } from '../Components/UserDatasetUtils';
 
 import { StateSlice } from '../StoreModules/types';
 
-import { UserDataset } from '../Utils/types';
+import { DataNoun, UserDataset } from '../Utils/types';
 
 import '../Components/UserDatasets.scss';
 
@@ -45,6 +45,7 @@ interface OwnProps extends RouteComponentProps<{}> {
   hasDirectUpload: boolean;
   helpRoute: string;
   workspaceTitle: string;
+  dataNoun: DataNoun;
 }
 type Props = {
   ownProps: OwnProps;
@@ -70,10 +71,8 @@ class UserDatasetListController extends PageController<Props> {
     if (config == null) {
       return true;
     }
-    const {
-      uploads,
-      badAllUploadsActionMessage,
-    } = this.props.stateProps.userDatasetUpload;
+    const { uploads, badAllUploadsActionMessage } =
+      this.props.stateProps.userDatasetUpload;
     return (
       hasDirectUpload && uploads == null && badAllUploadsActionMessage == null
     );
@@ -120,12 +119,8 @@ class UserDatasetListController extends PageController<Props> {
 
     const { projectId, displayName: projectName } = config;
 
-    const {
-      baseUrl,
-      hasDirectUpload,
-      helpRoute,
-      location,
-    } = this.props.ownProps;
+    const { baseUrl, hasDirectUpload, helpRoute, location, dataNoun } =
+      this.props.ownProps;
 
     const {
       userDatasetList: { userDatasets, userDatasetsById, filterByProject },
@@ -147,6 +142,7 @@ class UserDatasetListController extends PageController<Props> {
       baseUrl,
       user,
       location,
+      dataNoun,
       projectId,
       projectName,
       numOngoingUploads,

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetRouter.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetRouter.tsx
@@ -7,7 +7,7 @@ import WdkRoute from '@veupathdb/wdk-client/lib/Core/WdkRoute';
 import UserDatasetsWorkspace from '../Components/UserDatasetsWorkspace';
 
 import { makeDatasetUploadPageConfig } from '../Utils/upload-config';
-import { DatasetUploadTypeConfig } from '../Utils/types';
+import { DatasetUploadTypeConfig, DataNoun } from '../Utils/types';
 
 import UserDatasetDetailController, {
   UserDatasetDetailProps,
@@ -24,6 +24,7 @@ interface Props<T1 extends string = string, T2 extends string = string> {
     string,
     ComponentType<UserDatasetDetailProps>
   >;
+  dataNoun: DataNoun;
 }
 
 export function UserDatasetRouter<T1 extends string, T2 extends string>({
@@ -34,6 +35,7 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
   workspaceTitle,
   helpTabContents,
   detailComponentsByTypeName,
+  dataNoun,
 }: Props<T1, T2>) {
   const { path, url } = useRouteMatch();
 
@@ -54,6 +56,7 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
               detailsPageTitle={detailsPageTitle}
               workspaceTitle={workspaceTitle}
               detailComponentsByTypeName={detailComponentsByTypeName}
+              dataNoun={dataNoun}
               {...props.match.params}
             />
           );
@@ -82,6 +85,7 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
               urlParams={urlParams}
               workspaceTitle={workspaceTitle}
               helpTabContents={helpTabContents}
+              dataNoun={dataNoun}
             />
           );
         }}

--- a/packages/libs/user-datasets/src/lib/Utils/types.ts
+++ b/packages/libs/user-datasets/src/lib/Utils/types.ts
@@ -137,3 +137,12 @@ export interface NewUserDataset extends UserDatasetMeta {
         reportConfig: unknown;
       };
 }
+
+/**
+ * In EDA, data is referred to as "Study" or "Studies"
+ * In genomics, data is referred to as "Data Set" or "Data Sets"
+ */
+export type DataNoun = {
+  singular: string;
+  plural: string;
+};

--- a/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
+++ b/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
@@ -8,23 +8,22 @@ import { RouteEntry } from '@veupathdb/wdk-client/lib/Core/RouteEntry';
 import { makeEdaRoute } from '@veupathdb/web-common/lib/routes';
 import { diyUserDatasetIdToWdkRecordId } from '@veupathdb/web-common/lib/util/diyDatasets';
 
-import {
-  UserDatasetDetailProps
-} from '@veupathdb/user-datasets/lib/Controllers/UserDatasetDetailController';
+import { UserDatasetDetailProps } from '@veupathdb/user-datasets/lib/Controllers/UserDatasetDetailController';
 
-import {
-  uploadTypeConfig
-} from '@veupathdb/user-datasets/lib/Utils/upload-config';
+import { uploadTypeConfig } from '@veupathdb/user-datasets/lib/Utils/upload-config';
 
 import { communitySite, projectId } from '@veupathdb/web-common/lib/config';
 
 import ExternalContentController from '@veupathdb/web-common/lib/controllers/ExternalContentController';
 
 const IsaDatasetDetail = React.lazy(
-  () => import('@veupathdb/user-datasets/lib/Components/Detail/IsaDatasetDetail')
+  () =>
+    import('@veupathdb/user-datasets/lib/Components/Detail/IsaDatasetDetail')
 );
 
-const UserDatasetRouter = React.lazy(() => import('../controllers/UserDatasetRouter'));
+const UserDatasetRouter = React.lazy(
+  () => import('../controllers/UserDatasetRouter')
+);
 
 const availableUploadTypes = ['isasimple'];
 
@@ -38,27 +37,33 @@ export const userDatasetRoutes: RouteEntry[] = [
       const location = useLocation();
 
       const helpTabContentUrl = useMemo(
-        () => [
-          communitySite,
-          USER_DATASETS_HELP_PAGE,
-          location.search,
-          location.hash
-        ].join(''),
+        () =>
+          [
+            communitySite,
+            USER_DATASETS_HELP_PAGE,
+            location.search,
+            location.hash,
+          ].join(''),
         [location.search, location.hash]
       );
 
-      const detailComponentsByTypeName = useMemo(() => ({
-        ISA: function ClinEpiIsaDatasetDetail(props: UserDatasetDetailProps) {
-          const wdkDatasetId = diyUserDatasetIdToWdkRecordId(props.userDataset.id);
+      const detailComponentsByTypeName = useMemo(
+        () => ({
+          ISA: function ClinEpiIsaDatasetDetail(props: UserDatasetDetailProps) {
+            const wdkDatasetId = diyUserDatasetIdToWdkRecordId(
+              props.userDataset.id
+            );
 
-          return (
-            <IsaDatasetDetail
-              {...props}
-              edaWorkspaceUrl={`${makeEdaRoute(wdkDatasetId)}/new`}
-            />
-          )
-        }
-      }), []);
+            return (
+              <IsaDatasetDetail
+                {...props}
+                edaWorkspaceUrl={`${makeEdaRoute(wdkDatasetId)}/new`}
+              />
+            );
+          },
+        }),
+        []
+      );
 
       return (
         <Suspense fallback={<Loading />}>
@@ -70,13 +75,12 @@ export const userDatasetRoutes: RouteEntry[] = [
             uploadTypeConfig={uploadTypeConfig}
             detailComponentsByTypeName={detailComponentsByTypeName}
             helpTabContents={
-              <ExternalContentController
-                url={helpTabContentUrl}
-              />
+              <ExternalContentController url={helpTabContentUrl} />
             }
+            dataNoun={{ singular: 'Study', plural: 'Studies' }}
           />
         </Suspense>
       );
     },
-  }
+  },
 ];

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/userDatasetRoutes.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/userDatasetRoutes.tsx
@@ -8,11 +8,11 @@ import { RouteEntry } from '@veupathdb/wdk-client/lib/Core/RouteEntry';
 import { communitySite } from '@veupathdb/web-common/lib/config';
 import ExternalContentController from '@veupathdb/web-common/lib/controllers/ExternalContentController';
 
-import {
-  uploadTypeConfig
-} from '@veupathdb/user-datasets/lib/Utils/upload-config';
+import { uploadTypeConfig } from '@veupathdb/user-datasets/lib/Utils/upload-config';
 
-const UserDatasetRouter = React.lazy(() => import('./controllers/UserDatasetRouter'));
+const UserDatasetRouter = React.lazy(
+  () => import('./controllers/UserDatasetRouter')
+);
 
 const availableUploadTypes = ['gene-list'];
 
@@ -26,12 +26,13 @@ export const userDatasetRoutes: RouteEntry[] = [
       const location = useLocation();
 
       const helpTabContentUrl = useMemo(
-        () => [
-          communitySite,
-          USER_DATASETS_HELP_PAGE,
-          location.search,
-          location.hash
-        ].join(''),
+        () =>
+          [
+            communitySite,
+            USER_DATASETS_HELP_PAGE,
+            location.search,
+            location.hash,
+          ].join(''),
         [location.search, location.hash]
       );
 
@@ -44,13 +45,12 @@ export const userDatasetRoutes: RouteEntry[] = [
             workspaceTitle="My Data Sets"
             uploadTypeConfig={uploadTypeConfig}
             helpTabContents={
-              <ExternalContentController
-                url={helpTabContentUrl}
-              />
+              <ExternalContentController url={helpTabContentUrl} />
             }
+            dataNoun={{ singular: 'Data Set', plural: 'Data Sets' }}
           />
         </Suspense>
-      )
+      );
     },
-  }
+  },
 ];

--- a/packages/sites/mbio-site/webapp/wdkCustomization/js/client/routes/userDatasetRoutes.tsx
+++ b/packages/sites/mbio-site/webapp/wdkCustomization/js/client/routes/userDatasetRoutes.tsx
@@ -8,23 +8,22 @@ import { RouteEntry } from '@veupathdb/wdk-client/lib/Core/RouteEntry';
 import { makeEdaRoute } from '@veupathdb/web-common/lib/routes';
 import { diyUserDatasetIdToWdkRecordId } from '@veupathdb/web-common/lib/util/diyDatasets';
 
-import {
-  UserDatasetDetailProps
-} from '@veupathdb/user-datasets/lib/Controllers/UserDatasetDetailController';
+import { UserDatasetDetailProps } from '@veupathdb/user-datasets/lib/Controllers/UserDatasetDetailController';
 
-import {
-  uploadTypeConfig
-} from '@veupathdb/user-datasets/lib/Utils/upload-config';
+import { uploadTypeConfig } from '@veupathdb/user-datasets/lib/Utils/upload-config';
 
 import { communitySite, projectId } from '@veupathdb/web-common/lib/config';
 
 import ExternalContentController from '@veupathdb/web-common/lib/controllers/ExternalContentController';
 
 const BiomDatasetDetail = React.lazy(
-  () => import('@veupathdb/user-datasets/lib/Components/Detail/BiomDatasetDetail')
+  () =>
+    import('@veupathdb/user-datasets/lib/Components/Detail/BiomDatasetDetail')
 );
 
-const UserDatasetRouter = React.lazy(() => import('../controllers/UserDatasetRouter'));
+const UserDatasetRouter = React.lazy(
+  () => import('../controllers/UserDatasetRouter')
+);
 
 const availableUploadTypes = ['biom'];
 
@@ -38,27 +37,33 @@ export const userDatasetRoutes: RouteEntry[] = [
       const location = useLocation();
 
       const helpTabContentUrl = useMemo(
-        () => [
-          communitySite,
-          USER_DATASETS_HELP_PAGE,
-          location.search,
-          location.hash
-        ].join(''),
+        () =>
+          [
+            communitySite,
+            USER_DATASETS_HELP_PAGE,
+            location.search,
+            location.hash,
+          ].join(''),
         [location.search, location.hash]
       );
 
-      const detailComponentsByTypeName = useMemo(() => ({
-        BIOM: function MbioBiomDatasetDetail(props: UserDatasetDetailProps) {
-          const wdkDatasetId = diyUserDatasetIdToWdkRecordId(props.userDataset.id);
+      const detailComponentsByTypeName = useMemo(
+        () => ({
+          BIOM: function MbioBiomDatasetDetail(props: UserDatasetDetailProps) {
+            const wdkDatasetId = diyUserDatasetIdToWdkRecordId(
+              props.userDataset.id
+            );
 
-          return (
-            <BiomDatasetDetail
-              {...props}
-              edaWorkspaceUrl={`${makeEdaRoute(wdkDatasetId)}/new`}
-            />
-          )
-        }
-      }), []);
+            return (
+              <BiomDatasetDetail
+                {...props}
+                edaWorkspaceUrl={`${makeEdaRoute(wdkDatasetId)}/new`}
+              />
+            );
+          },
+        }),
+        []
+      );
 
       return (
         <Suspense fallback={<Loading />}>
@@ -70,13 +75,12 @@ export const userDatasetRoutes: RouteEntry[] = [
             uploadTypeConfig={uploadTypeConfig}
             detailComponentsByTypeName={detailComponentsByTypeName}
             helpTabContents={
-              <ExternalContentController
-                url={helpTabContentUrl}
-              />
+              <ExternalContentController url={helpTabContentUrl} />
             }
+            dataNoun={{ singular: 'Study', plural: 'Studies' }}
           />
         </Suspense>
       );
     },
-  }
+  },
 ];


### PR DESCRIPTION
Resolves #98 

Related to https://github.com/VEuPathDB/EdaNewIssues/issues/621

**THE PROBLEM:** 
The `My User Studies` table in EDA (or `My Data Sets` in genomics) **currently** has disparate verbiage ("Datasets", "data sets", "Studies") as shown:
![image](https://user-images.githubusercontent.com/69446567/234024413-173443eb-6d77-4f6d-8c1c-ae104118d16a.png)

**THE SOLUTION:**
In introducing a `dataNoun` prop, we can specify singular and plural forms of the appropriate noun used in genomics or EDA sites.

This screenshot shows this new prop implemented in EDA:
![image](https://user-images.githubusercontent.com/69446567/234025235-d9eb1be7-96d0-4a60-a942-1afd4d09a19f.png)

This screenshot shows this new prop implemented in genomics:
![image](https://user-images.githubusercontent.com/69446567/234025435-a921e4f9-c632-48c3-9843-32dbd912cdfc.png)