### PR TITLE
Fix webpack cache key in github workflow

### DIFF
--- a/.github/workflows/npm-publish-sites.yml
+++ b/.github/workflows/npm-publish-sites.yml
@@ -37,10 +37,7 @@ jobs:
         with:
           # cache directory
           path: packages/sites/${{ matrix.dir }}/node_modules/.cache/webpack/
-          key: ${{ github.ref_name }}-${{ matrix.dir }}-webpack-build
-          # fallback to use "main" branch cache
-          restore-keys: |
-            main-${{ matrix.dir }}-webpack-build
+          key: ${{ matrix.dir }}-webpack-build
       - run: yarn
       - run: yarn nx bundle:npm @veupathdb/${{matrix.dir}}
         env:


### PR DESCRIPTION
This PR removes the ref_name from webpack cache key, since it refers to the git tag used for the release. Since those tags are unique, it makes the cache useless. Unfortunately, it is not possible to get a branch name for workflows triggered by release events.