### PR TITLE
Use a primary color close to current link colors

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
@@ -499,7 +499,7 @@ export function Page() {
         <UIThemeProvider
           theme={{
             palette: {
-              primary: { hue: colors.gray, level: 100 },
+              primary: { hue: colors.mutedBlue, level: 600 },
               secondary: { hue: colors.mutedRed, level: 500 },
             },
           }}


### PR DESCRIPTION
This PR updates the primary color of the coreui theme for genomics sites. The color is meant to be as close to the link color as possible.

**Before**
![image](https://user-images.githubusercontent.com/365139/234669112-bf54f3e4-116b-47bd-87fc-574f63730cbf.png)

![image](https://user-images.githubusercontent.com/365139/234668929-b19e49a1-0e94-4e07-9cfc-053cb9f24a64.png)


**After**
![image](https://user-images.githubusercontent.com/365139/234669191-c8274026-8348-492f-beb9-53b904995c05.png)

![image](https://user-images.githubusercontent.com/365139/234664721-8154a0f4-4912-4054-970b-ca95c8c3d6e1.png)
