### PR TITLE
Fix header issue in eda subset download table preview

### DIFF
--- a/packages/libs/coreui/src/components/grids/DataGrid/HeaderCell.tsx
+++ b/packages/libs/coreui/src/components/grids/DataGrid/HeaderCell.tsx
@@ -64,11 +64,14 @@ export default function HeaderCell({
   return (
     <th
       {...headerGroup.getHeaderProps()}
-      {...(sortable && headerGroup.getSortByToggleProps({
-        title: 'Click to toggle sorting and Shift-Click to multi-sort'
-      }))}
+      {...(sortable &&
+        headerGroup.getSortByToggleProps({
+          title: 'Click to toggle sorting and Shift-Click to multi-sort',
+        }))}
       css={{
-        padding: 0, verticalAlign: 'bottom', height: '100%', ...borderCSSOverrides
+        padding: 0,
+        verticalAlign: 'bottom',
+        ...borderCSSOverrides,
       }}
     >
       <div

--- a/packages/libs/eda/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
+++ b/packages/libs/eda/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
@@ -435,7 +435,6 @@ export default function SubsetDownloadModal({
               position: 'relative',
               flex: '0 1 auto',
               minHeight: 0,
-              '.css-1nxo5ei-HeaderCell': { height: 'auto' },
             }}
             className="DataGrid-Wrapper"
             ref={dataGridWrapperRef}
@@ -449,7 +448,6 @@ export default function SubsetDownloadModal({
                 headerCells: {
                   textTransform: 'none',
                   position: 'relative',
-                  height: '100%',
                 },
                 table: {
                   width: '100%',
@@ -750,10 +748,8 @@ export default function SubsetDownloadModal({
     }
   };
 
-  const {
-    observe: observeModalHeader,
-    width: modalHeaderWidth,
-  } = useDimensions();
+  const { observe: observeModalHeader, width: modalHeaderWidth } =
+    useDimensions();
 
   // ~18px (round to 20px) per character for medium title size
   const maxStudyNameLength = Math.floor(modalHeaderWidth / 20);

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -600,7 +600,13 @@ const useHeaderMenuItems = (
           metadata: {
             include: useEda ? [VectorBase] : [],
           },
-          items: mapMenuItems ?? [],
+          items: mapMenuItems ?? [
+            {
+              key: 'maps-loading',
+              type: 'custom',
+              display: <Loading radius={4} />,
+            },
+          ],
         },
         {
           key: 'pubcrawler',


### PR DESCRIPTION
### Description

Use "height: auto" as default for table header and remove css targeting generated classname. Note that this issue is only happening on feature/qa/prod sites.

ETA: I also added a loading indicator in the site menu entry for the maps.

### Screenshots

**Before**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/e6afb466-ad04-477f-bb17-6fd50215575a)

**After**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/244f529e-c5f7-4f68-8d1a-9876917d6561)
