### PR TITLE
Use checkmark instead of chip to indicate active mapType

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -22,7 +22,7 @@ import MapVEuMap from '@veupathdb/components/lib/map/MapVEuMap';
 import { useGeoConfig } from '../../core/hooks/geoConfig';
 import { DocumentationContainer } from '../../core/components/docs/DocumentationContainer';
 import {
-  Chip,
+  CheckIcon,
   Download,
   FilledButton,
   Filter as FilterIcon,
@@ -1211,32 +1211,24 @@ function SideNavigationItems({
                         item.onClick();
                       }}
                     >
+                      {/* *
+                       * This div contains a checkmark that indicates which map type is active. The checkmark persists even if a different side nav item is selected.
+                       */}
+                      <div
+                        style={{
+                          marginRight: '0.5em',
+                          width: '1em',
+                          height: '1em',
+                        }}
+                      >
+                        {item.isActive && <CheckIcon />}
+                      </div>
                       <span style={{ fontSize: '0.9em', marginRight: '0.5em' }}>
                         {item.labelText}
                       </span>
                       <span style={iconStyles} aria-hidden>
                         {item.icon}
                       </span>
-                      {/**
-                       * This div contains a chip that indicates which map type is active. The chip persists even if a different side nav item is selected
-                       */}
-                      <div
-                        style={{
-                          display: 'flex',
-                          justifyContent: 'flex-end',
-                          flexGrow: 1,
-                          marginLeft: '0.5em',
-                          width: '3.5em',
-                        }}
-                      >
-                        {item.isActive && (
-                          <Chip
-                            text="active"
-                            themeRole="primary"
-                            staticState="hover"
-                          />
-                        )}
-                      </div>
                     </button>
                   </li>
                 );


### PR DESCRIPTION
Replaces the `Chip` component with `active` string content with a checkmark per concerns about A) the `Chip` component looking like a button and B) an unclear parent-child hierarchy. The checkmark gives us better indentation that also better conveys the hierarchy.

Before:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/2886ea4c-56ed-4fdd-a4bf-4bcc5391dc10)

After:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/21be7d3d-5d1f-4e4e-b25a-011c22a4757c)