### PR TITLE
Theme user datasets buttons

### DIFF
--- a/packages/libs/coreui/src/components/buttons/index.ts
+++ b/packages/libs/coreui/src/components/buttons/index.ts
@@ -41,7 +41,7 @@ type ButtonStateStyleSpec = {
     offsetX: string;
     offsetY: string;
     blurRadius: string;
-    color: string;
+    color: CSSProperties['color'];
   };
 };
 

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -18,10 +18,8 @@ import { isUserDatasetsCompatibleWdkService } from '../../Service/UserDatasetWra
 import SharingModal from '../Sharing/UserDatasetSharingModal';
 import UserDatasetStatus from '../UserDatasetStatus';
 import { makeClassifier, normalizePercentage } from '../UserDatasetUtils';
-import { ThemedGrantAccessButton } from '../List/UserDatasetList';
-
-import { MesaButton, Trash } from '@veupathdb/coreui';
-import { gray, mutedRed } from '@veupathdb/coreui/dist/definitions/colors';
+import { ThemedGrantAccessButton } from '../ThemedGrantAccessButton';
+import { ThemedDeleteButton } from '../ThemedDeleteButton';
 
 import { DateTime } from '../DateTime';
 
@@ -319,50 +317,7 @@ class UserDatasetDetail extends React.Component {
             onPress={this.openSharingModal}
           />
         )}
-        <MesaButton
-          text="Delete"
-          textTransform="none"
-          onPress={this.handleDelete}
-          themeRole={undefined}
-          icon={Trash}
-          styleOverrides={{
-            default: {
-              color: gray[100],
-              textColor: '#4D4D4D',
-              dropShadow: {
-                color: gray[200],
-                blurRadius: '0px',
-                offsetX: '0px',
-                offsetY: '3px',
-              },
-              border: {
-                color: gray[200],
-                style: 'solid',
-                width: 1,
-              },
-            },
-            hover: {
-              color: mutedRed[500],
-              textColor: 'white',
-              dropShadow: {
-                color: mutedRed[700],
-                blurRadius: '0px',
-                offsetX: '0px',
-                offsetY: '4px',
-              },
-            },
-            pressed: {
-              color: mutedRed[600],
-              textColor: 'white',
-              dropShadow: {
-                color: mutedRed[700],
-                blurRadius: '0px',
-                offsetX: '0px',
-                offsetY: '4px',
-              },
-            },
-          }}
-        />
+        <ThemedDeleteButton buttonText="Delete" onPress={this.handleDelete} />
       </div>
     );
   }

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -94,13 +94,14 @@ class UserDatasetDetail extends React.Component {
   }
 
   handleDelete() {
-    const { baseUrl, isOwner, userDataset, removeUserDataset } = this.props;
+    const { baseUrl, isOwner, userDataset, removeUserDataset, dataNoun } =
+      this.props;
     const { sharedWith } = userDataset;
     const shareCount = !Array.isArray(sharedWith) ? null : sharedWith.length;
     const message =
       `Are you sure you want to ${
         isOwner ? 'delete' : 'remove'
-      } this data set? ` +
+      } this ${dataNoun.singular.toLowerCase()}? ` +
       (!isOwner || !shareCount
         ? ''
         : `${shareCount} collaborator${
@@ -386,7 +387,7 @@ class UserDatasetDetail extends React.Component {
    -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= */
 
   renderFileSection() {
-    const { userDataset, appUrl } = this.props;
+    const { userDataset, appUrl, dataNoun } = this.props;
     const fileTableState = MesaState.create({
       columns: this.getFileTableColumns({ userDataset, appUrl }),
       rows: userDataset.datafiles,
@@ -397,7 +398,7 @@ class UserDatasetDetail extends React.Component {
         <h2>Data Files</h2>
         <h3 className={classify('SectionTitle')}>
           <Icon fa="files-o" />
-          Files in Data Set
+          Files in {dataNoun.singular}
         </h3>
         <Mesa state={fileTableState} />
       </section>
@@ -472,7 +473,7 @@ class UserDatasetDetail extends React.Component {
    -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-= */
 
   renderCompatibilitySection() {
-    const { userDataset, config } = this.props;
+    const { userDataset, config, dataNoun } = this.props;
     const { projectId, displayName } = config;
 
     const compatibilityTableState = MesaState.create({
@@ -486,11 +487,15 @@ class UserDatasetDetail extends React.Component {
 
     return (
       <section id="dataset-compatibility">
-        <h2>Use This Data Set in {displayName}</h2>
+        <h2>
+          Use This {dataNoun.singular} in {displayName}
+        </h2>
         <h3 className={classify('SectionTitle')}>
           <Icon fa="puzzle-piece" />
           Compatibility Information &nbsp;
-          <AnchoredTooltip content="The data and genomes listed here are requisite for using the data in this user data set.">
+          <AnchoredTooltip
+            content={`The data and genomes listed here are requisite for using the data in this user ${dataNoun.singular.toLowerCase()}.`}
+          >
             <div className="HelpTrigger">
               <Icon fa="question-circle" />
             </div>
@@ -501,13 +506,15 @@ class UserDatasetDetail extends React.Component {
         </div>
         {isCompatibleProject && isCompatible ? (
           <p className="success">
-            This data set is compatible with the current release, build{' '}
-            {buildNumber}, of <b>{projectId}</b>. It is installed for use.
+            This {dataNoun.singular.toLowerCase()} is compatible with the
+            current release, build {buildNumber}, of <b>{projectId}</b>. It is
+            installed for use.
           </p>
         ) : (
           <p className="danger">
-            This data set is not compatible with the current release, build{' '}
-            {buildNumber}, of <b>{projectId}</b>. It is not installed for use.
+            This {dataNoun.singular.toLowerCase()} is not compatible with the
+            current release, build {buildNumber}, of <b>{projectId}</b>. It is
+            not installed for use.
           </p>
         )}
       </section>

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -18,6 +18,10 @@ import { isUserDatasetsCompatibleWdkService } from '../../Service/UserDatasetWra
 import SharingModal from '../Sharing/UserDatasetSharingModal';
 import UserDatasetStatus from '../UserDatasetStatus';
 import { makeClassifier, normalizePercentage } from '../UserDatasetUtils';
+import { ThemedGrantAccessButton } from '../List/UserDatasetList';
+
+import { MesaButton, Trash } from '@veupathdb/coreui';
+import { gray, mutedRed } from '@veupathdb/coreui/dist/definitions/colors';
 
 import { DateTime } from '../DateTime';
 
@@ -309,15 +313,55 @@ class UserDatasetDetail extends React.Component {
     return (
       <div className={classify('Actions')}>
         {!isOwner ? null : (
-          <button className="btn btn-success" onClick={this.openSharingModal}>
-            <Icon fa="share-alt" className="left-side" />
-            Grant Access to {this.props.dataNoun.singular}
-          </button>
+          <ThemedGrantAccessButton
+            buttonText={`Grant Access to ${this.props.dataNoun.singular}`}
+            onPress={this.openSharingModal}
+          />
         )}
-        <button className="btn btn-error" onClick={this.handleDelete}>
-          <Icon fa="trash" className="left-side" />
-          Delete
-        </button>
+        <MesaButton
+          text="Delete"
+          textTransform="none"
+          onPress={this.handleDelete}
+          themeRole={undefined}
+          icon={Trash}
+          styleOverrides={{
+            default: {
+              color: gray[100],
+              textColor: '#4D4D4D',
+              dropShadow: {
+                color: gray[200],
+                blurRadius: '0px',
+                offsetX: '0px',
+                offsetY: '3px',
+              },
+              border: {
+                color: gray[200],
+                style: 'solid',
+                width: 1,
+              },
+            },
+            hover: {
+              color: mutedRed[500],
+              textColor: 'white',
+              dropShadow: {
+                color: mutedRed[700],
+                blurRadius: '0px',
+                offsetX: '0px',
+                offsetY: '4px',
+              },
+            },
+            pressed: {
+              color: mutedRed[600],
+              textColor: 'white',
+              dropShadow: {
+                color: mutedRed[700],
+                blurRadius: '0px',
+                offsetX: '0px',
+                offsetY: '4px',
+              },
+            },
+          }}
+        />
       </div>
     );
   }

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
@@ -37,6 +37,7 @@
     display: flex;
     flex-flow: row nowrap;
     justify-content: flex-end;
+    gap: 1em;
   }
 
   .UserDatasetDetail-Header {

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -474,10 +474,11 @@ class UserDatasetList extends React.Component<Props, State> {
 
   getTableOptions() {
     const { isRowSelected, toggleProjectScope } = this;
-    const { userDatasets, projectName, filterByProject } = this.props;
+    const { userDatasets, projectName, filterByProject, dataNoun } = this.props;
     const emptyMessage = !userDatasets.length ? (
       <p style={{ textAlign: 'center' }}>
-        This page is empty because you do not have any data sets.
+        This page is empty because you do not have any{' '}
+        {dataNoun.plural.toLowerCase()}.
       </p>
     ) : filterByProject ? (
       <React.Fragment>
@@ -489,7 +490,7 @@ class UserDatasetList extends React.Component<Props, State> {
           className="btn btn-info"
           onClick={() => toggleProjectScope(false)}
         >
-          Show All User Datasets
+          Show All User {dataNoun.plural}
         </button>
       </React.Fragment>
     ) : (

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -37,6 +37,10 @@ import { normalizePercentage, textCell } from '../UserDatasetUtils';
 import './UserDatasetList.scss';
 import { DateTime } from '../DateTime';
 
+import { useUITheme } from '@veupathdb/coreui/dist/components/theming';
+import { MesaButton, Share, Trash } from '@veupathdb/coreui';
+import { gray, mutedRed } from '@veupathdb/coreui/dist/definitions/colors';
+
 interface Props {
   baseUrl: string;
   user: User;
@@ -362,17 +366,17 @@ class UserDatasetList extends React.Component<Props, State> {
 
   getTableActions() {
     const { isMyDataset } = this;
-    const { removeUserDataset } = this.props;
+    const { removeUserDataset, dataNoun } = this.props;
     return [
       {
         callback: (rows: UserDataset[]) => {
           this.openSharingModal();
         },
         element: (
-          <button className="btn btn-info">
-            <Icon fa="share-alt left-side" />
-            Grant Access to {this.props.dataNoun.plural}
-          </button>
+          <ThemedGrantAccessButton
+            buttonText={`Grant Access to ${dataNoun.plural}`}
+            onPress={() => null}
+          />
         ),
         selectionRequired: true,
       },
@@ -418,10 +422,50 @@ class UserDatasetList extends React.Component<Props, State> {
           userDatasets.forEach((userDataset) => removeUserDataset(userDataset));
         },
         element: (
-          <button className="btn btn-error">
-            <Icon fa="trash-o left-side" />
-            Delete
-          </button>
+          <MesaButton
+            text="Delete"
+            textTransform="none"
+            onPress={() => null}
+            themeRole={undefined}
+            icon={Trash}
+            styleOverrides={{
+              default: {
+                color: gray[100],
+                textColor: '#4D4D4D',
+                dropShadow: {
+                  color: gray[200],
+                  blurRadius: '0px',
+                  offsetX: '0px',
+                  offsetY: '3px',
+                },
+                border: {
+                  color: gray[200],
+                  style: 'solid',
+                  width: 1,
+                },
+              },
+              hover: {
+                color: mutedRed[500],
+                textColor: 'white',
+                dropShadow: {
+                  color: mutedRed[700],
+                  blurRadius: '0px',
+                  offsetX: '0px',
+                  offsetY: '4px',
+                },
+              },
+              pressed: {
+                color: mutedRed[600],
+                textColor: 'white',
+                dropShadow: {
+                  color: mutedRed[700],
+                  blurRadius: '0px',
+                  offsetX: '0px',
+                  offsetY: '4px',
+                },
+              },
+            }}
+          />
         ),
         selectionRequired: true,
       },
@@ -646,3 +690,54 @@ class UserDatasetList extends React.Component<Props, State> {
 }
 
 export default UserDatasetList;
+
+type ThemedGrantAccessButtonProps = {
+  buttonText: string;
+  onPress: () => null;
+};
+
+export function ThemedGrantAccessButton({
+  buttonText,
+  onPress,
+}: ThemedGrantAccessButtonProps) {
+  const theme = useUITheme();
+  return (
+    <MesaButton
+      text={buttonText}
+      textTransform="none"
+      onPress={onPress}
+      themeRole="primary"
+      icon={Share}
+      styleOverrides={{
+        default: {
+          border: {
+            color:
+              theme?.palette.primary.hue[theme.palette.primary.level + 100],
+            style: 'solid',
+            width: 1,
+          },
+        },
+        hover: {
+          color: theme?.palette.primary.hue[theme.palette.primary.level + 100],
+          dropShadow: {
+            color:
+              theme?.palette.primary.hue[theme.palette.primary.level + 300],
+            blurRadius: '0px',
+            offsetX: '0px',
+            offsetY: '4px',
+          },
+        },
+        pressed: {
+          color: theme?.palette.primary.hue[theme.palette.primary.level + 200],
+          dropShadow: {
+            color:
+              theme?.palette.primary.hue[theme.palette.primary.level + 400],
+            blurRadius: '0px',
+            offsetX: '0px',
+            offsetY: '4px',
+          },
+        },
+      }}
+    />
+  );
+}

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -37,9 +37,8 @@ import { normalizePercentage, textCell } from '../UserDatasetUtils';
 import './UserDatasetList.scss';
 import { DateTime } from '../DateTime';
 
-import { useUITheme } from '@veupathdb/coreui/dist/components/theming';
-import { MesaButton, Share, Trash } from '@veupathdb/coreui';
-import { gray, mutedRed } from '@veupathdb/coreui/dist/definitions/colors';
+import { ThemedGrantAccessButton } from '../ThemedGrantAccessButton';
+import { ThemedDeleteButton } from '../ThemedDeleteButton';
 
 interface Props {
   baseUrl: string;
@@ -422,50 +421,7 @@ class UserDatasetList extends React.Component<Props, State> {
           userDatasets.forEach((userDataset) => removeUserDataset(userDataset));
         },
         element: (
-          <MesaButton
-            text="Delete"
-            textTransform="none"
-            onPress={() => null}
-            themeRole={undefined}
-            icon={Trash}
-            styleOverrides={{
-              default: {
-                color: gray[100],
-                textColor: '#4D4D4D',
-                dropShadow: {
-                  color: gray[200],
-                  blurRadius: '0px',
-                  offsetX: '0px',
-                  offsetY: '3px',
-                },
-                border: {
-                  color: gray[200],
-                  style: 'solid',
-                  width: 1,
-                },
-              },
-              hover: {
-                color: mutedRed[500],
-                textColor: 'white',
-                dropShadow: {
-                  color: mutedRed[700],
-                  blurRadius: '0px',
-                  offsetX: '0px',
-                  offsetY: '4px',
-                },
-              },
-              pressed: {
-                color: mutedRed[600],
-                textColor: 'white',
-                dropShadow: {
-                  color: mutedRed[700],
-                  blurRadius: '0px',
-                  offsetX: '0px',
-                  offsetY: '4px',
-                },
-              },
-            }}
-          />
+          <ThemedDeleteButton buttonText="Delete" onPress={() => null} />
         ),
         selectionRequired: true,
       },
@@ -692,54 +648,3 @@ class UserDatasetList extends React.Component<Props, State> {
 }
 
 export default UserDatasetList;
-
-type ThemedGrantAccessButtonProps = {
-  buttonText: string;
-  onPress: () => null;
-};
-
-export function ThemedGrantAccessButton({
-  buttonText,
-  onPress,
-}: ThemedGrantAccessButtonProps) {
-  const theme = useUITheme();
-  return (
-    <MesaButton
-      text={buttonText}
-      textTransform="none"
-      onPress={onPress}
-      themeRole="primary"
-      icon={Share}
-      styleOverrides={{
-        default: {
-          border: {
-            color:
-              theme?.palette.primary.hue[theme.palette.primary.level + 100],
-            style: 'solid',
-            width: 1,
-          },
-        },
-        hover: {
-          color: theme?.palette.primary.hue[theme.palette.primary.level + 100],
-          dropShadow: {
-            color:
-              theme?.palette.primary.hue[theme.palette.primary.level + 300],
-            blurRadius: '0px',
-            offsetX: '0px',
-            offsetY: '4px',
-          },
-        },
-        pressed: {
-          color: theme?.palette.primary.hue[theme.palette.primary.level + 200],
-          dropShadow: {
-            color:
-              theme?.palette.primary.hue[theme.palette.primary.level + 400],
-            blurRadius: '0px',
-            offsetX: '0px',
-            offsetY: '4px',
-          },
-        },
-      }}
-    />
-  );
-}

--- a/packages/libs/user-datasets/src/lib/Components/ThemedDeleteButton.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/ThemedDeleteButton.tsx
@@ -1,0 +1,54 @@
+import { useUITheme } from '@veupathdb/coreui/dist/components/theming';
+import { MesaButton, Trash } from '@veupathdb/coreui';
+import { gray, mutedRed } from '@veupathdb/coreui/dist/definitions/colors';
+import { ThemedButtonProps } from './ThemedGrantAccessButton';
+
+export function ThemedDeleteButton({ buttonText, onPress }: ThemedButtonProps) {
+  const theme = useUITheme();
+  return (
+    <MesaButton
+      text={buttonText}
+      textTransform="none"
+      onPress={onPress}
+      themeRole={undefined}
+      icon={Trash}
+      styleOverrides={{
+        default: {
+          color: gray[100],
+          textColor: '#4D4D4D',
+          dropShadow: {
+            color: gray[200],
+            blurRadius: '0px',
+            offsetX: '0px',
+            offsetY: '3px',
+          },
+          border: {
+            color: gray[200],
+            style: 'solid',
+            width: 1,
+          },
+        },
+        hover: {
+          color: mutedRed[500],
+          textColor: 'white',
+          dropShadow: {
+            color: mutedRed[700],
+            blurRadius: '0px',
+            offsetX: '0px',
+            offsetY: '4px',
+          },
+        },
+        pressed: {
+          color: mutedRed[600],
+          textColor: 'white',
+          dropShadow: {
+            color: mutedRed[700],
+            blurRadius: '0px',
+            offsetX: '0px',
+            offsetY: '4px',
+          },
+        },
+      }}
+    />
+  );
+}

--- a/packages/libs/user-datasets/src/lib/Components/ThemedGrantAccessButton.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/ThemedGrantAccessButton.tsx
@@ -1,0 +1,53 @@
+import { useUITheme } from '@veupathdb/coreui/dist/components/theming';
+import { MesaButton, Share } from '@veupathdb/coreui';
+
+export type ThemedButtonProps = {
+  buttonText: string;
+  onPress: () => null;
+};
+
+export function ThemedGrantAccessButton({
+  buttonText,
+  onPress,
+}: ThemedButtonProps) {
+  const theme = useUITheme();
+  return (
+    <MesaButton
+      text={buttonText}
+      textTransform="none"
+      onPress={onPress}
+      themeRole="primary"
+      icon={Share}
+      styleOverrides={{
+        default: {
+          border: {
+            color:
+              theme?.palette.primary.hue[theme.palette.primary.level + 100],
+            style: 'solid',
+            width: 1,
+          },
+        },
+        hover: {
+          color: theme?.palette.primary.hue[theme.palette.primary.level + 100],
+          dropShadow: {
+            color:
+              theme?.palette.primary.hue[theme.palette.primary.level + 300],
+            blurRadius: '0px',
+            offsetX: '0px',
+            offsetY: '4px',
+          },
+        },
+        pressed: {
+          color: theme?.palette.primary.hue[theme.palette.primary.level + 200],
+          dropShadow: {
+            color:
+              theme?.palette.primary.hue[theme.palette.primary.level + 400],
+            blurRadius: '0px',
+            offsetX: '0px',
+            offsetY: '4px',
+          },
+        },
+      }}
+    />
+  );
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
@@ -29,9 +29,12 @@ import { BlockRecordAttributeSection } from '@veupathdb/wdk-client/lib/Views/Rec
 
 import './record-page-new-feature.scss';
 
+import UIThemeProvider from '@veupathdb/coreui/dist/components/theming/UIThemeProvider';
+import { colors } from '@veupathdb/coreui';
+
 export const SiteHeader = () => ApiSiteHeader;
 
-const stopPropagation = event => event.stopPropagation();
+const stopPropagation = (event) => event.stopPropagation();
 
 /**
  * In ./routes.js, we redirect urls to the record page that have the project ID
@@ -44,27 +47,30 @@ const stopPropagation = event => event.stopPropagation();
  * values separated by a '/'.
  */
 export function RecordController(WdkRecordController) {
-  const enhance = connect(
-    state => ({ globalData: state.globalData }),
-    { loadPathwayGeneDynamicCols }
-  );
+  const enhance = connect((state) => ({ globalData: state.globalData }), {
+    loadPathwayGeneDynamicCols,
+  });
   class ApiRecordController extends WdkRecordController {
     getRecordRequestOptions(recordClass, categoryTree) {
       // as necessary, append tables to initial request options
       // TODO We should be explicit here and not rely on what super returns
-      const requestOptions = super.getRecordRequestOptions(recordClass, categoryTree);
+      const requestOptions = super.getRecordRequestOptions(
+        recordClass,
+        categoryTree
+      );
       if (
         recordClass.urlSegment !== 'gene' &&
         recordClass.urlSegment !== 'dataset'
-      ) return requestOptions;
+      )
+        return requestOptions;
 
       // Dataset records
       if (recordClass.urlSegment === 'dataset') {
         return [
           {
             attributes: requestOptions[0].attributes,
-            tables: requestOptions[0].tables.concat(['Version'])
-          }
+            tables: requestOptions[0].tables.concat(['Version']),
+          },
         ];
       }
 
@@ -74,12 +80,32 @@ export function RecordController(WdkRecordController) {
           attributes: requestOptions[0].attributes,
           tables: requestOptions[0].tables
             .concat(['MetaTable'])
-            .concat('TranscriptionSummary' in recordClass.tablesMap ? ['TranscriptionSummary'] : [])
-            .concat('ExpressionGraphs' in recordClass.tablesMap ? ['ExpressionGraphs'] : [])
-            .concat('PhenotypeGraphs' in recordClass.tablesMap ? ['PhenotypeGraphs'] : [])
-            .concat('CrisprPhenotypeGraphs' in recordClass.tablesMap ? ['CrisprPhenotypeGraphs'] : [])
-            .concat('FungiVBOrgLinkoutsTable' in recordClass.tablesMap ? ['FungiVBOrgLinkoutsTable'] : [])
-        }
+            .concat(
+              'TranscriptionSummary' in recordClass.tablesMap
+                ? ['TranscriptionSummary']
+                : []
+            )
+            .concat(
+              'ExpressionGraphs' in recordClass.tablesMap
+                ? ['ExpressionGraphs']
+                : []
+            )
+            .concat(
+              'PhenotypeGraphs' in recordClass.tablesMap
+                ? ['PhenotypeGraphs']
+                : []
+            )
+            .concat(
+              'CrisprPhenotypeGraphs' in recordClass.tablesMap
+                ? ['CrisprPhenotypeGraphs']
+                : []
+            )
+            .concat(
+              'FungiVBOrgLinkoutsTable' in recordClass.tablesMap
+                ? ['FungiVBOrgLinkoutsTable']
+                : []
+            ),
+        },
       ];
     }
     loadData(prevProps) {
@@ -89,12 +115,27 @@ export function RecordController(WdkRecordController) {
       // record) is present, load dynamic attributes of that step for all genes
       // relevant to this pathway that were also in that result
       let { recordClass, primaryKey } = this.props.ownProps;
-      if (recordClass == 'pathway' && !isEqual(this.props.ownProps, prevProps && prevProps.ownProps)) {
-        let [ pathwaySource, pathwayId ] = primaryKey.split('/');
-        let geneStepId = QueryString.parse(this.props.globalData.location.search.slice(1)).geneStepId;
-        let exactMatchOnly = QueryString.parse(this.props.globalData.location.search.slice(1)).exact_match_only;
-        let excludeIncompleteEc = QueryString.parse(this.props.globalData.location.search.slice(1)).exclude_incomplete_ec;
-        this.props.loadPathwayGeneDynamicCols(geneStepId, pathwaySource, pathwayId, exactMatchOnly, excludeIncompleteEc);
+      if (
+        recordClass == 'pathway' &&
+        !isEqual(this.props.ownProps, prevProps && prevProps.ownProps)
+      ) {
+        let [pathwaySource, pathwayId] = primaryKey.split('/');
+        let geneStepId = QueryString.parse(
+          this.props.globalData.location.search.slice(1)
+        ).geneStepId;
+        let exactMatchOnly = QueryString.parse(
+          this.props.globalData.location.search.slice(1)
+        ).exact_match_only;
+        let excludeIncompleteEc = QueryString.parse(
+          this.props.globalData.location.search.slice(1)
+        ).exclude_incomplete_ec;
+        this.props.loadPathwayGeneDynamicCols(
+          geneStepId,
+          pathwaySource,
+          pathwayId,
+          exactMatchOnly,
+          excludeIncompleteEc
+        );
       }
     }
   }
@@ -102,16 +143,22 @@ export function RecordController(WdkRecordController) {
 }
 
 function EnhancedRecordUIContainer(props) {
-  return (
-    cloneElement(props.children, { bottomOffset: 100 })
-  )
+  return cloneElement(props.children, { bottomOffset: 100 });
 }
 
 export const RecordHeading = makeDynamicWrapper('RecordHeading');
-export const RecordUI = makeDynamicWrapper('RecordUI', EnhancedRecordUIContainer);
+export const RecordUI = makeDynamicWrapper(
+  'RecordUI',
+  EnhancedRecordUIContainer
+);
 export const RecordMainSection = makeDynamicWrapper('RecordMainSection');
-export const RecordTable = makeDynamicWrapper('RecordTable', RecordTableContainer);
-export const RecordTableDescription = makeDynamicWrapper('RecordTableDescription');
+export const RecordTable = makeDynamicWrapper(
+  'RecordTable',
+  RecordTableContainer
+);
+export const RecordTableDescription = makeDynamicWrapper(
+  'RecordTableDescription'
+);
 export const ResultTable = makeDynamicWrapper('ResultTable');
 export const ResultPanelHeader = makeDynamicWrapper('ResultPanelHeader');
 
@@ -120,12 +167,14 @@ const RecordClassSpecificRecordlink = makeDynamicWrapper('RecordLink');
 /** Remove project_id from record links */
 export function RecordLink(WdkRecordLink) {
   const isPortal = projectId === 'EuPathDB';
-  const ResolvedRecordLink = RecordClassSpecificRecordlink(makePortalRecordLink(WdkRecordLink));
+  const ResolvedRecordLink = RecordClassSpecificRecordlink(
+    makePortalRecordLink(WdkRecordLink)
+  );
   return function ApiRecordLink(props) {
-    let recordId = isPortal ? props.recordId : props.recordId.filter(p => p.name !== 'project_id');
-    return (
-      <ResolvedRecordLink {...props} recordId={recordId}/>
-    );
+    let recordId = isPortal
+      ? props.recordId
+      : props.recordId.filter((p) => p.name !== 'project_id');
+    return <ResolvedRecordLink {...props} recordId={recordId} />;
   };
 }
 
@@ -133,18 +182,32 @@ function makePortalRecordLink(WdkRecordLink) {
   if (projectId !== 'EuPathDB') return WdkRecordLink;
   return function PortalRecordLink(props) {
     const { recordId, recordClass } = props;
-    const projectIdPart = recordId.find(part => part.name === 'project_id');
+    const projectIdPart = recordId.find((part) => part.name === 'project_id');
     const projectUrls = useProjectUrls();
 
-    if (projectUrls == null || projectIdPart == null || projectIdPart.value === 'EuPathDB' || projectUrls[projectIdPart.value] == null ) return <WdkRecordLink {...props}/>;
+    if (
+      projectUrls == null ||
+      projectIdPart == null ||
+      projectIdPart.value === 'EuPathDB' ||
+      projectUrls[projectIdPart.value] == null
+    )
+      return <WdkRecordLink {...props} />;
 
     const baseUrl = projectUrls[projectIdPart.value];
-    const pkValues = recordId.filter(p => p.name !== 'project_id').map(p => p.value).join('/');
-    const url = new URL(`app/record/${recordClass.urlSegment}/${pkValues}`, baseUrl);
-    return (
-      <a href={url} target="_blank">{props.children}</a>
+    const pkValues = recordId
+      .filter((p) => p.name !== 'project_id')
+      .map((p) => p.value)
+      .join('/');
+    const url = new URL(
+      `app/record/${recordClass.urlSegment}/${pkValues}`,
+      baseUrl
     );
-  }
+    return (
+      <a href={url} target="_blank">
+        {props.children}
+      </a>
+    );
+  };
 }
 
 function downloadRecordTable(record, tableName) {
@@ -153,10 +216,10 @@ function downloadRecordTable(record, tableName) {
     let formatting = {
       format: 'tableTabular',
       formatConfig: {
-        tables: [ tableName ],
+        tables: [tableName],
         includeHeader: true,
-        attachmentType: "text"
-      }
+        attachmentType: 'text',
+      },
     };
     wdkService.downloadAnswer({ answerSpec, formatting });
     return emptyAction;
@@ -164,132 +227,141 @@ function downloadRecordTable(record, tableName) {
 }
 
 export function RecordTableSection(DefaultComponent) {
-  return connect(null, { downloadRecordTable })(class ApiRecordTableSection extends React.PureComponent {
-    render () {
-      if (this.props.recordClass.fullName === 'DatasetRecordClasses.DatasetRecordClass') {
-        return (
-          <DefaultComponent {...this.props}/>
+  return connect(null, { downloadRecordTable })(
+    class ApiRecordTableSection extends React.PureComponent {
+      render() {
+        if (
+          this.props.recordClass.fullName ===
+          'DatasetRecordClasses.DatasetRecordClass'
+        ) {
+          return <DefaultComponent {...this.props} />;
+        }
+
+        let { table, record, downloadRecordTable, ontologyProperties } =
+          this.props;
+        let customName = `Data Sets used to generate ${String.fromCharCode(
+          8220
+        )}${table.displayName.replace('/', '-')}${String.fromCharCode(8221)}`;
+        let callDownloadTable = (event) => {
+          event.stopPropagation();
+          downloadRecordTable(record, table.name);
+        };
+
+        // FIXME Revise this since we now lazy load tables...
+        let showDownload =
+          record.tables[table.name] &&
+          record.tables[table.name].length > 0 &&
+          ontologyProperties.scope.includes('download');
+
+        let hideDatasetLinkFromProperty =
+          record.tables[table.name] &&
+          table.properties.hideDatasetLink &&
+          table.properties.hideDatasetLink[0].toLowerCase() == 'true';
+
+        let showDatasetsLink =
+          record.tables[table.name] &&
+          !table.name.startsWith('UserDatasets') &&
+          !hideDatasetLinkFromProperty;
+
+        var hasTaxonId = 0;
+        if (
+          record.recordClassName == 'GeneRecordClasses.GeneRecordClass' ||
+          record.recordClassName ==
+            'SequenceRecordClasses.SequenceRecordClass' ||
+          record.recordClassName == 'OrganismRecordClasses.OrganismRecordClass'
+        ) {
+          hasTaxonId = 1;
+        }
+
+        const title = (
+          <span>
+            {table.displayName}{' '}
+            {showDownload && (
+              <span
+                style={{
+                  fontSize: '.8em',
+                  fontWeight: 'normal',
+                  marginLeft: '1em',
+                }}
+              >
+                <button
+                  type="button"
+                  className="wdk-Link"
+                  onClick={callDownloadTable}
+                >
+                  <i className="fa fa-download" /> Download
+                </button>
+              </span>
+            )}
+            {hasTaxonId == 0 && showDatasetsLink && (
+              <Link
+                style={{
+                  fontSize: '.8em',
+                  fontWeight: 'normal',
+                  marginLeft: '1em',
+                }}
+                onClick={stopPropagation}
+                to={{
+                  pathname: `/search/dataset/DatasetsByReferenceNameNoTaxon:${customName}/result`,
+                  search: QueryString.stringify({
+                    'param.record_class': record.recordClassName,
+                    'param.reference_name': table.name,
+                  }),
+                }}
+              >
+                <i className="fa fa-database" /> Data Sets
+              </Link>
+            )}
+            {hasTaxonId == 1 && showDatasetsLink && (
+              <Link
+                style={{
+                  fontSize: '.8em',
+                  fontWeight: 'normal',
+                  marginLeft: '1em',
+                }}
+                onClick={stopPropagation}
+                to={{
+                  pathname: `/search/dataset/DatasetsByReferenceName:${customName}/result`,
+                  search: QueryString.stringify({
+                    'param.record_class': record.recordClassName,
+                    'param.reference_name': table.name,
+                    'param.taxon': record.attributes.organism_full,
+                  }),
+                }}
+              >
+                <i className="fa fa-database" /> Data sets
+              </Link>
+            )}
+          </span>
         );
+
+        return <DefaultComponent {...this.props} title={title} />;
       }
-
-      let { table, record, downloadRecordTable, ontologyProperties } = this.props;
-      let customName = `Data Sets used to generate ${String.fromCharCode(8220)}${table.displayName.replace('/','-')}${String.fromCharCode(8221)}`
-      let callDownloadTable = event => {
-        event.stopPropagation();
-        downloadRecordTable(record, table.name);
-      };
-
-      // FIXME Revise this since we now lazy load tables...
-      let showDownload = (
-        record.tables[table.name] &&
-        record.tables[table.name].length > 0 &&
-        ontologyProperties.scope.includes('download')
-      );
-
-
-        let hideDatasetLinkFromProperty = (
-            record.tables[table.name] &&
-            table.properties.hideDatasetLink &&
-            table.properties.hideDatasetLink[0].toLowerCase() == 'true'
-        );
-
-      let showDatasetsLink = (
-        record.tables[table.name] &&
-        !table.name.startsWith("UserDatasets") &&
-        !hideDatasetLinkFromProperty
-      );
-
-
-      var hasTaxonId = 0;
-      if (record.recordClassName == 'GeneRecordClasses.GeneRecordClass' ||
-          record.recordClassName == 'SequenceRecordClasses.SequenceRecordClass' ||
-          record.recordClassName == 'OrganismRecordClasses.OrganismRecordClass')
-      {
-        hasTaxonId = 1;
-      }
-
-      const title = (
-        <span>
-          {table.displayName}
-          {' '}
-          {showDownload &&
-            <span
-              style={{
-                fontSize: '.8em',
-                fontWeight: 'normal',
-                marginLeft: '1em'
-              }}>
-              <button type="button"
-                className="wdk-Link"
-                onClick={callDownloadTable}>
-                <i className="fa fa-download"/> Download
-              </button>
-            </span>
-          }
-          { hasTaxonId == 0 && showDatasetsLink &&
-          <Link
-            style={{
-              fontSize: '.8em',
-              fontWeight: 'normal',
-              marginLeft: '1em'
-            }}
-            onClick={stopPropagation}
-            to={{
-              pathname: `/search/dataset/DatasetsByReferenceNameNoTaxon:${customName}/result`,
-              search: QueryString.stringify({
-                'param.record_class': record.recordClassName,
-                'param.reference_name': table.name,
-              })
-            }}
-          ><i className="fa fa-database"/> Data Sets</Link>}
-          { hasTaxonId == 1 && showDatasetsLink &&
-          <Link
-            style={{
-              fontSize: '.8em',
-              fontWeight: 'normal',
-              marginLeft: '1em'
-            }}
-            onClick={stopPropagation}
-            to={{
-              pathname: `/search/dataset/DatasetsByReferenceName:${customName}/result`,
-              search: QueryString.stringify({
-                'param.record_class': record.recordClassName,
-                'param.reference_name': table.name,
-                'param.taxon': record.attributes.organism_full
-              })
-            }}
-          ><i className="fa fa-database"/> Data sets</Link>}
-
-        </span>
-      );
-
-      return (
-        <DefaultComponent {...this.props} title={title} />
-      );
     }
-  });
+  );
 }
 
 function getGbrowseContext(attributeName) {
-  return Gbrowse.contexts.find(context => context.gbrowse_url === attributeName);
+  return Gbrowse.contexts.find(
+    (context) => context.gbrowse_url === attributeName
+  );
 }
 
-export const RecordAttribute = makeDynamicWrapper('RecordAttribute',
+export const RecordAttribute = makeDynamicWrapper(
+  'RecordAttribute',
   function MaybeDyamicWrapper(props) {
     const { attribute, record } = props;
 
     const context = getGbrowseContext(attribute.name);
 
     if (context) {
-      return (
-        <Gbrowse.GbrowseContext {...props} context={context} />
-      );
+      return <Gbrowse.GbrowseContext {...props} context={context} />;
     }
 
     // Render attribute as a Sequence if attribute name ends with "sequence".
     let sequenceRE = /sequence$/;
     if (sequenceRE.test(attribute.name)) {
-      return ( <Sequence sequence={record.attributes[attribute.name]}/> );
+      return <Sequence sequence={record.attributes[attribute.name]} />;
     }
 
     return props.children;
@@ -302,15 +374,14 @@ export function RecordAttributeSection(DefaultComponent) {
     const context = getGbrowseContext(attribute.name);
 
     if (context) {
-      return (
-        <BlockRecordAttributeSection {...props} />
-      );
+      return <BlockRecordAttributeSection {...props} />;
     }
 
     // use standard record class overriding
     let ResolvedComponent =
-      findComponent('RecordAttributeSection', props.recordClass.fullName) || DefaultComponent;
-    return <ResolvedComponent {...props} DefaultComponent={DefaultComponent}/>
+      findComponent('RecordAttributeSection', props.recordClass.fullName) ||
+      DefaultComponent;
+    return <ResolvedComponent {...props} DefaultComponent={DefaultComponent} />;
   };
 }
 
@@ -318,13 +389,13 @@ export function RecordAttributeSection(DefaultComponent) {
  * Trims PROJECT_ID off the tail end of a comma-delimited list of primary key value parts
  */
 export function PrimaryKeySpan() {
-  return function(props) {
+  return function (props) {
     let pkValues = props.primaryKeyString.split(',');
     let newPkString = pkValues[0];
     for (let i = 1; i < pkValues.length - 1; i++) {
-      newPkString += ", " + pkValues[i];
+      newPkString += ', ' + pkValues[i];
     }
-    return ( <span>{newPkString}</span> );
+    return <span>{newPkString}</span>;
   };
 }
 
@@ -334,13 +405,14 @@ export function PrimaryKeySpan() {
 function sendToGalaxy(props) {
   return ({ wdkService }) => {
     let { galaxyUrl, resultType, selectedReporter, formState } = props;
-    wdkService.getTemporaryResultPath(resultType.step, selectedReporter, formState)
-      .then(path => {
+    wdkService
+      .getTemporaryResultPath(resultType.step, selectedReporter, formState)
+      .then((path) => {
         const url = new URL(wdkService.serviceUrl + path, window.location);
         submitAsForm({
           target: '_new',
           action: galaxyUrl,
-          inputs: { URL: url.toString() }
+          inputs: { URL: url.toString() },
         });
       });
     return emptyAction;
@@ -351,31 +423,47 @@ function SendToGalaxyButton(props) {
   const [galaxyUrl, setGalaxyUrl] = React.useState(null);
   React.useEffect(() => {
     setGalaxyUrl(sessionStorage.getItem('galaxyUrl'));
-  })
-  return (!galaxyUrl ? null :
-    <button className="btn" type="button" onClick={() => { props.sendToGalaxy({...props, galaxyUrl}); }}>
+  });
+  return !galaxyUrl ? null : (
+    <button
+      className="btn"
+      type="button"
+      onClick={() => {
+        props.sendToGalaxy({ ...props, galaxyUrl });
+      }}
+    >
       Send {props.recordClass.displayNamePlural} to Galaxy
     </button>
   );
 }
 
-export function TabularReporterFormSubmitButtons(ApiTabularReporterFormSubmitButtons) {
-  return connect(state => Object.assign({}, state.downloadForm, { webAppUrl: state.globalData.siteConfig.webAppUrl }), { sendToGalaxy })(
-    props => (
-      <div>
-        <ApiTabularReporterFormSubmitButtons {...props} />
-        <SendToGalaxyButton {...props} />
-      </div>
-    )
-  );
+export function TabularReporterFormSubmitButtons(
+  ApiTabularReporterFormSubmitButtons
+) {
+  return connect(
+    (state) =>
+      Object.assign({}, state.downloadForm, {
+        webAppUrl: state.globalData.siteConfig.webAppUrl,
+      }),
+    { sendToGalaxy }
+  )((props) => (
+    <div>
+      <ApiTabularReporterFormSubmitButtons {...props} />
+      <SendToGalaxyButton {...props} />
+    </div>
+  ));
 }
 
 export function ResultTabs(DefaultComponent) {
   return function ApiResultTabs(props) {
     return (
-      <div style={{ display: "flex", paddingTop: "1em", alignItems: "stretch" }}>
-        <OrganismFilter {...props}/>
-        <div style={{ flex: 1, overflow: 'auto' }}><DefaultComponent {...props}/></div>
+      <div
+        style={{ display: 'flex', paddingTop: '1em', alignItems: 'stretch' }}
+      >
+        <OrganismFilter {...props} />
+        <div style={{ flex: 1, overflow: 'auto' }}>
+          <DefaultComponent {...props} />
+        </div>
       </div>
     );
   };
@@ -390,7 +478,7 @@ export function StrategyWorkspaceController(DefaultComponent) {
         </StepDetailsActionContext.Provider>
       </BinaryOperationsContext.Provider>
     );
-  }
+  };
 }
 
 export function Page() {
@@ -404,12 +492,20 @@ export function Page() {
 
     React.useEffect(() => {
       if (galaxyUrl != null) sessionStorage.setItem('galaxyUrl', galaxyUrl);
-    }, [galaxyUrl])
-
+    }, [galaxyUrl]);
 
     return (
       <RecoilRoot>
-        <VEuPathDBHomePage {...props} isHomePage={isHomePage} />
+        <UIThemeProvider
+          theme={{
+            palette: {
+              primary: { hue: colors.gray, level: 100 },
+              secondary: { hue: colors.mutedRed, level: 500 },
+            },
+          }}
+        >
+          <VEuPathDBHomePage {...props} isHomePage={isHomePage} />
+        </UIThemeProvider>
       </RecoilRoot>
     );
   };


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/EdaNewIssues/issues/621 when combined with https://github.com/VEuPathDB/web-monorepo/pull/100

Replaced `Grant Access` and `Delete` buttons with `CoreUI` `MesaButton`s. The `Grant Access` button listens to the site's theme colors. The `Delete` button does not use theme colors but instead relies on style overrides to mimic the old look. Screenshots below.

**Mbio**:
![image](https://user-images.githubusercontent.com/69446567/234291542-930a8780-187c-4a9f-bc2b-d027404c53ce.png)
![image](https://user-images.githubusercontent.com/69446567/234291651-8bee8d7c-6b09-4589-9445-d0362a2eecdb.png)

**ClinEpi**:
![image](https://user-images.githubusercontent.com/69446567/234293122-a95bb0b6-973e-4c6d-bc87-9e65c2261e18.png)
![image](https://user-images.githubusercontent.com/69446567/234293259-9108aca5-5d28-4834-b612-428ecc953b54.png)

**Plasmo**:
![image](https://user-images.githubusercontent.com/69446567/234293903-4266c60d-d937-4630-b434-51c7b8287c65.png)
![image](https://user-images.githubusercontent.com/69446567/234294356-0e03ae83-7c27-4beb-963e-36bac2f28c40.png)