### PR TITLE
209: prevent interactions with filter from re-rendering the map or exploding the application

### DIFF
--- a/packages/libs/components/src/map/DonutMarker.tsx
+++ b/packages/libs/components/src/map/DonutMarker.tsx
@@ -237,7 +237,7 @@ function donutMarkerSVGIcon(props: DonutMarkerStandaloneProps): {
         .map((o) => o.value)
         .reduce((a, c) => {
           return a + c;
-        });
+        }, 0);
 
   // for display, convert large value with k (e.g., 12345 -> 12k): return original value if less than a criterion
   const sumLabel = props.markerLabel ?? String(fullPieValue);

--- a/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
@@ -277,12 +277,13 @@ export function HistogramFilter(props: Props) {
   const updateUIState = useCallback(
     (newUiState: Partial<UIState>) => {
       // if (uiState.binWidth === newUiState.binWidth) return;
-      analysisState.setVariableUISettings({
+      analysisState.setVariableUISettings((currentState) => ({
+        ...currentState,
         [uiStateKey]: {
           ...uiState,
           ...newUiState,
         },
-      });
+      }));
     },
     [analysisState, uiStateKey, uiState]
   );


### PR DESCRIPTION
Resolves #209.

**Before**:

# Screencast of the map unmounting. ♻️ 
https://github.com/VEuPathDB/web-monorepo/assets/24446573/b71bcaaa-c972-4ac5-b019-54a32ee0128f

# Screencast of the map exploding from a `TypeError` 💥 .
https://github.com/VEuPathDB/web-monorepo/assets/24446573/f84ebb3b-c470-4862-a24f-40cbab958ecc

☝ Here's the stack trace:
```
Reduce of empty array with no initial value
TypeError: Reduce of empty array with no initial value
```

Root cause: we're attempting to `reduce` an empty array without providing an initial value. If `props.data` is an empty array, calling `reduce` on it without an initial value raises this error. The array is empty only very rarely. Perhaps only when the user's thrashing around inputs like a punk. 👊 

Pictures say more than words. Here's the problem:
![Image](https://github.com/VEuPathDB/web-monorepo/assets/24446573/fe4a05de-9253-49a4-af53-3c20a8b5a622)




