### PR TITLE
Fix position of x axis title on mosaic plot

### DIFF
--- a/packages/libs/components/src/plots/MosaicPlot.tsx
+++ b/packages/libs/components/src/plots/MosaicPlot.tsx
@@ -184,8 +184,7 @@ const MosaicPlot = makePlotlyPlotComponent(
           standoff: xAxisTitleStandoff,
         },
         tickvals: column_centers,
-        tickangle: 90,
-        ticktext: new Array(data.independentLabels.length).fill(''),
+        ticktext: new Array(data.independentLabels.length).fill(' '),
         range: [0, 100] as number[],
         // this is required to separate axis tick label from axis title
         automargin: true,

--- a/packages/libs/components/src/plots/MosaicPlot.tsx
+++ b/packages/libs/components/src/plots/MosaicPlot.tsx
@@ -183,8 +183,10 @@ const MosaicPlot = makePlotlyPlotComponent(
               : independentAxisLabel,
           standoff: xAxisTitleStandoff,
         },
-        tickvals: column_centers,
-        ticktext: new Array(data.independentLabels.length).fill(' '),
+        // Make sure there's always tick labels so that the axis title gets
+        // positioned correctly
+        tickvals: column_centers.length > 0 ? column_centers : [50],
+        ticktext: new Array(data.independentLabels.length || 1).fill(' '),
         range: [0, 100] as number[],
         // this is required to separate axis tick label from axis title
         automargin: true,


### PR DESCRIPTION
Fixes https://github.com/VEuPathDB/web-monorepo/issues/182

Because the dummy x axis tick values were empty strings, the title had no labels to "automargin" against, so it was just positioned relative to the top of the plot. Changing the dummy labels to a single space gives it something to "automargin" against.

Removed tick angle because we don't actually have plotly-native tick labels.