### PR TITLE
filter-aware axis range for Vizs

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -102,6 +102,8 @@ import { useDeepValue } from '../../../hooks/immutability';
 // reset to defaults button
 import { ResetButtonCoreUI } from '../../ResetButton';
 
+import { filterMinMax } from '../../../utils/filter-axis-range';
+
 type BoxplotData = { series: BoxplotSeries };
 // type of computedVariableMetadata for computation apps such as alphadiv and abundance
 type BoxplotComputedVariableMetadata = {
@@ -582,6 +584,10 @@ function BoxplotViz(props: VisualizationProps<Options>) {
     )
   );
 
+  const dependentAxisFilterRange = useMemo(() => {
+    return filterMinMax(filters, vizConfig.yAxisVariable);
+  }, [filters, vizConfig.yAxisVariable]);
+
   const defaultDependentAxisRange = useDefaultAxisRange(
     yAxisVariable ??
       data?.value?.computedVariableMetadata?.find(
@@ -591,7 +597,8 @@ function BoxplotViz(props: VisualizationProps<Options>) {
     undefined, // no minPos needed if no logscale option offered
     dependentAxisMinMax?.max,
     false, // never logscale
-    vizConfig.dependentAxisValueSpec
+    vizConfig.dependentAxisValueSpec,
+    dependentAxisFilterRange
   ) as NumberRange;
 
   // custom legend items for checkbox

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -110,6 +110,8 @@ import { useDeepValue } from '../../../hooks/immutability';
 // reset to defaults button
 import { ResetButtonCoreUI } from '../../ResetButton';
 
+import { filterMinMax } from '../../../utils/filter-axis-range';
+
 export type HistogramDataWithCoverageStatistics = (
   | HistogramData
   | FacetedData<HistogramData>
@@ -555,6 +557,10 @@ function HistogramViz(props: VisualizationProps<Options>) {
     [data]
   );
 
+  const independentAxisFilterRange = useMemo(() => {
+    return filterMinMax(filters, vizConfig.xAxisVariable);
+  }, [filters, vizConfig.xAxisVariable]);
+
   const defaultIndependentRange = useDefaultAxisRange(
     xAxisVariable,
     vizConfig.independentAxisValueSpec === 'Full'
@@ -565,7 +571,8 @@ function HistogramViz(props: VisualizationProps<Options>) {
       ? undefined
       : independentAxisMinMax?.max,
     undefined,
-    vizConfig.independentAxisValueSpec
+    vizConfig.independentAxisValueSpec,
+    independentAxisFilterRange
   );
 
   // separate minPosMax from dependentMinPosMax

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -132,6 +132,8 @@ import { ResetButtonCoreUI } from '../../ResetButton';
 import Banner from '@veupathdb/coreui/dist/components/banners/Banner';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 
+import { filterMinMax } from '../../../utils/filter-axis-range';
+
 const plotContainerStyles = {
   width: 750,
   height: 450,
@@ -782,13 +784,21 @@ function LineplotViz(props: VisualizationProps<Options>) {
       ? data.value?.completeCasesAllVars
       : data.value?.completeCasesAxesVars;
 
+  const independentAxisFilterRange = useMemo(() => {
+    return filterMinMax(filters, vizConfig.xAxisVariable);
+  }, [filters, vizConfig.xAxisVariable]);
+  const dependentAxisFilterRange = useMemo(() => {
+    return filterMinMax(filters, vizConfig.yAxisVariable);
+  }, [filters, vizConfig.yAxisVariable]);
+
   const defaultIndependentAxisRange = useDefaultAxisRange(
     xAxisVariable,
     data.value?.xMin,
     data.value?.xMinPos,
     data.value?.xMax,
     vizConfig.independentAxisLogScale,
-    vizConfig.independentAxisValueSpec
+    vizConfig.independentAxisValueSpec,
+    independentAxisFilterRange
   );
 
   const xMinMaxDataRange = useMemo(
@@ -824,7 +834,8 @@ function LineplotViz(props: VisualizationProps<Options>) {
     yAxisVariable,
     vizConfig.dependentAxisLogScale,
     vizConfig.valueSpecConfig,
-    vizConfig.dependentAxisValueSpec
+    vizConfig.dependentAxisValueSpec,
+    dependentAxisFilterRange
   );
 
   // custom legend list
@@ -2598,7 +2609,11 @@ function useDefaultDependentAxisRangeProportion(
   yAxisVariable?: Variable,
   dependentAxisLogScale?: boolean,
   valueSpecConfig?: string,
-  dependentAxisValueSpec?: string
+  dependentAxisValueSpec?: string,
+  dependentAxisFilterRange?: {
+    min: string | number | undefined;
+    max: string | number | undefined;
+  }
 ) {
   let defaultDependentAxisRange = useDefaultAxisRange(
     yAxisVariable,
@@ -2606,7 +2621,8 @@ function useDefaultDependentAxisRangeProportion(
     data.value?.yMinPos,
     data.value?.yMax,
     dependentAxisLogScale,
-    dependentAxisValueSpec
+    dependentAxisValueSpec,
+    dependentAxisFilterRange
   );
 
   // include min origin: 0 (linear) or minPos (logscale)

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -138,6 +138,8 @@ import SliderWidget, {
   SliderWidgetProps,
 } from '@veupathdb/components/lib/components/widgets/Slider';
 
+import { filterMinMax } from '../../../utils/filter-axis-range';
+
 const MAXALLOWEDDATAPOINTS = 100000;
 const SMOOTHEDMEANTEXT = 'Smoothed mean';
 const SMOOTHEDMEANSUFFIX = `, ${SMOOTHEDMEANTEXT}`;
@@ -568,15 +570,23 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     (vizConfig.valueSpecConfig === 'Smoothed mean with raw' ||
       vizConfig.valueSpecConfig === 'Best fit line with raw');
 
+  const overlayFilterRange = useMemo(() => {
+    return filterMinMax(filters, vizConfig.overlayVariable);
+  }, [filters, vizConfig.overlayVariable]);
+
   // If numeric overlay, record the min and max and make a value to color map function
   // assign 0 to avoid undefined
-  const overlayMin: number | undefined =
+  const overlayMin: number =
     overlayVariable?.type === 'number' || overlayVariable?.type === 'integer'
-      ? overlayVariable?.distributionDefaults?.rangeMin
+      ? overlayFilterRange != null && overlayFilterRange.min != null
+        ? (overlayFilterRange.min as number)
+        : overlayVariable?.distributionDefaults?.rangeMin
       : 0;
-  const overlayMax: number | undefined =
+  const overlayMax: number =
     overlayVariable?.type === 'number' || overlayVariable?.type === 'integer'
-      ? overlayVariable?.distributionDefaults?.rangeMax
+      ? overlayFilterRange != null && overlayFilterRange.max != null
+        ? (overlayFilterRange.max as number)
+        : overlayVariable?.distributionDefaults?.rangeMax
       : 0;
 
   // Diverging colorscale, assume 0 is midpoint. Colorscale must be symmetric around the midpoint
@@ -834,6 +844,13 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
       ? data.value?.completeCasesAllVars
       : data.value?.completeCasesAxesVars;
 
+  const independentAxisFilterRange = useMemo(() => {
+    return filterMinMax(filters, vizConfig.xAxisVariable);
+  }, [filters, vizConfig.xAxisVariable]);
+  const dependentAxisFilterRange = useMemo(() => {
+    return filterMinMax(filters, vizConfig.yAxisVariable);
+  }, [filters, vizConfig.yAxisVariable]);
+
   // use hook
   const defaultIndependentAxisRange = useDefaultAxisRange(
     xAxisVariable ??
@@ -844,7 +861,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     data.value?.xMinPos,
     data.value?.xMax,
     vizConfig.independentAxisLogScale,
-    vizConfig.independentAxisValueSpec
+    vizConfig.independentAxisValueSpec,
+    independentAxisFilterRange
   );
 
   // use custom hook
@@ -857,7 +875,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     data.value?.yMinPos,
     data.value?.yMax,
     vizConfig.dependentAxisLogScale,
-    vizConfig.dependentAxisValueSpec
+    vizConfig.dependentAxisValueSpec,
+    dependentAxisFilterRange
   );
 
   // yMinMaxDataRange will be used for truncation to judge whether data has negative value

--- a/packages/libs/eda/src/lib/core/hooks/computeDefaultAxisRange.ts
+++ b/packages/libs/eda/src/lib/core/hooks/computeDefaultAxisRange.ts
@@ -22,7 +22,11 @@ export function useDefaultAxisRange(
   max?: number | string,
   /** are we using a log scale */
   logScale?: boolean,
-  axisRangeSpec = 'Full'
+  axisRangeSpec = 'Full',
+  filterRange?: {
+    min: string | number | undefined;
+    max: string | number | undefined;
+  }
 ): NumberOrDateRange | undefined {
   const defaultAxisRange = useMemo(() => {
     // Check here to make sure number ranges (min, minPos, max) came with number variables
@@ -45,7 +49,8 @@ export function useDefaultAxisRange(
         minPos,
         max,
         logScale,
-        axisRangeSpec
+        axisRangeSpec,
+        filterRange
       );
 
       // 4 significant figures

--- a/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
+++ b/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
@@ -12,7 +12,11 @@ export function numberDateDefaultAxisRange(
   observedMax: number | string | undefined,
   /** are we using a log scale */
   logScale?: boolean,
-  axisRangeSpec = 'Full'
+  axisRangeSpec = 'Full',
+  filterRange?: {
+    min: string | number | undefined;
+    max: string | number | undefined;
+  }
 ): NumberOrDateRange | undefined {
   if (Variable.is(variable)) {
     if (variable.type === 'number' || variable.type === 'integer') {
@@ -38,12 +42,12 @@ export function numberDateDefaultAxisRange(
                   // This can be expressed as a `min` function.
                   (min([
                     defaults.displayRangeMin ?? 0,
-                    defaults.rangeMin,
+                    filterRange != null ? filterRange.min : defaults.rangeMin,
                     observedMin as number,
                   ]) as number),
             max: max([
               defaults.displayRangeMax,
-              defaults.rangeMax,
+              filterRange != null ? filterRange.max : defaults.rangeMax,
               observedMax,
             ]) as number,
           }
@@ -63,7 +67,9 @@ export function numberDateDefaultAxisRange(
                 observedMin != null
                   ? [
                       defaults.displayRangeMin,
-                      defaults.rangeMin,
+                      filterRange != null && filterRange.min != null
+                        ? filterRange.min
+                        : defaults.rangeMin,
                       observedMin as string,
                     ].reduce(function (a, b) {
                       return a < b ? a : b;
@@ -77,7 +83,9 @@ export function numberDateDefaultAxisRange(
                 observedMax != null
                   ? [
                       defaults.displayRangeMax,
-                      defaults.rangeMax,
+                      filterRange != null && filterRange.max != null
+                        ? filterRange.max
+                        : defaults.rangeMax,
                       observedMax as string,
                     ].reduce(function (a, b) {
                       return a > b ? a : b;
@@ -91,19 +99,23 @@ export function numberDateDefaultAxisRange(
           : {
               min:
                 observedMin != null
-                  ? [defaults.rangeMin, observedMin as string].reduce(function (
-                      a,
-                      b
-                    ) {
+                  ? [
+                      filterRange != null && filterRange.min != null
+                        ? filterRange.min
+                        : defaults.rangeMin,
+                      observedMin as string,
+                    ].reduce(function (a, b) {
                       return a < b ? a : b;
                     }) + 'T00:00:00Z'
                   : defaults.rangeMin + 'T00:00:00Z',
               max:
                 observedMax != null
-                  ? [defaults.rangeMax, observedMax as string].reduce(function (
-                      a,
-                      b
-                    ) {
+                  ? [
+                      filterRange != null && filterRange.max != null
+                        ? filterRange.max
+                        : defaults.rangeMax,
+                      observedMax as string,
+                    ].reduce(function (a, b) {
                       return a > b ? a : b;
                     }) + 'T00:00:00Z'
                   : defaults.rangeMax + 'T00:00:00Z',
@@ -113,10 +125,14 @@ export function numberDateDefaultAxisRange(
             min:
               observedMin != null
                 ? observedMin + 'T00:00:00Z'
+                : filterRange != null && filterRange.min != null
+                ? filterRange.min + 'T00:00:00Z'
                 : defaults.rangeMin + 'T00:00:00Z',
             max:
               observedMax != null
                 ? observedMax + 'T00:00:00Z'
+                : filterRange != null && filterRange.max != null
+                ? filterRange.max + 'T00:00:00Z'
                 : defaults.rangeMax + 'T00:00:00Z',
           };
     }

--- a/packages/libs/eda/src/lib/core/utils/filter-axis-range.ts
+++ b/packages/libs/eda/src/lib/core/utils/filter-axis-range.ts
@@ -1,0 +1,24 @@
+import { Filter } from '../types/filter';
+import { VariableDescriptor } from '../types/variable';
+
+export function filterMinMax(
+  filters: Filter[] | undefined,
+  variable: VariableDescriptor | undefined
+) {
+  const minMaxArray =
+    filters != null && variable != null
+      ? filters
+          ?.map((value) => {
+            if (value.type === 'numberRange' || value.type === 'dateRange')
+              return value.entityId === variable?.entityId &&
+                value.variableId === variable?.variableId
+                ? value
+                : undefined;
+          })
+          .filter((data) => data != null)
+      : undefined;
+
+  return minMaxArray != null && minMaxArray.length > 0
+    ? { min: minMaxArray[0]?.min, max: minMaxArray[0]?.max }
+    : undefined;
+}


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1698. Changes are made for following Vizs

- Histogram X axis
- Boxplot Y axis
- Lineplot X and Y axes
- Scatterplot X and Y axes
- Scatterplot continuous overlay variable (colormap)

Here is an example screenshot for a case of Scatterplot continuous overlay variable (colormap): BMI-for-age z-core is filtered as [-10, 50]



 