### PR TITLE
remove-zero-baseline-consideration

### DIFF
--- a/packages/libs/eda/src/lib/core/hooks/computeDefaultAxisRange.ts
+++ b/packages/libs/eda/src/lib/core/hooks/computeDefaultAxisRange.ts
@@ -24,7 +24,8 @@ export function useDefaultAxisRange(
   logScale?: boolean,
   axisRangeSpec = 'Full',
   // check non-zero baseline for continuous overlay variable
-  isNonZeroBaseline: boolean = false
+  // but not used in any Viz yet, so change the default to true
+  isNonZeroBaseline: boolean = true
 ): NumberOrDateRange | undefined {
   const defaultAxisRange = useMemo(() => {
     // Check here to make sure number ranges (min, minPos, max) came with number variables

--- a/packages/libs/eda/src/lib/core/hooks/computeDefaultAxisRange.ts
+++ b/packages/libs/eda/src/lib/core/hooks/computeDefaultAxisRange.ts
@@ -22,10 +22,7 @@ export function useDefaultAxisRange(
   max?: number | string,
   /** are we using a log scale */
   logScale?: boolean,
-  axisRangeSpec = 'Full',
-  // check non-zero baseline for continuous overlay variable
-  // but not used in any Viz yet, so change the default to true
-  isNonZeroBaseline: boolean = true
+  axisRangeSpec = 'Full'
 ): NumberOrDateRange | undefined {
   const defaultAxisRange = useMemo(() => {
     // Check here to make sure number ranges (min, minPos, max) came with number variables
@@ -48,8 +45,7 @@ export function useDefaultAxisRange(
         minPos,
         max,
         logScale,
-        axisRangeSpec,
-        isNonZeroBaseline
+        axisRangeSpec
       );
 
       // 4 significant figures
@@ -64,12 +60,10 @@ export function useDefaultAxisRange(
           typeof defaultRange?.max === 'number')
       )
         // check non-zero baseline for continuous overlay variable
-        return isNonZeroBaseline
-          ? defaultRange
-          : {
-              min: numberSignificantFigures(defaultRange.min, 4, 'down'),
-              max: numberSignificantFigures(defaultRange.max, 4, 'up'),
-            };
+        return {
+          min: numberSignificantFigures(defaultRange.min, 4, 'down'),
+          max: numberSignificantFigures(defaultRange.max, 4, 'up'),
+        };
       else return defaultRange;
     } else if (
       variable == null &&
@@ -93,7 +87,7 @@ export function useDefaultAxisRange(
     } else {
       return undefined;
     }
-  }, [variable, min, minPos, max, logScale, axisRangeSpec, isNonZeroBaseline]);
+  }, [variable, min, minPos, max, logScale, axisRangeSpec]);
   return defaultAxisRange;
 }
 

--- a/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
+++ b/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
@@ -12,8 +12,7 @@ export function numberDateDefaultAxisRange(
   observedMax: number | string | undefined,
   /** are we using a log scale */
   logScale?: boolean,
-  axisRangeSpec = 'Full',
-  isNonZeroBaseline: boolean = false
+  axisRangeSpec = 'Full'
 ): NumberOrDateRange | undefined {
   if (Variable.is(variable)) {
     if (variable.type === 'number' || variable.type === 'integer') {
@@ -31,7 +30,7 @@ export function numberDateDefaultAxisRange(
                 defaults.rangeMin <= 0)
                 ? (observedMinPos as number)
                 : (min([
-                    isNonZeroBaseline ? undefined : 0,
+                    // remove 0
                     defaults.displayRangeMin,
                     defaults.rangeMin,
                     observedMin as number,


### PR DESCRIPTION
This will resolve https://github.com/VEuPathDB/web-monorepo/issues/147. I have tested several cases, but one of the best and simplest way is to set the default value of the isNonZeroBaseline prop as true for. Actually, it is not used anywhere yet.

Here are various screenshots using year variable after applying this:

![year variable 01](https://user-images.githubusercontent.com/12802305/236014146-e477c570-0b15-4123-ae10-226351f1e03c.png)

![year variable 02](https://user-images.githubusercontent.com/12802305/236014169-3346e8ac-6bb3-4b53-8569-4388396c827d.png)

![year variable 03](https://user-images.githubusercontent.com/12802305/236014193-ae90b236-4e17-46af-8020-12ca98649ebd.png)

![year variable 04](https://user-images.githubusercontent.com/12802305/236014218-fdcef13d-9c13-4ac0-a532-a10942ccc88c.png)
