### PR TITLE
Strip HTML from document title

### DIFF
--- a/packages/libs/wdk-client/src/Utils/ComponentUtils.tsx
+++ b/packages/libs/wdk-client/src/Utils/ComponentUtils.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { AttributeValue } from '../Utils/WdkModel';
+import { stripHTML } from './DomUtils';
 
 /**
  * React Component utils
@@ -468,7 +469,7 @@ export function propertyIsNonNull<T, K extends keyof T>(
 
 export function useSetDocumentTitle(title: string) {
   useEffect(() => {
-    document.title = title;
+    document.title = stripHTML(title);
     return () => {
       document.title = '';
     };


### PR DESCRIPTION
Minor nit: some ClinEpi studies include HTML in their `displayName` properties, which then gets displayed in the browser tab due to the `document.title` logic we use. This aims to fix that by stripping HTML from the string used for `document.title`.

Before:
![image](https://user-images.githubusercontent.com/69446567/236315438-8ffcee1d-651e-45c5-8bef-b4c169c1e85d.png)

After:
![image](https://user-images.githubusercontent.com/69446567/236317279-cac88e14-46d5-4f7d-b2be-b99781198794.png)