### PR TITLE
Fix build problem by making sure the typescript compiler knows import-export tokens are types

### DIFF
--- a/packages/libs/coreui/src/assets/icons/index.tsx
+++ b/packages/libs/coreui/src/assets/icons/index.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { IconProps } from "./types";
-import Arrow from "./Arrow";
-import CaretDown from "./CaretDown";
-import CaretUp from "./CaretUp";
-import DoubleArrow from "./DoubleArrow";
-import Cancel from "./Cancel";
+import React from 'react';
+import type { IconProps } from './types';
+import Arrow from './Arrow';
+import CaretDown from './CaretDown';
+import CaretUp from './CaretUp';
+import DoubleArrow from './DoubleArrow';
+import Cancel from './Cancel';
 
 export { IconProps, Arrow, CaretDown, CaretUp, DoubleArrow, Cancel };
 

--- a/packages/libs/coreui/src/components/theming/index.ts
+++ b/packages/libs/coreui/src/components/theming/index.ts
@@ -1,3 +1,3 @@
-export { UITheme } from './types';
+export type { UITheme } from './types';
 export { default as useUITheme } from './useUITheme';
 export { default as UIThemeProvider } from './UIThemeProvider';


### PR DESCRIPTION
Original compile issues with `yarn nx start @veupathdb/eda`

```
Compiled with problems:
ERROR in ../coreui/dist/assets/icons/index.js 70:0-69
export 'IconProps' (reexported as 'IconProps') was not found in './types' (module has no exports)
ERROR in ../coreui/dist/components/theming/index.js 3:0-34
export 'UITheme' (reexported as 'UITheme') was not found in './types' (module has no exports)
```

Looks like the compiler needs a hint about the reexport of a type.

Do we solve this here, or in the webpack/ts-config somehow? That's above my pay grade ;-) 

From my googling, I think `import type ...` and `export type ...` are typescript >= 3.8.x.

We are on 4.x so safe to proceed?
