### PR TITLE
164: Tweak header styles to better match mockup

### DIFF
--- a/packages/libs/coreui/src/styleDefinitions/typography.ts
+++ b/packages/libs/coreui/src/styleDefinitions/typography.ts
@@ -1,89 +1,95 @@
-import { css } from "@emotion/react";
-import { gray } from "../definitions/colors";
+import { css } from '@emotion/react';
+import { gray } from '../definitions/colors';
+import { CSSInterpolation } from '@emotion/serialize';
 
 export const primaryFont = "'Inter', sans-serif";
 export const secondaryFont = '"Roboto", sans-serif';
+const defaultHeadingStyles: CSSInterpolation = {
+  fontFamily: primaryFont,
+  margin: 0,
+};
 
 export const h1 = css([
-  { fontFamily: primaryFont },
+  defaultHeadingStyles,
   {
     fontSize: 72,
     fontWeight: 700,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 export const h2 = css([
-  { fontFamily: primaryFont },
+  defaultHeadingStyles,
   {
     fontSize: 56,
     fontWeight: 700,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 export const h3 = css([
-  { fontFamily: primaryFont },
+  defaultHeadingStyles,
   {
     fontSize: 42,
     fontWeight: 600,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 export const h4 = css([
-  { fontFamily: primaryFont },
+  defaultHeadingStyles,
   {
     fontSize: 32,
     fontWeight: 600,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 export const h5 = css([
-  { fontFamily: primaryFont },
+  defaultHeadingStyles,
   {
     fontSize: 21,
     fontWeight: 500,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 export const h6 = css([
-  { fontFamily: primaryFont },
+  defaultHeadingStyles,
   {
     fontSize: 16,
     fontWeight: 500,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 
 export const p = css([
   { fontFamily: secondaryFont },
   {
-    fontSize: "0.8rem",
+    fontSize: '0.8rem',
     fontWeight: 400,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    margin: 0,
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 export const pre = css([
   { fontFamily: secondaryFont },
   {
-    fontSize: ".80rem",
+    fontSize: '.80rem',
     fontWeight: 400,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 export const label = css([
   { fontFamily: secondaryFont },
   {
-    fontSize: ".75rem",
+    fontSize: '.75rem',
     fontWeight: 400,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
     color: gray[400],
   },
 ]);
@@ -91,31 +97,31 @@ export const label = css([
 export const metaData = css([
   { fontFamily: secondaryFont },
   {
-    fontSize: ".70rem",
+    fontSize: '.70rem',
     fontWeight: 400,
-    textTransform: "uppercase",
+    textTransform: 'uppercase',
     color: gray[300],
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 
 export const th = css([
   { fontFamily: secondaryFont },
   {
-    fontSize: ".90rem",
+    fontSize: '.90rem',
     fontWeight: 500,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 export const td = css([
   { fontFamily: secondaryFont },
   {
-    fontSize: ".90rem",
+    fontSize: '.90rem',
     fontWeight: 400,
-    MozOsxFontSmoothing: "auto",
-    WebkitFontSmoothing: "auto",
+    MozOsxFontSmoothing: 'auto',
+    WebkitFontSmoothing: 'auto',
   },
 ]);
 
@@ -125,15 +131,15 @@ export const screenReaderOnly = css([
   // https://gomakethings.com/revisting-aria-label-versus-a-visually-hidden-class/#:~:text=In%20the%20posts%2C%20I%20recommended,visually%20shown%20to%20sighted%20users.
   {
     border: 0,
-    clip: "rect(0 0 0 0)",
-    clipPath: "inset(50%)",
-    display: "inline-block", // new - for reading order in macOS VO
-    height: "1px",
-    margin: "-1px",
-    overflow: "hidden",
+    clip: 'rect(0 0 0 0)',
+    clipPath: 'inset(50%)',
+    display: 'inline-block', // new - for reading order in macOS VO
+    height: '1px',
+    margin: '-1px',
+    overflow: 'hidden',
     padding: 0,
-    position: "relative", // different - for reading order in macOS VO
-    width: "1px",
+    position: 'relative', // different - for reading order in macOS VO
+    width: '1px',
   },
 ]);
 

--- a/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
+++ b/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
@@ -111,7 +111,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
-    margin-bottom: 30px;
+    margin: 15px 0 15px 0;
 
     &:last-child {
       margin-bottom: 0;

--- a/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -342,7 +342,7 @@ export function NewVisualizationPickerGrouped(
       {includeHeader && (
         <H5
           additionalStyles={{
-            marginBottom: 10,
+            margin: '5px 0 5px 0',
           }}
         >
           Select a visualization
@@ -351,7 +351,13 @@ export function NewVisualizationPickerGrouped(
       {groupVisualizations(visualizationsOverview).map((vizGroup) => (
         <div className={cx('-GroupedPickerContainer')} key={vizGroup.groupName}>
           <div className={cx('-GroupedPickerEntryHeadline')}>
-            <H6>{vizGroup.groupName}</H6>
+            <H6
+              additionalStyles={{
+                margin: 0,
+              }}
+            >
+              {vizGroup.groupName}
+            </H6>
             <Paragraph styleOverrides={{ margin: '5px 0' }}>
               {vizGroup.groupDescription}
             </Paragraph>

--- a/packages/libs/eda/src/lib/map/analysis/MapVizManagement.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapVizManagement.tsx
@@ -66,8 +66,18 @@ export default function MapVizManagement({
     // picker in addition to some explanatory text.
     return (
       <div className={mapVizManagementClassName('-NewVizPicker')}>
-        <H5>Select a visualization</H5>
-        <Paragraph>
+        <H5
+          additionalStyles={{
+            margin: '0 0 5px 0',
+          }}
+        >
+          Select a visualization
+        </H5>
+        <Paragraph
+          styleOverrides={{
+            margin: '0 0 5px 0',
+          }}
+        >
           Pick a visualization type to get started! If you update your subset,
           your visualizations will update when you reopen them.
         </Paragraph>
@@ -101,7 +111,7 @@ export default function MapVizManagement({
             />
           )}
         </div>
-        <H5 additionalStyles={{ marginBottom: 15, marginLeft: 10 }}>
+        <H5 additionalStyles={{ margin: '0 0 15px 10px' }}>
           Plots ({totalVisualizationCount}):
         </H5>
         <VisualizationsList

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
@@ -58,7 +58,7 @@ export function BarPlotMarkerConfigurationMenu({
     <div>
       <H6
         additionalStyles={{
-          margin: '1em 0.75em',
+          margin: '15px 12px',
         }}
       >
         Configure Bar Plots:

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
@@ -58,8 +58,7 @@ export function BarPlotMarkerConfigurationMenu({
     <div>
       <H6
         additionalStyles={{
-          padding: '10px 25px 10px 25px',
-          textAlign: 'center',
+          margin: '1em 0.75em',
         }}
       >
         Configure Bar Plots:

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/MarkerConfigurationSelector.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/MarkerConfigurationSelector.tsx
@@ -46,7 +46,7 @@ export function MarkerConfigurationSelector({
       <div>
         <H6
           additionalStyles={{
-            margin: '1em 0.75em',
+            margin: '15px 12px',
           }}
         >
           Choose marker type:

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/MarkerConfigurationSelector.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/MarkerConfigurationSelector.tsx
@@ -27,8 +27,7 @@ const buttonStyles: React.CSSProperties = {
   background: 'none',
   border: 'none',
   display: 'flex',
-  justifyContent: 'space-around',
-  padding: '5px 10px',
+  justifyContent: 'space-between',
   width: '100%',
 };
 
@@ -47,8 +46,7 @@ export function MarkerConfigurationSelector({
       <div>
         <H6
           additionalStyles={{
-            padding: '10px 25px 10px 25px',
-            textAlign: 'center',
+            margin: '1em 0.75em',
           }}
         >
           Choose marker type:
@@ -76,6 +74,7 @@ export function MarkerConfigurationSelector({
                       fontFamily: theme?.typography?.paragraphs?.fontFamily,
                       fontSize: 16,
                       fontWeight: isActive ? 'bold' : 'normal',
+                      marginRight: 5,
                     }}
                   >
                     {name}

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
@@ -46,7 +46,7 @@ export function PieMarkerConfigurationMenu({
     <div>
       <H6
         additionalStyles={{
-          margin: '1em 0.75em',
+          margin: '15px 12px',
         }}
       >
         Configure Donuts:

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
@@ -46,8 +46,7 @@ export function PieMarkerConfigurationMenu({
     <div>
       <H6
         additionalStyles={{
-          padding: '10px 25px 10px 25px',
-          textAlign: 'center',
+          margin: '1em 0.75em',
         }}
       >
         Configure Donuts:


### PR DESCRIPTION
Issue: #164 

Running `yarn nx start @veupathdb/eda`:
<img width="733" alt="image" src="https://user-images.githubusercontent.com/24446573/236922012-619de16d-29c2-4056-8ae7-d4355742e0f3.png">

Running `yarn nx start @veupathdb/clinepi-site`:
![image](https://user-images.githubusercontent.com/24446573/236922086-cb671d5d-427f-48f0-a22a-0d34cfc39fad.png)

<img width="1352" alt="Screenshot 2023-05-08 at 4 54 04 PM" src="https://user-images.githubusercontent.com/24446573/236946523-51a5aafb-4f74-437a-bc8e-b87852b90d9f.png">

**After**

Running `yarn nx start @veupathdb/clinepi-site`:

<img width="1352" alt="Screenshot 2023-05-08 at 4 51 01 PM" src="https://user-images.githubusercontent.com/24446573/236946678-cdfd5296-a16d-4a28-a0c4-42b1d08f5ed6.png">
<img width="1352" alt="Screenshot 2023-05-08 at 4 50 51 PM" src="https://user-images.githubusercontent.com/24446573/236946718-4a097065-2fd4-4cea-94f2-106270e26890.png">

