### PR TITLE
Revert map side menu toggle btn size/placement changes

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MapSideNavigation.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapSideNavigation.tsx
@@ -77,13 +77,13 @@ export function MapSideNavigation({
           border: mapNavigationBorder,
           borderLeft: 'none',
           borderRadius: '0px 5px 5px 0px',
-          height: 100,
+          height: 60,
           width: sideMenuExpandButtonWidth,
           // These styles pin the expand/collapse to the right of
           // the lefthand side menu at the nav's vertical center.
           position: 'absolute',
           right: -sideMenuExpandButtonWidth,
-          top: '10%',
+          top: '50%',
           transform: 'translate(0%, -50%)',
           transition: 'all 0.1s ease',
           // These styles make sure that the button's SVG


### PR DESCRIPTION
Resolves https://github.com/VEuPathDB/web-monorepo/issues/167

Relates to changes made in https://github.com/VEuPathDB/web-monorepo/issues/125

Maps created by Google and Bing place the toggle in the center of the side menu and its size is proportionally small wrt its parent container. These changes reflect the "norm" established by those two powerhouses in the map world.

Screenshot of change:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/0206cc74-99c0-41b6-9d1e-6ed61cf3dd9e)