### PR TITLE
Make the SAM legend filter-aware

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -305,7 +305,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
       return visualization.withOptions({
         hideFacetInputs: true,
         layoutComponent: FloatingLayout,
-        getOverlayVariable: (_) => selectedVariables,
+        getOverlayVariable: (_) => activeMarkerConfiguration.selectedVariable,
         getOverlayVariableHelp: () =>
           'The overlay variable can be selected via the top-right panel.',
       });
@@ -326,7 +326,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
         boxplot: vizWithOptions(boxplotVisualization),
       },
     };
-  }, [selectedVariables]);
+  }, [activeMarkerConfiguration.selectedVariable]);
 
   const computation = analysisState.analysis?.descriptor.computations[0];
 

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -172,7 +172,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
   const theme = useUITheme();
 
   const getDefaultVariableId = useGetDefaultVariableIdCallback();
-  const selectedVariables = getDefaultVariableId(studyMetadata.rootEntity.id);
+  const defaultVariable = getDefaultVariableId(studyMetadata.rootEntity.id);
 
   const { activeMarkerConfigurationType = 'pie', markerConfigurations = [] } =
     appState;
@@ -181,15 +181,15 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
     return [
       {
         type: 'pie',
-        selectedVariable: selectedVariables,
+        selectedVariable: defaultVariable,
       },
       {
         type: 'barplot',
         selectedPlotMode: 'count',
-        selectedVariable: selectedVariables,
+        selectedVariable: defaultVariable,
       },
     ];
-  }, [selectedVariables]);
+  }, [defaultVariable]);
 
   useEffect(
     function generateDefaultMarkerConfigurationsIfNeeded() {
@@ -211,7 +211,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
 
   const findEntityAndVariable = useFindEntityAndVariable();
   const { variable: overlayVariable } =
-    findEntityAndVariable(selectedVariables) ?? {};
+    findEntityAndVariable(activeMarkerConfiguration.selectedVariable) ?? {};
 
   const filters = analysisState.analysis?.descriptor.subset.descriptor;
 

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
@@ -173,13 +173,6 @@ export function useStandaloneMapMarkers(
     overlayConfig?: OverlayConfig;
   };
 
-  // The categorical overlay config changes when the vocabulary changes,
-  // while the continuous overlay is filter-sensitive.
-  // But only one or the other is a dependency for the markerVariableBundlePromise
-  // so we combine them and "demultiplex" it inside the callback using type guards
-  const vocabularyOrFilters: string[] | Filter[] | undefined =
-    overlayVariableAndEntity?.variable.vocabulary ?? filters;
-
   const markerVariableBundlePromise = usePromise<
     MarkerVariableBundle | undefined
   >(
@@ -189,19 +182,16 @@ export function useStandaloneMapMarkers(
         overlayVariable != null &&
         outputEntity != null
       ) {
-        if (isNonEmptyStringArray(vocabularyOrFilters)) {
+        const vocabulary = overlayVariableAndEntity.variable.vocabulary;
+        if (vocabulary?.length) {
           // categorical
-          // If the variable has "too many" values, get the top 7 from the distribution service
-          const vocabulary = vocabularyOrFilters;
-          const overlayValues =
-            vocabulary.length <= ColorPaletteDefault.length
-              ? vocabulary
-              : await getMostFrequentValues({
-                  studyId: studyId,
-                  ...overlayVariable,
-                  numValues: ColorPaletteDefault.length - 1,
-                  subsettingClient,
-                });
+          const overlayValues = await getMostFrequentValues({
+            ...overlayVariable,
+            studyId,
+            vocabulary,
+            subsettingClient,
+            filters,
+          });
 
           return {
             overlayConfig: {
@@ -211,17 +201,13 @@ export function useStandaloneMapMarkers(
             },
             outputEntityId: outputEntity.id,
           };
-        } else if (
-          isFilterArray(vocabularyOrFilters) ||
-          vocabularyOrFilters == null
-        ) {
+        } else {
           // continuous
-          const filters = vocabularyOrFilters;
           const overlayBins = await getBinRanges({
-            studyId,
-            filters: filters ?? [],
             ...overlayVariable,
+            studyId,
             dataClient,
+            filters: filters ?? [],
           });
 
           return {
@@ -244,10 +230,10 @@ export function useStandaloneMapMarkers(
       overlayVariableAndEntity,
       overlayVariable,
       outputEntity,
-      vocabularyOrFilters,
       studyId,
       subsettingClient,
       dataClient,
+      filters,
     ])
   );
 
@@ -518,8 +504,9 @@ type GetMostFrequentValuesProps = {
   studyId: string;
   variableId: string;
   entityId: string;
-  numValues: number; // the N of the top N most frequent values
+  vocabulary: string[];
   subsettingClient: SubsettingClient;
+  filters?: Filter[];
 };
 
 // get the most frequent values for the entire dataset, no filters at all
@@ -528,8 +515,9 @@ async function getMostFrequentValues({
   studyId,
   variableId,
   entityId,
-  numValues,
+  vocabulary,
   subsettingClient,
+  filters = [],
 }: GetMostFrequentValuesProps): Promise<string[]> {
   const distributionResponse = await subsettingClient.getDistribution(
     studyId,
@@ -537,14 +525,14 @@ async function getMostFrequentValues({
     variableId,
     {
       valueSpec: 'count',
-      filters: [],
+      filters,
     }
   );
 
   const sortedValues = distributionResponse.histogram
     .sort((bin1, bin2) => bin2.value - bin1.value)
     .map((bin) => bin.binLabel);
-  if (sortedValues.length < numValues) {
+  if (sortedValues.length < vocabulary.length) {
     // console logging message because the throw didn't seem to bring up the usual dialogue on the screen
     // TO DO: understand/fix this
     const message =
@@ -552,7 +540,13 @@ async function getMostFrequentValues({
     console.log({ message, sortedValues });
     throw new Error(message);
   }
-  return [...sortedValues.slice(0, numValues), UNSELECTED_TOKEN];
+  if (sortedValues.length > ColorPaletteDefault.length) {
+    return [
+      ...sortedValues.slice(0, ColorPaletteDefault.length - 1),
+      UNSELECTED_TOKEN,
+    ];
+  }
+  return sortedValues;
 }
 
 type GetBinRangesProps = {
@@ -589,18 +583,4 @@ async function getBinRanges({
 
 function fixLabelForOtherValues(input: string): string {
   return input === UNSELECTED_TOKEN ? UNSELECTED_DISPLAY_TEXT : input;
-}
-
-function isNonEmptyStringArray(
-  value: unknown[] | undefined
-): value is string[] {
-  return (
-    value != null &&
-    value.length > 0 &&
-    value.every((item) => typeof item === 'string')
-  );
-}
-
-function isFilterArray(value: unknown[] | undefined): value is Filter[] {
-  return value != null && value.every((item) => Filter.is(item));
 }

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
@@ -188,7 +188,6 @@ export function useStandaloneMapMarkers(
           const overlayValues = await getMostFrequentValues({
             ...overlayVariable,
             studyId,
-            vocabulary,
             subsettingClient,
             filters,
           });
@@ -504,7 +503,6 @@ type GetMostFrequentValuesProps = {
   studyId: string;
   variableId: string;
   entityId: string;
-  vocabulary: string[];
   subsettingClient: SubsettingClient;
   filters?: Filter[];
 };
@@ -515,7 +513,6 @@ async function getMostFrequentValues({
   studyId,
   variableId,
   entityId,
-  vocabulary,
   subsettingClient,
   filters = [],
 }: GetMostFrequentValuesProps): Promise<string[]> {
@@ -532,14 +529,6 @@ async function getMostFrequentValues({
   const sortedValues = distributionResponse.histogram
     .sort((bin1, bin2) => bin2.value - bin1.value)
     .map((bin) => bin.binLabel);
-  if (sortedValues.length < vocabulary.length) {
-    // console logging message because the throw didn't seem to bring up the usual dialogue on the screen
-    // TO DO: understand/fix this
-    const message =
-      'standaloneMapMarkers: getMostFrequentValues was called for a low-cardinality variable';
-    console.log({ message, sortedValues });
-    throw new Error(message);
-  }
   if (sortedValues.length > ColorPaletteDefault.length) {
     return [
       ...sortedValues.slice(0, ColorPaletteDefault.length - 1),


### PR DESCRIPTION
### Description

This PR makes the legend in the standalone map (SAM) "filter-aware".

Previously, there was some logic to use the variable's vocabulary directly, with no ordering, if its cardinality was smaller than the color palette. Otherwise, the top 7 values of the _entire study_ was used for the legend.

In this PR, that logic has been replaced with always using the top values of the _subset_. If the number of values is larger than the color palette, then an "other" value is included; otherwise, all of the values are used without the "other" value.

In the function `getMostFrequentValues`, I'm passing in `vocabulary`, but this is only used for the "low-cardinality" check. I'm not entirely sure we need that, anymore. @bobular can you comment on the utility of this check, especially given the changes in the PR? Thanks in advance.