### PR TITLE
Remove gitter btn in map UI to prevent obscuring map info

### DIFF
--- a/packages/libs/components/src/map/MapVEuMap.tsx
+++ b/packages/libs/components/src/map/MapVEuMap.tsx
@@ -232,6 +232,20 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
     [sharedPlotCreation.run]
   );
 
+  useEffect(() => {
+    const gitterBtn: HTMLAnchorElement | null = document.querySelector(
+      '.gitter-open-chat-button'
+    );
+    if (gitterBtn) {
+      gitterBtn.style.display = 'none';
+    }
+    () => {
+      if (gitterBtn) {
+        gitterBtn.style.display = 'inline';
+      }
+    };
+  }, []);
+
   useImperativeHandle<PlotRef, PlotRef>(
     ref,
     () => ({


### PR DESCRIPTION
The button's position obscures the map scale (see bottom right of screenshot), plus could potentially obscure map markers. Low cost choice for now was to remove the button from the map UI.

Problem:
![image](https://user-images.githubusercontent.com/69446567/236922075-3fd87e21-81dd-4ea7-8459-792c6db478ce.png)