### PR TITLE
113/standalone-map-menu-remaining

### DIFF
--- a/packages/libs/eda/src/lib/core/hooks/workspace.ts
+++ b/packages/libs/eda/src/lib/core/hooks/workspace.ts
@@ -21,6 +21,7 @@ import {
   findEntityAndVariable,
 } from '../utils/study-metadata';
 import { ComputeClient } from '../api/ComputeClient';
+import { DownloadClient } from '../api';
 
 /** Return the study identifier and a hierarchy of the study entities. */
 export function useStudyMetadata(): StudyMetadata {
@@ -37,6 +38,9 @@ export function useSubsettingClient(): SubsettingClient {
 }
 export function useDataClient(): DataClient {
   return useNonNullableContext(WorkspaceContext).dataClient;
+}
+export function useDownloadClient(): DownloadClient {
+  return useNonNullableContext(WorkspaceContext).downloadClient;
 }
 export function useAnalysisClient(): AnalysisClient {
   return useNonNullableContext(WorkspaceContext).analysisClient;

--- a/packages/libs/eda/src/lib/map/MapVEu.scss
+++ b/packages/libs/eda/src/lib/map/MapVEu.scss
@@ -10,5 +10,10 @@
 
   .MapVEu {
     height: 100%;
+
+    .wdk-RecordSidebarToggle,
+    .wdk-RecordSidebar {
+      background-color: #eaeaea;
+    }
   }
 }

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -6,6 +6,7 @@ import {
   PromiseResult,
   useAnalysis,
   useDataClient,
+  useDownloadClient,
   useFindEntityAndVariable,
   usePromise,
   useStudyEntities,
@@ -74,6 +75,8 @@ import NameAnalysis from '../../workspace/sharing/NameAnalysis';
 import NotesTab from '../../workspace/NotesTab';
 import ConfirmShareAnalysis from '../../workspace/sharing/ConfirmShareAnalysis';
 import { useHistory } from 'react-router';
+import DownloadTab from '../../workspace/DownloadTab';
+import { RecordController } from '@veupathdb/wdk-client/lib/Controllers';
 
 enum MapSideNavItemLabels {
   Download = 'Download',
@@ -186,6 +189,8 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
   const finalMarkers = useMemo(() => markers || [], [markers]);
 
   const dataClient = useDataClient();
+
+  const downloadClient = useDownloadClient();
 
   const userLoggedIn = useWdkService((wdkService) => {
     return wdkService.getCurrentUser().then((user) => !user.isGuest);
@@ -424,7 +429,8 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
           return (
             <div
               style={{
-                width: '80vw',
+                width: '70vw',
+                maxWidth: 1500,
                 maxHeight: 650,
                 padding: '0 25px',
               }}
@@ -467,7 +473,24 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
       {
         labelText: MapSideNavItemLabels.Download,
         icon: <Download />,
-        renderSideNavigationPanel: sideNavigationRenderPlaceholder,
+        renderSideNavigationPanel: () => {
+          return (
+            <div
+              style={{
+                padding: '1em',
+                width: '70vw',
+                maxWidth: '1500px',
+              }}
+            >
+              <DownloadTab
+                downloadClient={downloadClient}
+                analysisState={analysisState}
+                totalCounts={totalCounts.value}
+                filteredCounts={filteredCounts.value}
+              />
+            </div>
+          );
+        },
       },
       {
         labelText: MapSideNavItemLabels.Share,
@@ -513,8 +536,9 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
           return (
             <div
               style={{
-                // This matches the `marginTop` applied by `<NotesTab />`
-                padding: '0 35px',
+                padding: '1em',
+                width: '70vw',
+                maxWidth: '1500px',
               }}
             >
               <NotesTab analysisState={analysisState} />
@@ -525,7 +549,23 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
       {
         labelText: MapSideNavItemLabels.StudyDetails,
         icon: <InfoOutlined />,
-        renderSideNavigationPanel: sideNavigationRenderPlaceholder,
+        renderSideNavigationPanel: () => {
+          return (
+            <div
+              style={{
+                padding: '1em',
+                width: '70vw',
+                maxWidth: '1500px',
+                fontSize: '.95em',
+              }}
+            >
+              <RecordController
+                recordClass="dataset"
+                primaryKey={studyRecord.id.map((p) => p.value).join('/')}
+              />
+            </div>
+          );
+        },
       },
     ];
 


### PR DESCRIPTION
Fixes #113

This PR adds the download and study details content to the standalone map menu.

Note that we might want to consider preventing menu items from being unmounted, since some of them may require service calls. This would effectively cache those calls, which will make switching between menu items faster.