### PR TITLE
Update alpha map menu item, and add missing provider components.

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -89,7 +89,11 @@ const VEuPathDBHomePageView: FunctionComponent<Props> = (props) => {
 const VEuPathDBHomePageViewFull: FunctionComponent<Props> = (props) => {
   const cx = makeClassNameHelper('wdk-RootContainer');
   return (
-    <div className={cx('', props.classNameModifier)}>{props.children}</div>
+    <VEuPathDBSnackbarProvider styleProps={{ headerExpanded: false }}>
+      <ReduxNotificationHandler>
+        <div className={cx('', props.classNameModifier)}>{props.children}</div>
+      </ReduxNotificationHandler>
+    </VEuPathDBSnackbarProvider>
   );
 };
 
@@ -531,11 +535,11 @@ const useHeaderMenuItems = (
           },
         },
         {
-          key: 'mapveu',
+          key: 'mapveu-alpha',
           display: 'MapVEu Alpha',
           tooltip: 'Population Biology map',
           type: 'reactRoute',
-          url: '/workspace/analyses/studies',
+          url: '/maps',
           metadata: {
             include: useEda ? [VectorBase] : [],
           },


### PR DESCRIPTION
I noticed that the header menu item in genomics sites should point to the stand alone map. I aso noticed some missing provider components when a route is rendered fullscreen. This PR addresses those issues.