### PR TITLE
Fix ininite loop on genomics sites

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -352,45 +352,46 @@ const useHeaderMenuItems = (
 
   const showInteractiveMaps = Boolean(useEda && projectId === 'VectorBase');
 
-  const mapMenuItems = useWdkService(async (wdkService): Promise<
-    HeaderMenuItem[]
-  > => {
-    if (!showInteractiveMaps) return [];
-    try {
-      const anwser = await wdkService.getAnswerJson(
-        {
-          searchName: 'AllDatasets',
-          searchConfig: {
-            parameters: {},
+  const mapMenuItems = useWdkService(
+    async (wdkService): Promise<HeaderMenuItem[]> => {
+      if (!showInteractiveMaps) return [];
+      try {
+        const anwser = await wdkService.getAnswerJson(
+          {
+            searchName: 'AllDatasets',
+            searchConfig: {
+              parameters: {},
+            },
           },
-        },
-        {
-          attributes: ['eda_study_id'],
-        }
-      );
-      return anwser.records
-        .filter((record) => record.attributes.eda_study_id != null)
-        .map((record) => ({
-          key: `map-${record.id[0].value}`,
-          display: record.displayName,
-          type: 'reactRoute',
-          url: `/maps/${record.id[0].value}/new`,
-        }));
-    } catch (error) {
-      console.error(error);
-      return [
-        {
-          key: 'maps-error',
-          display: (
-            <>
-              <Warning /> Could not load map data
-            </>
-          ),
-          type: 'custom',
-        },
-      ];
-    }
-  });
+          {
+            attributes: ['eda_study_id'],
+          }
+        );
+        return anwser.records
+          .filter((record) => record.attributes.eda_study_id != null)
+          .map((record) => ({
+            key: `map-${record.id[0].value}`,
+            display: record.displayName,
+            type: 'reactRoute',
+            url: `/maps/${record.id[0].value}/new`,
+          }));
+      } catch (error) {
+        console.error(error);
+        return [
+          {
+            key: 'maps-error',
+            display: (
+              <>
+                <Warning /> Could not load map data
+              </>
+            ),
+            type: 'custom',
+          },
+        ];
+      }
+    },
+    [showInteractiveMaps]
+  );
 
   // type: reactRoute, webAppRoute, externalLink, subMenu, custom
   const fullMenuItemEntries: HeaderMenuItemEntry[] = [


### PR DESCRIPTION
I forgot that `useWdkService` has a signature similar to `useEffect`, and not including an array of dependencies causes it to run on every render. This was causing an infinite loop on genomics sites. This PR addresses that.