### PR TITLE
Use minmax for varTree column in subsetting UI

### DIFF
--- a/packages/libs/eda/src/lib/workspace/EDAWorkspace.scss
+++ b/packages/libs/eda/src/lib/workspace/EDAWorkspace.scss
@@ -205,7 +205,7 @@
     grid:
       [row1-start] '.             filter-chips tabular-download' auto [row1-end]
       [row2-start] 'variables     filter       filter' 1fr [row2-end]
-      / 20% 1fr auto;
+      / minmax(200px, 20%) 1fr auto;
     gap: 1em 3em;
     padding-top: 1em;
     .Variables {


### PR DESCRIPTION
Variable tree gets squished more aggressively in the map context. Switched the column width to use `minmax` to limit how small the width of the column gets.

Before:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/40f4bac4-e71d-426b-9380-13501e783b8a)

After:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/db8b1227-6a25-445b-bf57-1c2097f15106)