### PR TITLE
216: Convert static legend to draggable legend

### DIFF
--- a/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
+++ b/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
@@ -60,7 +60,7 @@ export type DraggablePanelProps = {
 export default function DraggablePanel({
   confineToParentContainer,
   children,
-  defaultPosition,
+  defaultPosition = { x: 0, y: 0 },
   isOpen,
   onDragComplete,
   onDragStart,
@@ -74,9 +74,15 @@ export default function DraggablePanel({
 
   const [wasDragged, setWasDragged] = useState<boolean>(false);
   const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [position, setPosition] =
+    useState<DraggablePanelCoordinatePair>(defaultPosition);
 
-  function handleDrag() {
+  function handleDrag(_: DraggableEvent, data: DraggableData) {
     !wasDragged && setWasDragged(true);
+    setPosition({
+      x: data.x,
+      y: data.y,
+    });
   }
 
   function handleDragStart() {
@@ -110,14 +116,31 @@ export default function DraggablePanel({
     [height, width, onPanelResize]
   );
 
+  const browserWidth = window.innerWidth;
+  const isOffscreen = position.x + (width || 0) > browserWidth;
+  useEffect(
+    function resetLegendX() {
+      if (!width) return;
+
+      if (isOffscreen) {
+        const rightMostXPoint = browserWidth - width;
+        setPosition((position) => ({
+          ...position,
+          x: rightMostXPoint,
+        }));
+      }
+    },
+    [browserWidth, isOffscreen, width]
+  );
+
   return (
     <Draggable
       bounds={confineToParentContainer ? 'parent' : false}
-      defaultPosition={defaultPosition || { x: 0, y: 0 }}
       handle=".dragHandle"
       onDrag={handleDrag}
       onStart={handleDragStart}
       onStop={handleOnDragStop}
+      position={position}
     >
       <div
         // ref={setRefForResizeObserver}

--- a/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
+++ b/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
@@ -117,7 +117,7 @@ export default function DraggablePanel({
   );
 
   const finalPosition = confineToParentContainer
-    ? constainPositionOnScreen(panelPosition, width, height, window)
+    ? constrainPositionOnScreen(panelPosition, width, height, window)
     : panelPosition;
 
   return (
@@ -252,7 +252,7 @@ function isPanelYAxisOffScreen(
  * @returns A coordinate pair that places the panel nearest to the original position.
  * but ensuring that the panel is on screen.
  */
-function constainPositionOnScreen(
+function constrainPositionOnScreen(
   position: DraggablePanelCoordinatePair,
   panelWidth = 0,
   panelHeight = 0,

--- a/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
+++ b/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
@@ -103,6 +103,7 @@ export default function DraggablePanel({
   }
 
   const { ref, height, width } = useResizeObserver();
+  console.log('🚀 ~ file: index.tsx:106 ~ width:', width);
 
   useEffect(
     function invokeOnPanelResize() {
@@ -131,7 +132,6 @@ export default function DraggablePanel({
       position={finalPosition}
     >
       <div
-        // ref={setRefForResizeObserver}
         ref={ref}
         // As the attribute's name suggests, this helps with automated testing.
         // At the moment, jsdom and dragging is a bad combo for testing.
@@ -151,10 +151,6 @@ export default function DraggablePanel({
           // initial heights and widths.
           height: ${styleOverrides?.height ?? 'fit-content'};
           width: ${styleOverrides?.width ?? 'fit-content'};
-          // Hey, so you need to explicitly set overflow wherever
-          // you plan to use resize.
-          overflow: auto;
-          resize: ${styleOverrides?.resize ?? 'none'};
           min-height: ${styleOverrides?.minHeight ?? 0};
           min-width: ${styleOverrides?.minWidth ?? 0};
         `}
@@ -202,6 +198,10 @@ export default function DraggablePanel({
         </div>
         <div
           css={css`
+            // Hey, so you need to explicitly set overflow wherever
+            // you plan to use resize.
+            overflow: auto;
+            resize: ${styleOverrides?.resize ?? 'none'};
             border-radius: 7px;
             // We want the content to render below the drag handle, so let's put this
             // container in the same stacking context as the drag handle by giving it

--- a/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
+++ b/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
@@ -103,7 +103,6 @@ export default function DraggablePanel({
   }
 
   const { ref, height, width } = useResizeObserver();
-  console.log('🚀 ~ file: index.tsx:106 ~ width:', width);
 
   useEffect(
     function invokeOnPanelResize() {
@@ -177,7 +176,13 @@ export default function DraggablePanel({
             width: 100%;
           `}
         >
-          <H6 additionalStyles={{ fontWeight: 'bold' }}>
+          <H6
+            additionalStyles={{
+              fontWeight: 'bold',
+              fontSize: 14,
+              padding: '0 10px',
+            }}
+          >
             <span css={showPanelTitle ? null : screenReaderOnly}>
               {panelTitle}
             </span>

--- a/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
+++ b/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
@@ -260,8 +260,9 @@ function constainPositionOnScreen(
     panelHeight,
     innerHeight
   );
-  const rightMostX = innerWidth - panelWidth;
-  const bottomMostY = innerHeight - panelHeight;
+  const GUTTER = 10;
+  const rightMostX = innerWidth - panelWidth - GUTTER;
+  const bottomMostY = innerHeight - panelHeight - GUTTER;
 
   return {
     x: isXOffScreen ? rightMostX : position.x,

--- a/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
@@ -32,7 +32,6 @@ interface Props {
   filteredCounts: PromiseHookState<EntityCounts>;
   toggleStarredVariable: (variable: VariableDescriptor) => void;
   filters: Filter[];
-  onTouch: () => void;
   zIndexForStackingContext: number;
 }
 
@@ -48,7 +47,6 @@ export default function DraggableVisualization({
   filteredCounts,
   toggleStarredVariable,
   filters,
-  onTouch = () => {},
   zIndexForStackingContext = 10,
 }: Props) {
   const [computation, activeViz] =
@@ -72,10 +70,8 @@ export default function DraggableVisualization({
         y: 142,
       }}
       onPanelDismiss={() => setActiveVisualizationId(undefined)}
-      onDragStart={onTouch}
     >
       <div
-        onClick={onTouch} // Ensure that the panel moves to the front when interacted with.
         style={{
           // Initial height & width.
           height: 547,

--- a/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
@@ -32,7 +32,7 @@ interface Props {
   filteredCounts: PromiseHookState<EntityCounts>;
   toggleStarredVariable: (variable: VariableDescriptor) => void;
   filters: Filter[];
-  onDragStart: () => void;
+  onTouch: () => void;
   zIndexForStackingContext: number;
 }
 
@@ -48,7 +48,7 @@ export default function DraggableVisualization({
   filteredCounts,
   toggleStarredVariable,
   filters,
-  onDragStart = () => {},
+  onTouch = () => {},
   zIndexForStackingContext = 10,
 }: Props) {
   const [computation, activeViz] =
@@ -60,55 +60,52 @@ export default function DraggableVisualization({
   const activeVizOverview: VisualizationOverview | undefined =
     app.visualizations.find((viz) => viz.name === activeViz?.descriptor.type);
 
-  return (
-    <>
-      {activeViz && (
-        <DraggablePanel
-          confineToParentContainer
-          showPanelTitle
-          isOpen
-          styleOverrides={{ zIndex: zIndexForStackingContext, resize: 'both' }}
-          panelTitle={activeVizOverview?.displayName || ''}
-          defaultPosition={{
-            x: 535,
-            y: 142,
-          }}
-          onPanelDismiss={() => setActiveVisualizationId(undefined)}
-          onDragStart={onDragStart}
-        >
-          <div
-            style={{
-              // Initial height & width.
-              height: 547,
-              width: 779,
-              // This prevents the panel from collapsing aburdly.
-              minWidth: 400,
-              minHeight: 200,
-            }}
-          >
-            <FullScreenVisualization
-              analysisState={analysisState}
-              computation={computation!}
-              updateVisualizations={updateVisualizations}
-              visualizationPlugins={visualizationPlugins}
-              visualizationsOverview={app.visualizations}
-              geoConfigs={geoConfigs}
-              computationAppOverview={app}
-              filters={filters}
-              starredVariables={
-                analysisState.analysis?.descriptor.starredVariables ?? []
-              }
-              toggleStarredVariable={toggleStarredVariable}
-              totalCounts={totalCounts}
-              filteredCounts={filteredCounts}
-              isSingleAppMode
-              disableThumbnailCreation
-              id={activeViz.visualizationId}
-              actions={<></>}
-            />
-          </div>
-        </DraggablePanel>
-      )}
-    </>
-  );
+  return activeViz ? (
+    <DraggablePanel
+      confineToParentContainer
+      showPanelTitle
+      isOpen
+      styleOverrides={{ zIndex: zIndexForStackingContext, resize: 'both' }}
+      panelTitle={activeVizOverview?.displayName || ''}
+      defaultPosition={{
+        x: 535,
+        y: 142,
+      }}
+      onPanelDismiss={() => setActiveVisualizationId(undefined)}
+      onDragStart={onTouch}
+    >
+      <div
+        onClick={onTouch} // Ensure that the panel moves to the front when interacted with.
+        style={{
+          // Initial height & width.
+          height: 547,
+          width: 779,
+          // This prevents the panel from collapsing aburdly.
+          minWidth: 400,
+          minHeight: 200,
+        }}
+      >
+        <FullScreenVisualization
+          analysisState={analysisState}
+          computation={computation!}
+          updateVisualizations={updateVisualizations}
+          visualizationPlugins={visualizationPlugins}
+          visualizationsOverview={app.visualizations}
+          geoConfigs={geoConfigs}
+          computationAppOverview={app}
+          filters={filters}
+          starredVariables={
+            analysisState.analysis?.descriptor.starredVariables ?? []
+          }
+          toggleStarredVariable={toggleStarredVariable}
+          totalCounts={totalCounts}
+          filteredCounts={filteredCounts}
+          isSingleAppMode
+          disableThumbnailCreation
+          id={activeViz.visualizationId}
+          actions={<></>}
+        />
+      </div>
+    </DraggablePanel>
+  ) : null;
 }

--- a/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
@@ -32,6 +32,8 @@ interface Props {
   filteredCounts: PromiseHookState<EntityCounts>;
   toggleStarredVariable: (variable: VariableDescriptor) => void;
   filters: Filter[];
+  onDragStart: () => void;
+  zIndexForStackingContext: number;
 }
 
 export default function DraggableVisualization({
@@ -46,6 +48,8 @@ export default function DraggableVisualization({
   filteredCounts,
   toggleStarredVariable,
   filters,
+  onDragStart = () => {},
+  zIndexForStackingContext = 10,
 }: Props) {
   const [computation, activeViz] =
     analysisState.analysis?.descriptor.computations
@@ -63,13 +67,14 @@ export default function DraggableVisualization({
           confineToParentContainer
           showPanelTitle
           isOpen
-          styleOverrides={{ zIndex: 10, resize: 'both' }}
+          styleOverrides={{ zIndex: zIndexForStackingContext, resize: 'both' }}
           panelTitle={activeVizOverview?.displayName || ''}
           defaultPosition={{
             x: 535,
             y: 142,
           }}
           onPanelDismiss={() => setActiveVisualizationId(undefined)}
+          onDragStart={onDragStart}
         >
           <div
             style={{

--- a/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
@@ -65,7 +65,7 @@ export default function DraggableVisualization({
       confineToParentContainer
       showPanelTitle
       isOpen
-      styleOverrides={{ zIndex: zIndexForStackingContext }}
+      styleOverrides={{ zIndex: zIndexForStackingContext, resize: 'both' }}
       panelTitle={activeVizOverview?.displayName || ''}
       defaultPosition={{
         x: 535,

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -978,7 +978,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                   confineToParentContainer
                   defaultPosition={{ x: 100, y: 100 }}
                   styleOverrides={{
-                    zIndex: 100,
+                    zIndex: sideNavigationIsExpanded ? 1 : 10,
                   }}
                 >
                   {legendItems.length > 0 && (

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -999,7 +999,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                   panelTitle="Legend"
                   showPanelTitle={false}
                   confineToParentContainer
-                  defaultPosition={{ x: window.innerWidth - 20, y: 100 }}
+                  defaultPosition={{ x: window.innerWidth, y: 225 }}
                   styleOverrides={{
                     zIndex: legendZIndex,
                   }}

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -986,8 +986,8 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
 
                 <DraggablePanel
                   isOpen
-                  panelTitle="Legend"
-                  showPanelTitle={false}
+                  showPanelTitle
+                  panelTitle={overlayVariable?.displayName || 'Legend'}
                   confineToParentContainer
                   defaultPosition={{ x: window.innerWidth, y: 225 }}
                   styleOverrides={{
@@ -998,7 +998,6 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                     <MapLegend
                       isLoading={legendItems.length === 0}
                       legendItems={legendItems}
-                      title={overlayVariable?.displayName}
                       // control to show checkbox. default: true
                       showCheckbox={false}
                     />

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -855,6 +855,21 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
     }
   }, [pending, appState.viewport]);
 
+  const [zIndicies, setZIndicies] = useState<string[]>(['legend']);
+  const [panelOpenDictionary, setPanelOpenDictionary] = useState<{
+    [key: string]: boolean;
+  }>({});
+
+  function movePanelToTopLayer(panelTitleToMove: string) {
+    setZIndicies((currentList) => {
+      return currentList
+        .filter((panelTitle) => panelTitle !== panelTitleToMove)
+        .concat(panelTitleToMove);
+    });
+  }
+
+  const zIndexFactor = sideNavigationIsExpanded ? 2 : 10;
+
   return (
     <PromiseResult state={appPromiseState}>
       {(app: ComputationAppOverview) => {
@@ -978,8 +993,10 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                   confineToParentContainer
                   defaultPosition={{ x: 100, y: 100 }}
                   styleOverrides={{
-                    zIndex: sideNavigationIsExpanded ? 1 : 10,
+                    zIndex:
+                      zIndicies.findIndex((i) => i === 'legend') + zIndexFactor,
                   }}
+                  onDragStart={() => movePanelToTopLayer('legend')}
                 >
                   {legendItems.length > 0 && (
                     <MapLegend
@@ -1023,6 +1040,10 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                     filteredCounts={filteredCounts}
                     toggleStarredVariable={toggleStarredVariable}
                     filters={filtersIncludingViewport}
+                    onDragStart={() => movePanelToTopLayer('viz')}
+                    zIndexForStackingContext={
+                      zIndicies.findIndex((i) => i === 'viz') + zIndexFactor
+                    }
                   />
                 )}
 

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -80,7 +80,7 @@ import NameAnalysis from '../../workspace/sharing/NameAnalysis';
 import NotesTab from '../../workspace/NotesTab';
 import ConfirmShareAnalysis from '../../workspace/sharing/ConfirmShareAnalysis';
 import { useHistory } from 'react-router';
-import { uniq, isEqual, findIndex } from 'lodash';
+import { uniq, isEqual } from 'lodash';
 import DownloadTab from '../../workspace/DownloadTab';
 import { RecordController } from '@veupathdb/wdk-client/lib/Controllers';
 import {
@@ -860,23 +860,9 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
     }
   }, [pending, appState.viewport]);
 
-  const [zIndicies, setZIndicies] = useState<DraggablePanelIds[]>(
+  const [zIndicies /* setZIndicies */] = useState<DraggablePanelIds[]>(
     Object.values(DraggablePanelIds)
   );
-
-  function movePanelToTopLayer(
-    panelTitleToMove: DraggablePanelIds
-  ): () => void {
-    return () =>
-      setZIndicies((currentList) => {
-        return currentList
-          .filter((panelTitle) => panelTitle !== panelTitleToMove)
-          .concat(panelTitleToMove);
-      });
-  }
-
-  const moveLegendToTop = movePanelToTopLayer(DraggablePanelIds.LEGEND_PANEL);
-  const moveVizToTop = movePanelToTopLayer(DraggablePanelIds.VIZ_PANEL);
 
   function getZIndexByPanelTitle(
     requestedPanelTitle: DraggablePanelIds
@@ -887,6 +873,10 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
     const zIndexFactor = sideNavigationIsExpanded ? 2 : 10;
     return index + zIndexFactor;
   }
+
+  const legendZIndex =
+    getZIndexByPanelTitle(DraggablePanelIds.LEGEND_PANEL) +
+    getZIndexByPanelTitle(DraggablePanelIds.VIZ_PANEL);
 
   return (
     <PromiseResult state={appPromiseState}>
@@ -1011,17 +1001,11 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                   confineToParentContainer
                   defaultPosition={{ x: 100, y: 100 }}
                   styleOverrides={{
-                    zIndex: getZIndexByPanelTitle(
-                      DraggablePanelIds.LEGEND_PANEL
-                    ),
+                    zIndex: legendZIndex,
                   }}
-                  onDragStart={moveLegendToTop}
                 >
                   {legendItems.length > 0 && (
-                    <div
-                      style={{ padding: '5px 10px' }}
-                      onClick={moveLegendToTop}
-                    >
+                    <div style={{ padding: '5px 10px' }}>
                       <MapLegend
                         legendItems={legendItems}
                         title={overlayVariable?.displayName}
@@ -1064,7 +1048,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                     filteredCounts={filteredCounts}
                     toggleStarredVariable={toggleStarredVariable}
                     filters={filtersIncludingViewport}
-                    onTouch={moveVizToTop}
+                    // onTouch={moveVizToTop}
                     zIndexForStackingContext={getZIndexByPanelTitle(
                       DraggablePanelIds.VIZ_PANEL
                     )}

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -999,7 +999,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                   panelTitle="Legend"
                   showPanelTitle={false}
                   confineToParentContainer
-                  defaultPosition={{ x: 100, y: 100 }}
+                  defaultPosition={{ x: window.innerWidth - 20, y: 100 }}
                   styleOverrides={{
                     zIndex: legendZIndex,
                   }}

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -93,6 +93,7 @@ import { BarPlotMarkers, DonutMarkers } from './MarkerConfiguration/icons';
 import { AllAnalyses } from '../../workspace/AllAnalyses';
 import { getStudyId } from '@veupathdb/study-data-access/lib/shared/studies';
 import { isSavedAnalysis } from '../../core/utils/analysis';
+import { DraggablePanel } from '@veupathdb/coreui/dist/components/containers';
 
 enum MapSideNavItemLabels {
   Download = 'Download',
@@ -970,10 +971,14 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                   />
                 </div>
 
-                <FloatingDiv
-                  style={{
-                    top: 250,
-                    right: 8,
+                <DraggablePanel
+                  isOpen
+                  panelTitle="Legend"
+                  showPanelTitle={false}
+                  confineToParentContainer
+                  defaultPosition={{ x: 100, y: 100 }}
+                  styleOverrides={{
+                    zIndex: 100,
                   }}
                 >
                   {legendItems.length > 0 && (
@@ -984,7 +989,7 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                       showCheckbox={false}
                     />
                   )}
-                </FloatingDiv>
+                </DraggablePanel>
                 {/* <FloatingDiv
                   style={{
                     top: 250,

--- a/packages/libs/eda/src/lib/map/analysis/MapLegend.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapLegend.tsx
@@ -5,37 +5,29 @@ import { LegendItemsProps } from '@veupathdb/components/lib/components/plotContr
 interface Props {
   legendItems: LegendItemsProps[];
   isLoading: boolean;
-  title?: string;
   showCheckbox?: boolean;
 }
 
 export function MapLegend(props: Props) {
-  const { legendItems, isLoading, title = 'Legend', showCheckbox } = props;
+  const { legendItems, isLoading, showCheckbox } = props;
 
-  return (
-    <>
-      <div>
-        <strong>{title}</strong>
-      </div>
-      {isLoading ? (
-        <div style={{ marginTop: '1em', height: 50, position: 'relative' }}>
-          <Spinner size={20} />
-        </div>
-      ) : (
-        <PlotLegend
-          type="list"
-          legendItems={legendItems}
-          showOverlayLegend
-          containerStyles={{
-            border: 'none',
-            boxShadow: 'none',
-            padding: 0,
-            width: 'auto',
-            maxWidth: 400,
-          }}
-          showCheckbox={showCheckbox}
-        />
-      )}
-    </>
+  return isLoading ? (
+    <div style={{ marginTop: '1em', height: 50, position: 'relative' }}>
+      <Spinner size={20} />
+    </div>
+  ) : (
+    <PlotLegend
+      type="list"
+      legendItems={legendItems}
+      showOverlayLegend
+      containerStyles={{
+        border: 'none',
+        boxShadow: 'none',
+        padding: 0,
+        width: 'auto',
+        maxWidth: 400,
+      }}
+      showCheckbox={showCheckbox}
+    />
   );
 }


### PR DESCRIPTION
#216 

Change list:
- Render the legend in a draggable panel.
- Ensure stacking order [as per a map UX meeting](https://epvb.slack.com/?redir=%2Farchives%2FCMQ8K9XRS%2Fp1684447704036989%255c%3Fthread_ts%255C%3D1684445660.278889%255C%26cid%255C%3DCMQ8K9XRS).
- Add logic to ensure the draggable panel remains on screen despite growing.  
   
<details> 
<summary id="warthog">See the logic in action!</summary> 

Before adding logic to constrain panel to browser screen:

https://user-images.githubusercontent.com/24446573/238075102-a0ff00ab-ff1c-4fb5-bb38-baec7903bda1.mp4 

After adding logic to constrain panel to browser screen:

https://github.com/VEuPathDB/web-monorepo/assets/24446573/d4610c85-18bf-42c1-b7fd-372ca4182431 

</details>


**Before**: 

<img width="502" alt="Screenshot 2023-05-23 at 11 20 01 AM" src="https://github.com/VEuPathDB/web-monorepo/assets/24446573/462fa108-c936-4e77-afb0-232660871c0b">

**After**:

<img width="502" alt="image" src="https://github.com/VEuPathDB/web-monorepo/assets/24446573/481b07c4-faed-458a-860a-1713ff62597b">
