### PR TITLE
Sam - enable proportion markers

### DIFF
--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -818,6 +818,7 @@ export const StandaloneMapMarkersResponse = type({
           type({
             binLabel: string,
             value: number,
+            count: number,
           }),
           partial({
             binStart: string,

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -525,9 +525,6 @@ function MapAnalysisImpl(props: Props & CompleteAppState) {
                           []
                         }
                         toggleStarredVariable={toggleStarredVariable}
-                        selectedPlotMode={
-                          activeMarkerConfiguration.selectedPlotMode
-                        }
                         configuration={activeMarkerConfiguration}
                       />
                     ) : (

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
@@ -24,7 +24,6 @@ interface Props
     InputVariablesProps,
     'onChange' | 'selectedVariables' | 'selectedPlotMode' | 'onPlotSelected'
   > {
-  selectedPlotMode: string;
   onChange: (configuration: BarPlotMarkerConfiguration) => void;
   configuration: BarPlotMarkerConfiguration;
 }

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
@@ -224,28 +224,28 @@ export function useStandaloneMapMarkers(
 
   // calculate minPos, max and sum for chart marker dependent axis
   // assumes the value is a count! (so never negative)
-  const { valueMax, valueMinPos, valueSum } = useMemo(
+  const { valueMax, valueMinPos, countSum } = useMemo(
     () =>
       markerData.value
         ? markerData.value.mapElements
             .flatMap((el) => el.overlayValues)
             .reduce(
-              ({ valueMax, valueMinPos, valueSum }, elem) => ({
+              ({ valueMax, valueMinPos, countSum }, elem) => ({
                 valueMax: Math.max(elem.value, valueMax),
                 valueMinPos:
                   elem.value > 0 &&
                   (valueMinPos == null || elem.value < valueMinPos)
                     ? elem.value
                     : valueMinPos,
-                valueSum: (valueSum ?? 0) + elem.value,
+                countSum: (countSum ?? 0) + elem.count,
               }),
               {
                 valueMax: 0,
                 valueMinPos: undefined as number | undefined,
-                valueSum: undefined as number | undefined,
+                countSum: undefined as number | undefined,
               }
             )
-        : { valueMax: undefined, valueMinPos: undefined, valueSum: undefined },
+        : { valueMax: undefined, valueMinPos: undefined, countSum: undefined },
     [markerData]
   );
 
@@ -404,7 +404,7 @@ export function useStandaloneMapMarkers(
 
   return {
     markers,
-    totalVisibleWithOverlayEntityCount: valueSum,
+    totalVisibleWithOverlayEntityCount: countSum,
     totalVisibleEntityCount,
     legendItems,
     pending: markerData.pending,

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
@@ -182,7 +182,7 @@ export function useStandaloneMapMarkers(
           longitudeVariable,
           overlayConfig,
           outputEntityId,
-          valueSpec: 'count', // TO DO: or proportion when we have the UI and back-end fix https://github.com/VEuPathDB/EdaDataService/issues/261 for this
+          valueSpec: markerType === 'pie' ? 'count' : markerType,
           viewport: {
             latitude: {
               xMin,
@@ -213,7 +213,7 @@ export function useStandaloneMapMarkers(
       longitudeVariable,
       boundsZoomLevel,
       geoConfig,
-      // TO DO: add markerType and make valueSpec depend on it
+      markerType,
     ])
   );
 


### PR DESCRIPTION
Resolves #203 

Branched from `sam-wire-floaters` but I see that it also merges to `main` without problems.

Also removed an unused prop in the barplot config.