### PR TITLE
Wire up a `workspace/maps` route

### DIFF
--- a/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
+++ b/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
@@ -3,6 +3,7 @@ import {
   RouteComponentProps,
   Switch,
   useRouteMatch,
+  useHistory,
 } from 'react-router';
 
 import { EDAAnalysisListContainer, EDAWorkspaceContainer } from '../core';
@@ -10,7 +11,7 @@ import { EDAAnalysisListContainer, EDAWorkspaceContainer } from '../core';
 import { AnalysisList } from './MapVeuAnalysisList';
 import { MapAnalysis } from './analysis/MapAnalysis';
 
-import { StudyList } from './StudyList';
+import { AllAnalyses } from '../workspace/AllAnalyses';
 import {
   useConfiguredSubsettingClient,
   useConfiguredDataClient,
@@ -37,6 +38,13 @@ export function MapVeuContainer(mapVeuContainerProps: Props) {
   const computeClient = useConfiguredComputeClient(edaServiceUrl);
   const analysisClient = useConfiguredAnalysisClient(edaServiceUrl);
   const downloadClient = useConfiguredDownloadClient(edaServiceUrl);
+
+  const history = useHistory();
+  function showLoginForm() {
+    const currentUrl = window.location.href;
+    const loginUrl = `${siteInformationProps.loginUrl}?destination=${currentUrl}`;
+    history.push(loginUrl);
+  }
 
   // This will get the matched path of the active parent route.
   // This is useful so we don't have to hardcode the path root.
@@ -89,7 +97,16 @@ export function MapVeuContainer(mapVeuContainerProps: Props) {
           </EDAAnalysisListContainer>
         )}
       />
-      <Route path={path} component={StudyList} />
+      <Route
+        path={path}
+        render={() => (
+          <AllAnalyses
+            analysisClient={analysisClient}
+            subsettingClient={edaClient}
+            showLoginForm={showLoginForm}
+          />
+        )}
+      />
     </Switch>
   );
 }

--- a/packages/libs/web-common/src/routes.jsx
+++ b/packages/libs/web-common/src/routes.jsx
@@ -71,11 +71,19 @@ export const wrapRoutes = (wdkRoutes) => [
   },
 
   {
-    path: '/maps',
+    path: '/workspace/maps',
     exact: false,
     isFullscreen: true,
     rootClassNameModifier: 'MapVEu',
     component: EdaMapController,
+  },
+
+  {
+    path: '/maps',
+    exact: false,
+    isFullscreen: true,
+    rootClassNameModifier: 'MapVEu',
+    component: () => <Redirect to="/workspace/maps" />,
   },
 
   {

--- a/packages/libs/web-common/src/routes.jsx
+++ b/packages/libs/web-common/src/routes.jsx
@@ -72,6 +72,12 @@ export const wrapRoutes = (wdkRoutes) => [
 
   {
     path: '/workspace/maps',
+    exact: true,
+    component: EdaMapController,
+  },
+
+  {
+    path: '/workspace/maps',
     exact: false,
     isFullscreen: true,
     rootClassNameModifier: 'MapVEu',

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -373,7 +373,7 @@ const useHeaderMenuItems = (
             key: `map-${record.id[0].value}`,
             display: record.displayName,
             type: 'reactRoute',
-            url: `/maps/${record.id[0].value}/new`,
+            url: `/workspace/maps/${record.id[0].value}/new`,
           }));
       } catch (error) {
         console.error(error);
@@ -673,6 +673,15 @@ const useHeaderMenuItems = (
           url: '/workspace/favorites',
           metadata: {
             exclude: [EuPathDB],
+          },
+        },
+        {
+          key: 'maps-workspace',
+          display: 'My interactive maps',
+          type: 'reactRoute',
+          url: '/workspace/maps',
+          metadata: {
+            test: () => Boolean(showInteractiveMaps),
           },
         },
         {


### PR DESCRIPTION
Resolves #212

New menu item:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/14aecc6e-330a-4cea-8557-f9978226cddb)

Result of clicking the `My interactive maps` menu item (routes to `workspace/maps`):
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/405a8c96-99ef-4949-846d-dc94c7bbdfe9)
