### PR TITLE
Map: saved analyses and downloads

### DIFF
--- a/packages/libs/eda/src/lib/map/MapVEu.scss
+++ b/packages/libs/eda/src/lib/map/MapVEu.scss
@@ -11,9 +11,19 @@
   .MapVEu {
     height: 100%;
 
+    .wdk-RecordContainer {
+      font-size: 0.9em;
+      margin-top: 1em;
+    }
+
     .wdk-RecordSidebarToggle,
     .wdk-RecordSidebar {
       background-color: #eaeaea;
+    }
+
+    .wdk-RecordActions,
+    .wdk-RecordHeading {
+      display: none;
     }
   }
 }

--- a/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
+++ b/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
@@ -44,10 +44,10 @@ export function MapVeuContainer(mapVeuContainerProps: Props) {
   return (
     <Switch>
       <Route
-        path={`${path}/:studyId/:analysisId`}
+        path={[`${path}/:studyId/new`, `${path}/:studyId/:analysisId`]}
         render={(
           routeProps: RouteComponentProps<{
-            analysisId: string;
+            analysisId?: string;
             studyId: string;
           }>
         ) => (

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -92,6 +92,7 @@ import {
 import { BarPlotMarkers, DonutMarkers } from './MarkerConfiguration/icons';
 import { AllAnalyses } from '../../workspace/AllAnalyses';
 import { getStudyId } from '@veupathdb/study-data-access/lib/shared/studies';
+import { isSavedAnalysis } from '../../core/utils/analysis';
 
 enum MapSideNavItemLabels {
   Download = 'Download',
@@ -730,8 +731,12 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
               }}
             >
               <AllAnalyses
-                // studyId={analysisState.analysis?.studyId!}
                 analysisClient={analysisClient}
+                activeAnalysisId={
+                  isSavedAnalysis(analysisState.analysis)
+                    ? analysisState.analysis.analysisId
+                    : undefined
+                }
                 subsettingClient={subsettingClient}
                 studyId={getStudyId(studyRecord)}
                 showLoginForm={showLoginForm}

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -734,7 +734,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                 analysisClient={analysisClient}
                 subsettingClient={subsettingClient}
                 studyId={getStudyId(studyRecord)}
-                showLoginForm={() => {}}
+                showLoginForm={showLoginForm}
               />
             </div>
           );

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -6,6 +6,7 @@ import {
   EntityDiagram,
   PromiseResult,
   useAnalysis,
+  useAnalysisClient,
   useDataClient,
   useDownloadClient,
   useFindEntityAndVariable,
@@ -13,11 +14,12 @@ import {
   useStudyEntities,
   useStudyMetadata,
   useStudyRecord,
+  useSubsettingClient,
 } from '../../core';
 import MapVEuMap from '@veupathdb/components/lib/map/MapVEuMap';
 import { useGeoConfig } from '../../core/hooks/geoConfig';
 import { DocumentationContainer } from '../../core/components/docs/DocumentationContainer';
-import { Download, FilledButton, Filter } from '@veupathdb/coreui';
+import { Download, FilledButton, Filter, H5, Table } from '@veupathdb/coreui';
 import { useEntityCounts } from '../../core/hooks/entityCounts';
 import ShowHideVariableContextProvider from '../../core/utils/show-hide-variable-context';
 import { MapLegend } from './MapLegend';
@@ -88,6 +90,8 @@ import {
   PieMarkerConfigurationMenu,
 } from './MarkerConfiguration';
 import { BarPlotMarkers, DonutMarkers } from './MarkerConfiguration/icons';
+import { AllAnalyses } from '../../workspace/AllAnalyses';
+import { getStudyId } from '@veupathdb/study-data-access/lib/shared/studies';
 
 enum MapSideNavItemLabels {
   Download = 'Download',
@@ -97,6 +101,7 @@ enum MapSideNavItemLabels {
   Plot = 'Plot',
   Share = 'Share',
   StudyDetails = 'View Study Details',
+  MyAnalyses = 'My Analyses',
 }
 
 type SideNavigationItemConfigurationObject = {
@@ -126,7 +131,7 @@ export const defaultAnimation = {
 };
 
 interface Props {
-  analysisId: string;
+  analysisId?: string;
   sharingUrl: string;
   studyId: string;
   siteInformationProps: SiteInformationProps;
@@ -170,6 +175,8 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
   const geoConfigs = useGeoConfig(studyEntities);
   const geoConfig = geoConfigs[0];
   const theme = useUITheme();
+  const analysisClient = useAnalysisClient();
+  const subsettingClient = useSubsettingClient();
 
   const getDefaultVariableId = useGetDefaultVariableIdCallback();
   const selectedVariables = getDefaultVariableId(studyMetadata.rootEntity.id);
@@ -701,6 +708,39 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
         },
       },
       {
+        labelText: MapSideNavItemLabels.MyAnalyses,
+        icon: <Table />,
+        renderSideNavigationPanel: () => {
+          return (
+            <div
+              css={{
+                h1: {
+                  fontSize: '21px',
+                  margin: '25px 0 0 0',
+                  padding: '0 0 1em 0',
+                },
+                '.MesaComponent .DataTable': {
+                  fontSize: 'inherit',
+                },
+              }}
+              style={{
+                padding: '1em',
+                width: '70vw',
+                maxWidth: '1500px',
+              }}
+            >
+              <AllAnalyses
+                // studyId={analysisState.analysis?.studyId!}
+                analysisClient={analysisClient}
+                subsettingClient={subsettingClient}
+                studyId={getStudyId(studyRecord)}
+                showLoginForm={() => {}}
+              />
+            </div>
+          );
+        },
+      },
+      {
         labelText: MapSideNavItemLabels.StudyDetails,
         icon: <InfoOutlined />,
         renderSideNavigationPanel: () => {
@@ -713,6 +753,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                 fontSize: '.95em',
               }}
             >
+              <H5 additionalStyles={{ margin: '25px 0 0 0' }}>Study Details</H5>
               <RecordController
                 recordClass="dataset"
                 primaryKey={studyRecord.id.map((p) => p.value).join('/')}

--- a/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
+++ b/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
@@ -549,7 +549,8 @@ export function AllAnalyses(props: Props) {
             const offerPublicityToggle =
               studyAccessLevel === 'public' ||
               studyAccessLevel === 'protected' ||
-              studyAccessLevel === 'controlled';
+              studyAccessLevel === 'controlled' ||
+              studyAccessLevel === null;
 
             return (
               <div style={{ display: 'flex', justifyContent: 'center' }}>

--- a/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
+++ b/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
@@ -72,6 +72,11 @@ interface Props {
    */
   studyId?: string | null;
   /**
+   * If the analysis with this ID is displayed,
+   * indicate it is "active"
+   */
+  activeAnalysisId?: string;
+  /**
    * Determines if the search term is stored as a query
    * param in the url
    */
@@ -109,6 +114,7 @@ export function AllAnalyses(props: Props) {
     studyId,
     synchronizeWithUrl,
     updateDocumentTitle,
+    activeAnalysisId,
   } = props;
   const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
   const history = useHistory();
@@ -494,6 +500,11 @@ export function AllAnalyses(props: Props) {
                   }}
                   maxLength={ANALYSIS_NAME_MAX_LENGTH}
                 />
+                {data.row.analysis.analysisId === activeAnalysisId ? (
+                  <>
+                    &nbsp;&nbsp;<em>(currently viewing)</em>
+                  </>
+                ) : null}
                 {data.row.analysis.provenance != null && (
                   <>
                     <br />

--- a/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
+++ b/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { orderBy } from 'lodash';
 import Path from 'path';
 import { Link, useHistory, useLocation } from 'react-router-dom';
@@ -67,6 +67,20 @@ interface Props {
   subsettingClient: SubsettingClient;
   exampleAnalysesAuthor?: number;
   /**
+   * When provided, the table is filtered to the study,
+   * and the study column is not displayed.
+   */
+  studyId?: string | null;
+  /**
+   * Determines if the search term is stored as a query
+   * param in the url
+   */
+  synchronizeWithUrl?: boolean;
+  /**
+   * Determines if the document title is updated
+   */
+  updateDocumentTitle?: boolean;
+  /**
    * A callback to open a login form.
    * This is passed down through several component layers. */
   showLoginForm: () => void;
@@ -88,29 +102,37 @@ const UNKNOWN_DATASET_NAME = 'Unknown study';
 const WDK_STUDY_RECORD_ATTRIBUTES = ['study_access'];
 
 export function AllAnalyses(props: Props) {
-  const { analysisClient, exampleAnalysesAuthor, showLoginForm } = props;
+  const {
+    analysisClient,
+    exampleAnalysesAuthor,
+    showLoginForm,
+    studyId,
+    synchronizeWithUrl,
+    updateDocumentTitle,
+  } = props;
   const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
   const history = useHistory();
   const location = useLocation();
   const classes = useStyles();
 
-  const searchText = useMemo(() => {
+  const searchTextQueryParam = useMemo(() => {
+    if (!synchronizeWithUrl) return '';
     const queryParams = new URLSearchParams(location.search);
     const searchParam = queryParams.get('s') ?? '';
     return stripHTML(searchParam); // matches stripHTML(dataset.displayName) below
-  }, [location.search]);
+  }, [location.search, synchronizeWithUrl]);
+
+  const [searchText, setSearchText] = useState(searchTextQueryParam);
 
   const debouncedSearchText = useDebounce(searchText, 250);
 
-  const setSearchText = useCallback(
-    (newSearchText: string) => {
-      const queryParams = newSearchText
-        ? '?s=' + encodeURIComponent(newSearchText)
-        : '';
-      history.replace(location.pathname + queryParams);
-    },
-    [history, location.pathname]
-  );
+  useEffect(() => {
+    if (!synchronizeWithUrl) return;
+    const queryParams = searchText
+      ? '?s=' + encodeURIComponent(searchText)
+      : '';
+    history.replace(location.pathname + queryParams);
+  }, [history, location.pathname, searchText, synchronizeWithUrl]);
 
   const onFilterFieldChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -143,13 +165,8 @@ export function AllAnalyses(props: Props) {
 
   const datasets = useWdkStudyRecords(WDK_STUDY_RECORD_ATTRIBUTES);
 
-  const {
-    analyses,
-    deleteAnalyses,
-    updateAnalysis,
-    loading,
-    error,
-  } = useAnalysisList(analysisClient);
+  const { analyses, deleteAnalyses, updateAnalysis, loading, error } =
+    useAnalysisList(analysisClient);
 
   const analysesAndDatasets: AnalysisAndDataset[] | undefined = useMemo(
     () =>
@@ -199,11 +216,15 @@ export function AllAnalyses(props: Props) {
   const searchableDatasetColumns = useMemo(() => ['displayName'] as const, []);
 
   const filteredAnalysesAndDatasets = useMemo(() => {
-    if (!debouncedSearchText) return analysesAndDatasets;
+    if (!debouncedSearchText && !studyId) return analysesAndDatasets;
     const lowerSearchText = debouncedSearchText.toLowerCase();
 
-    return analysesAndDatasets?.filter(
-      ({ analysis, dataset }) =>
+    return analysesAndDatasets?.filter(({ analysis, dataset }) => {
+      const matchesStudyId =
+        !studyId || dataset?.attributes.dataset_id === studyId;
+      if (!matchesStudyId) return false;
+      if (!debouncedSearchText) return true;
+      return (
         searchableAnalysisColumns.some((columnKey) =>
           analysis[columnKey]?.toLowerCase().includes(lowerSearchText)
         ) ||
@@ -212,12 +233,14 @@ export function AllAnalyses(props: Props) {
         ) ||
         (dataset == null &&
           UNKNOWN_DATASET_NAME.toLowerCase().includes(lowerSearchText))
-    );
+      );
+    });
   }, [
     searchableAnalysisColumns,
     searchableDatasetColumns,
     debouncedSearchText,
     analysesAndDatasets,
+    studyId,
   ]);
 
   const removeUnpinned = useCallback(() => {
@@ -229,9 +252,8 @@ export function AllAnalyses(props: Props) {
   }, [filteredAnalysesAndDatasets, deleteAnalyses, isPinnedAnalysis]);
 
   const [sharingModalVisible, setSharingModalVisible] = useState(false);
-  const [selectedAnalysisId, setSelectedAnalysisId] = useState<
-    string | undefined
-  >(undefined);
+  const [selectedAnalysisId, setSelectedAnalysisId] =
+    useState<string | undefined>(undefined);
 
   const tableState = useMemo(
     () => ({
@@ -422,16 +444,20 @@ export function AllAnalyses(props: Props) {
             </Tooltip>
           ),
         },
-        {
-          key: 'study',
-          name: 'Study',
-          sortable: true,
-          renderCell: (data: { row: AnalysisAndDataset }) => {
-            const { dataset } = data.row;
-            if (dataset == null) return UNKNOWN_DATASET_NAME;
-            return safeHtml(dataset.displayNameHTML);
-          },
-        },
+        ...(studyId
+          ? []
+          : [
+              {
+                key: 'study',
+                name: 'Study',
+                sortable: true,
+                renderCell: (data: { row: AnalysisAndDataset }) => {
+                  const { dataset } = data.row;
+                  if (dataset == null) return UNKNOWN_DATASET_NAME;
+                  return safeHtml(dataset.displayNameHTML);
+                },
+              },
+            ]),
         {
           key: 'name',
           name: 'Analysis',
@@ -597,10 +623,11 @@ export function AllAnalyses(props: Props) {
       removePinnedAnalysis,
       exampleAnalysesAuthor,
       user,
+      studyId,
     ]
   );
 
-  useSetDocumentTitle('My Analyses');
+  useSetDocumentTitle(updateDocumentTitle ? 'My Analyses' : document.title);
 
   return (
     <div className={classes.root}>
@@ -618,7 +645,7 @@ export function AllAnalyses(props: Props) {
       />
 
       <h1>My Analyses</h1>
-      {(loading || datasets == null) && (
+      {(loading || datasets == null || analyses == null || user == null) && (
         <Loading style={{ position: 'absolute', left: '50%', top: '1em' }} />
       )}
       {error && <ContentError>{error}</ContentError>}
@@ -663,9 +690,7 @@ export function AllAnalyses(props: Props) {
             </span>
           </div>
         </Mesa.Mesa>
-      ) : (
-        <Loading />
-      )}
+      ) : null}
     </div>
   );
 }

--- a/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
+++ b/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
@@ -474,11 +474,15 @@ export function AllAnalyses(props: Props) {
                   value={displayName}
                   displayValue={(value) => (
                     <Link
-                      to={Path.join(
-                        history.location.pathname,
-                        data.row.analysis.studyId,
-                        data.row.analysis.analysisId
-                      )}
+                      to={
+                        studyId
+                          ? data.row.analysis.analysisId
+                          : Path.join(
+                              history.location.pathname,
+                              data.row.analysis.studyId,
+                              data.row.analysis.analysisId
+                            )
+                      }
                     >
                       {value}
                     </Link>

--- a/packages/libs/eda/src/lib/workspace/DownloadTab/index.tsx
+++ b/packages/libs/eda/src/lib/workspace/DownloadTab/index.tsx
@@ -103,7 +103,7 @@ export default function DownloadTab({
     const studyAccess =
       typeof studyRecord.attributes['study_access'] === 'string'
         ? studyRecord.attributes['study_access']
-        : '<status not found>';
+        : 'Public';
     const hasPermission = permission.loading
       ? undefined
       : permission.permissions.perDataset[studyRecord.id[0].value]
@@ -129,14 +129,7 @@ export default function DownloadTab({
         )}
       </span>
     );
-  }, [
-    user,
-    permission,
-    studyRecord,
-    handleClick,
-    datasetId,
-    projectDisplayName,
-  ]);
+  }, [user, permission, studyRecord, handleClick]);
 
   /**
    * Ok, this is confusing, but there are two places where we need
@@ -167,9 +160,14 @@ export default function DownloadTab({
       return;
     }
 
-    downloadClient.getStudyReleases(studyMetadata.id).then((result) => {
-      setDownloadServiceStudyReleases(result);
-    });
+    downloadClient.getStudyReleases(studyMetadata.id).then(
+      (result) => {
+        setDownloadServiceStudyReleases(result);
+      },
+      (error) => {
+        console.error('Error fetching download details of study.', error);
+      }
+    );
   }, [shouldFetchStudyReleases, downloadClient, studyMetadata]);
 
   /**
@@ -243,13 +241,13 @@ export default function DownloadTab({
             release={mergedReleaseData[0]}
           />
         )}
-        {mergedReleaseData[0] && (
+        {
           <MySubset
             datasetId={datasetId}
             entities={enhancedEntityData}
             analysisState={analysisState}
           />
-        )}
+        }
         {mergedReleaseData.map((release, index) =>
           index === 0 ? (
             <CurrentRelease

--- a/packages/libs/eda/src/lib/workspace/WorkspaceRouter.tsx
+++ b/packages/libs/eda/src/lib/workspace/WorkspaceRouter.tsx
@@ -164,6 +164,8 @@ export function WorkspaceRouter({
                 subsettingClient={subsettingClient}
                 exampleAnalysesAuthor={exampleAnalysesAuthor}
                 showLoginForm={showLoginForm}
+                synchronizeWithUrl
+                updateDocumentTitle
               />
             )}
           />

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -539,10 +539,10 @@ const useHeaderMenuItems = (
         },
         {
           key: 'mapveu-alpha',
-          display: 'MapVEu Alpha',
+          display: 'Map of Popbio Data [Alpha]',
           tooltip: 'Population Biology map',
           type: 'reactRoute',
-          url: '/maps',
+          url: '/maps/DS_480c976ef9/new',
           metadata: {
             include: useEda ? [VectorBase] : [],
           },

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -60,6 +60,8 @@ import { makeVpdbClassNameHelper } from './Utils';
 
 import './VEuPathDBHomePage.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
+import { Warning } from '@veupathdb/coreui';
 
 const vpdbCx = makeVpdbClassNameHelper('');
 
@@ -348,6 +350,45 @@ const useHeaderMenuItems = (
   const alphabetizedSearchTree = useAlphabetizedSearchTree(searchTree);
   const communitySite = useCommunitySiteRootUrl();
 
+  const mapMenuItems = useWdkService(async (wdkService): Promise<
+    HeaderMenuItem[]
+  > => {
+    try {
+      const anwser = await wdkService.getAnswerJson(
+        {
+          searchName: 'AllDatasets',
+          searchConfig: {
+            parameters: {},
+          },
+        },
+        {
+          attributes: ['eda_study_id'],
+        }
+      );
+      return anwser.records
+        .filter((record) => record.attributes.eda_study_id != null)
+        .map((record) => ({
+          key: `map-${record.id[0].value}`,
+          display: record.displayName,
+          type: 'reactRoute',
+          url: `/maps/${record.id[0].value}/new`,
+        }));
+    } catch (error) {
+      console.error(error);
+      return [
+        {
+          key: 'maps-error',
+          display: (
+            <>
+              <Warning /> Could not load map data
+            </>
+          ),
+          type: 'custom',
+        },
+      ];
+    }
+  });
+
   // type: reactRoute, webAppRoute, externalLink, subMenu, custom
   const fullMenuItemEntries: HeaderMenuItemEntry[] = [
     {
@@ -538,16 +579,6 @@ const useHeaderMenuItems = (
           },
         },
         {
-          key: 'mapveu-alpha',
-          display: 'Map of Popbio Data [Alpha]',
-          tooltip: 'Population Biology map',
-          type: 'reactRoute',
-          url: '/maps/DS_480c976ef9/new',
-          metadata: {
-            include: useEda ? [VectorBase] : [],
-          },
-        },
-        {
           key: 'mapveu',
           display: 'MapVEu',
           tooltip: 'Population Biology map',
@@ -557,6 +588,19 @@ const useHeaderMenuItems = (
           metadata: {
             include: [EuPathDB, UniDB],
           },
+        },
+        {
+          key: 'maps-alpha',
+          display: (
+            <>
+              Maps <img alt="BETA" src={betaImage} />
+            </>
+          ),
+          type: 'subMenu',
+          metadata: {
+            include: useEda ? [VectorBase] : [],
+          },
+          items: mapMenuItems ?? [],
         },
         {
           key: 'pubcrawler',


### PR DESCRIPTION
closes #89
closes #140
closes #171
closes #173

This PR addresses several issues. Sorry about that. I can break it up into multiple PRs, if needed.

Of primary concern is the newly added **My Analyses** entry:
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/ed259a21-c5fe-403b-b167-af9dd57d0b5c)

### Open questions

- [ ] Are we okay with the "My Analyses" verbiage?
- [ ] Do we need to offer some explanation of what that table is, why it's useful?
- [x] We are currently displaying the active analysis in the table. Should this be highlighted somehow, or filtered out?
- [ ] I haven't added **New Analysis** button, yet. I was wondering if that should be in the header, along with "make a copy" and "delete"?
- [ ] Currently, changes to marker configuration will not cause an unsaved analysis to become saved. Is this okay?

### Remaining TODOs

- [ ] Synchronize analysis list and active analysis. This might involve moving the cache to the AnalysisClient class. It might also involve adding a `subscribe()` method. This will keep changes to either the analysis or the list of analyses up-to-date.
- [ ] There are some issues with changing analysis in the table. The layout doesn't appear to be changing, etc. It might involve clearing app state if the analysis id changes. Or maybe use analysis id as the key for the MapAnalysisImpl component.
- [ ] Need to add loading indicator to the download panel, when counts are updating.
- [ ] Need to have a UX discussion about where to place analysis actions (copy, delete, etc)
- [ ] Close MyAnalyses section when a new one is selected
- [ ] This needs addressing `Showing 2 of 161 analyses` (the user can't get to the other 159)