### PR TITLE
Revert "Fix: ensure map legend title reflects selected variable in active marker configuration"

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -5,7 +5,6 @@ import {
   DEFAULT_ANALYSIS_NAME,
   EntityDiagram,
   PromiseResult,
-  StudyEntity,
   useAnalysis,
   useDataClient,
   useDownloadClient,
@@ -210,6 +209,10 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
       (markerConfig) => markerConfig.type === activeMarkerConfigurationType
     ) || defautMarkerConfigurations[0];
 
+  const findEntityAndVariable = useFindEntityAndVariable();
+  const { variable: overlayVariable } =
+    findEntityAndVariable(selectedVariables) ?? {};
+
   const filters = analysisState.analysis?.descriptor.subset.descriptor;
 
   function updateMarkerConfigurations(
@@ -249,8 +252,12 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
     geoConfig: geoConfig,
     studyId: studyMetadata.id,
     filters,
+    // xAxisVariable: activeMarkerConfiguration.selectedVariable,
+    // computationType: 'pass',
     markerType: adaptedMarkerTypename,
+    // checkedLegendItems: undefined,
     overlayVariable: activeMarkerConfiguration.selectedVariable,
+    //TO DO: maybe dependentAxisLogScale
   });
 
   const finalMarkers = useMemo(() => markers || [], [markers]);
@@ -821,9 +828,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                     totalVisibleWithOverlayEntityCount ??
                     totalVisibleEntityCount
                   }
-                  overlayActive={
-                    activeMarkerConfiguration.selectedVariable != null
-                  }
+                  overlayActive={overlayVariable != null}
                 />
                 <div
                   style={{
@@ -911,10 +916,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                   {legendItems.length > 0 && (
                     <MapLegend
                       legendItems={legendItems}
-                      title={getLegendTitleFromActiveMarkerConfiguration(
-                        studyEntities,
-                        activeMarkerConfiguration
-                      )}
+                      title={overlayVariable?.displayName}
                       // control to show checkbox. default: true
                       showCheckbox={false}
                     />
@@ -1014,14 +1016,4 @@ export function useGetDefaultVariableIdCallback() {
 
     return { entityId: finalEntityId, variableId: finalVariableId };
   };
-}
-
-function getLegendTitleFromActiveMarkerConfiguration(
-  studyEntities: StudyEntity[],
-  activeMarkerConfiguration: MarkerConfiguration
-) {
-  const { entityId, variableId } = activeMarkerConfiguration.selectedVariable;
-  const entity = studyEntities.find((e) => e.id === entityId);
-  const variable = entity?.variables.find((v) => v.id === variableId);
-  return variable?.displayName || 'Variable';
 }


### PR DESCRIPTION
Reverts VEuPathDB/web-monorepo#159

This commit in my big PR will fix a root cause of the problem (`selectedVariables` is really just one default variable)
https://github.com/VEuPathDB/web-monorepo/pull/143/commits/db0905e8d573990e359f8c561e2a45c841133deb