### PR TITLE
Remove hardcoded apps filtering in SAM and only display apps with plugins

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
@@ -54,8 +54,9 @@ export function StartPage(props: Props) {
           }}
         >
           {/* orderBy renders available apps ahead of those in development */}
-          {orderBy(apps, [(app) => (plugins[app.name] ? 1 : 0)], ['desc']).map(
-            (app) => (
+          {apps
+            .filter((app) => plugins[app.name] != null)
+            .map((app) => (
               <div
                 style={{
                   display: 'grid',
@@ -224,8 +225,7 @@ export function StartPage(props: Props) {
                   })}
                 </div>
               </div>
-            )
-          )}
+            ))}
         </div>
       </div>
     )

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -336,7 +336,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
   const appsPromiseState = usePromise(
     useCallback(async () => {
       const { apps } = await dataClient.getApps();
-      return apps.filter((app) => app.name.startsWith('standalone-map-')); // TO DO: remove this temporary hack
+      return apps; // return all apps; new viz picker will only show those with client plugins defined
     }, [dataClient])
   );
 


### PR DESCRIPTION
Note merge target is `sam-wire-floaters`

Partly addresses https://github.com/VEuPathDB/web-monorepo/issues/161

Removes a hardcoded app filter from MapAnalysis and only shows apps in `StartPage` (SAM+Mbio) that have client plugins defined.

Does not address what to do with the `projects` prop in the `apps` response.

At some point after we have removed the "single app mode" we will want to be able to configure different flavours of EDA (and potentially SAM) to use different apps.

So I'm not sure if/when we close #161, but @asizemore has confirmed it is OK to roll out this `StartPage` to MBio.