### PR TITLE
Adjust scroll behavior and verbiage in map's filtering UI

### DIFF
--- a/packages/libs/eda/src/lib/core/components/variableTrees/VariableList.tsx
+++ b/packages/libs/eda/src/lib/core/components/variableTrees/VariableList.tsx
@@ -198,6 +198,9 @@ interface VariableListProps {
   startExpanded?: boolean;
   asDropdown?: boolean;
   dropdownLabel?: string;
+  /**
+   * used to disable FieldNode's scrollIntoView property in map scope
+   */
   scope?: VariableScope;
   clearSelectionButton?: ReactNode;
 }
@@ -436,7 +439,12 @@ export default function VariableList({
           isStarred={starredVariableTermsSet.has(fieldTerm)}
           starredVariablesLoading={starredVariablesLoading}
           onClickStar={() => toggleStarredVariable({ entityId, variableId })}
-          scrollIntoView
+          /**
+           * map UI has limited space, so let's disable scrollIntoView
+           * in the map context so that we don't inadvertantly hide
+           * contextual info like the entity diagram
+           */
+          scrollIntoView={scope !== 'map'}
           asDropdown={asDropdown}
         />
       );

--- a/packages/libs/eda/src/lib/core/components/variableTrees/VariableTree.tsx
+++ b/packages/libs/eda/src/lib/core/components/variableTrees/VariableTree.tsx
@@ -97,6 +97,7 @@ export default function VariableTree({
       clearSelectionButton={
         showClearSelectionButton === false ? null : clearSelectionButton
       }
+      scope={scope}
     />
   );
 }

--- a/packages/libs/eda/src/lib/core/types/study.ts
+++ b/packages/libs/eda/src/lib/core/types/study.ts
@@ -91,6 +91,7 @@ export type VariableScope = t.TypeOf<typeof VariableScope>;
 export const VariableScope = t.keyof({
   download: null,
   variableTree: null,
+  map: null,
 });
 
 export const VariableTreeNode_Base = t.intersection([

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -599,7 +599,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                 analysisState={analysisState}
                 totalCounts={totalCounts.value}
                 filteredCounts={filteredCounts.value}
-                // gets passed to variable tree in order to disaable scrollIntoView
+                // gets passed to variable tree in order to disable scrollIntoView
                 scope="map"
               />
             </div>

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -599,6 +599,8 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                 analysisState={analysisState}
                 totalCounts={totalCounts.value}
                 filteredCounts={filteredCounts.value}
+                // gets passed to variable tree in order to disaable scrollIntoView
+                scope="map"
               />
             </div>
           );

--- a/packages/libs/eda/src/lib/map/analysis/MapHeader.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapHeader.tsx
@@ -118,7 +118,7 @@ export function MapHeader({
                   totalEntityInSubsetCount > 1
                 )} in the subset.`}
               >
-                <td>Subset</td>
+                <td>Filtered</td>
                 <td>{format(totalEntityInSubsetCount)}</td>
               </tr>
               <tr

--- a/packages/libs/eda/src/lib/workspace/Subsetting/index.tsx
+++ b/packages/libs/eda/src/lib/workspace/Subsetting/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Redirect } from 'react-router';
 
-import { MultiFilterVariable, Variable } from '../../core';
+import { MultiFilterVariable, Variable, VariableScope } from '../../core';
 
 // Components
 import { VariableDetails } from '../Variable';
@@ -32,6 +32,10 @@ interface SubsettingProps {
   totalCounts: EntityCounts | undefined;
   filteredCounts: EntityCounts | undefined;
   variableLinkConfig: VariableLinkConfig;
+  /**
+   * used to disable FieldNode's scrollIntoView property in map scope
+   */
+  scope?: VariableScope;
 }
 
 /** Allow user to filter study data based on the value(s) of any available variable. */
@@ -42,6 +46,7 @@ export default function Subsetting({
   totalCounts,
   filteredCounts,
   variableLinkConfig,
+  scope = 'variableTree',
 }: SubsettingProps) {
   // Obtain all entities and associated variables.
   const entities = useStudyEntities();
@@ -82,7 +87,7 @@ export default function Subsetting({
     <div className={cx('-Subsetting')}>
       <div className="Variables">
         <VariableTree
-          scope="variableTree"
+          scope={scope}
           entityId={entity.id}
           starredVariables={starredVariables}
           toggleStarredVariable={toggleStarredVariable}


### PR DESCRIPTION
Addresses the 2nd and 3rd points of #169 
<br>
> (2nd point): the entity diagram is scrolled offscreen at the top.

**Solution**: The `FieldNode` component in the variable tree has some `scrollIntoView` logic. I disabled this logic in the map context.
<br><br>
> (3rd point): We use the word Filter to describe the filters, but Subset in heading. We need to either:
    - use just one, always
    - or add a bold title in the Filter display, indicating that when you filter, you are creating a subset


**Solution**: In the map header, the word 'Subset' has been replaced with 'Filtered' in hopes to better connect that value with the filter panel.

![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/465927b7-be77-4d12-a140-976911346963)