### PR TITLE
Patch ortho clustergraph layout

### DIFF
--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/cluster-graph/ClusterGraphCanvas.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/cluster-graph/ClusterGraphCanvas.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 
-import { Core,use } from 'cytoscape';
+import { Core, use } from 'cytoscape';
 import produce from 'immer';
-import fcose from 'cytoscape-fcose';
+import cola from 'cytoscape-cola';
 import CytoscapeComponent from 'react-cytoscapejs';
 
-use(fcose);
+use(cola);
 
 import { useCytoscapeConfig } from 'ortho-client/hooks/cytoscapeData';
 import {
@@ -13,17 +13,17 @@ import {
   useNodeClickEventHandler,
   useNodeMouseMovementEventHandlers,
   useUpdateHighlightedEdge,
-  useUpdateHighlightedNodes
+  useUpdateHighlightedNodes,
 } from 'ortho-client/hooks/cytoscapeEventHandlers';
 
 import {
   EdgeType,
   NodeDisplayType,
-  ProteinType
+  ProteinType,
 } from 'ortho-client/utils/clusterGraph';
 import {
   addCytoscapeClass,
-  removeCytoscapeClass
+  removeCytoscapeClass,
 } from 'ortho-client/utils/cytoscapeClasses';
 import { GroupLayout } from 'ortho-client/utils/groupLayout';
 import { TaxonUiMetadata } from 'ortho-client/utils/taxons';
@@ -55,27 +55,34 @@ export function ClusterGraphCanvas({
   highlightedLegendNodeIds,
   highlightedSequenceNodeId,
   highlightedBlastEdgeId,
-  onClickNode
+  onClickNode,
 }: Props) {
   const cyRef = useRef<Core>();
-  const [ cytoscapeConfig, setCytoscapeConfig ] = useCytoscapeConfig(
+  const [cytoscapeConfig, setCytoscapeConfig] = useCytoscapeConfig(
     layout,
     corePeripheralMap,
     taxonUiMetadata,
     selectedNodeDisplayType
   );
 
-  const updateHighlightedNodes = useUpdateHighlightedNodes(cytoscapeConfig, setCytoscapeConfig);
-  const updateHighlightedEdge = useUpdateHighlightedEdge(cyRef.current, cytoscapeConfig, setCytoscapeConfig);
+  const updateHighlightedNodes = useUpdateHighlightedNodes(
+    cytoscapeConfig,
+    setCytoscapeConfig
+  );
+  const updateHighlightedEdge = useUpdateHighlightedEdge(
+    cyRef.current,
+    cytoscapeConfig,
+    setCytoscapeConfig
+  );
 
   const onMouseLeaveCanvas = useCallback(() => {
     updateHighlightedNodes([]);
     updateHighlightedEdge(undefined);
-  }, [ updateHighlightedNodes, updateHighlightedEdge ]);
+  }, [updateHighlightedNodes, updateHighlightedEdge]);
 
   useEffect(() => {
-    const newConfig = produce(cytoscapeConfig, draftConfig => {
-      draftConfig.elements.forEach(element => {
+    const newConfig = produce(cytoscapeConfig, (draftConfig) => {
+      draftConfig.elements.forEach((element) => {
         if (element.group === 'nodes') {
           element.classes = selectedNodeDisplayType;
         }
@@ -83,60 +90,71 @@ export function ClusterGraphCanvas({
     });
 
     setCytoscapeConfig(newConfig);
-  }, [ selectedNodeDisplayType ]);
+  }, [selectedNodeDisplayType]);
 
   useEffect(() => {
-    const newConfig = produce(cytoscapeConfig, draftConfig => {
+    const newConfig = produce(cytoscapeConfig, (draftConfig) => {
       const maxEValue = parseFloat(`1e${eValueExp}`);
 
-      draftConfig.elements.forEach(element => {
+      draftConfig.elements.forEach((element) => {
         if (element.group === 'edges') {
           if (
             !selectedEdgeTypes[element.data.type as EdgeType] ||
             element.data.eValue > maxEValue
           ) {
-            element.classes = addCytoscapeClass(element.classes, 'filtered-out');
+            element.classes = addCytoscapeClass(
+              element.classes,
+              'filtered-out'
+            );
           } else {
-            element.classes = removeCytoscapeClass(element.classes, 'filtered-out');
+            element.classes = removeCytoscapeClass(
+              element.classes,
+              'filtered-out'
+            );
           }
         }
       });
     });
 
     setCytoscapeConfig(newConfig);
-  }, [ eValueExp, selectedEdgeTypes ]);
+  }, [eValueExp, selectedEdgeTypes]);
 
   useEffect(() => {
     updateHighlightedNodes(highlightedLegendNodeIds);
-  }, [ highlightedLegendNodeIds ]);
+  }, [highlightedLegendNodeIds]);
 
   useEffect(() => {
-    const newHighlightedNodeIds = highlightedSequenceNodeId == null
-      ? [ ]
-      : [ highlightedSequenceNodeId ];
+    const newHighlightedNodeIds =
+      highlightedSequenceNodeId == null ? [] : [highlightedSequenceNodeId];
 
     updateHighlightedNodes(newHighlightedNodeIds);
-  }, [ highlightedSequenceNodeId ]);
+  }, [highlightedSequenceNodeId]);
 
   useEffect(() => {
     updateHighlightedEdge(highlightedBlastEdgeId);
-  }, [ highlightedBlastEdgeId ]);
+  }, [highlightedBlastEdgeId]);
 
   useEffect(() => {
-    const newConfig = produce(cytoscapeConfig, draftConfig => {
-      draftConfig.elements.forEach(element => {
+    const newConfig = produce(cytoscapeConfig, (draftConfig) => {
+      draftConfig.elements.forEach((element) => {
         if (element.group === 'edges' && element.data.type != null) {
           if (element.data.type === highlightedEdgeType) {
-            element.classes = addCytoscapeClass(element.classes, 'type-highlighted');
+            element.classes = addCytoscapeClass(
+              element.classes,
+              'type-highlighted'
+            );
           } else {
-            element.classes = removeCytoscapeClass(element.classes, 'type-highlighted');
+            element.classes = removeCytoscapeClass(
+              element.classes,
+              'type-highlighted'
+            );
           }
         }
       });
     });
 
     setCytoscapeConfig(newConfig);
-  }, [ highlightedEdgeType ]);
+  }, [highlightedEdgeType]);
 
   useNodeClickEventHandler(cyRef, onClickNode);
 
@@ -151,7 +169,7 @@ export function ClusterGraphCanvas({
     >
       <CytoscapeComponent
         className="ClusterGraphCanvas"
-        cy={cy => {
+        cy={(cy) => {
           cyRef.current = cy;
         }}
         {...cytoscapeConfig}

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/hooks/cytoscapeData.ts
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/hooks/cytoscapeData.ts
@@ -68,14 +68,13 @@ export function useCytoscapeConfig(
     elements,
     stylesheet,
     layout: {
-      name: 'fcose',
+      name: 'cola',
       animate: false,
-      nodeSeparation: 500,
-      idealEdgeLength: function (edge) {
+      edgeLength: function (edge) {
         if (edge.data('score')) {
           return edge.data('score') + 500;
         }
-        return 500;
+        return 700;
       },
     },
     panningEnabled: true,

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/hooks/cytoscapeData.ts
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/hooks/cytoscapeData.ts
@@ -1,29 +1,21 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
-import {
-  Core,
-  EdgeDefinition,
-  NodeDefinition,
-  Stylesheet
-} from 'cytoscape';
+import { Core, EdgeDefinition, NodeDefinition, Stylesheet } from 'cytoscape';
 import { noop, orderBy } from 'lodash';
 
-import {
-  NodeDisplayType,
-  ProteinType
-} from 'ortho-client/utils/clusterGraph';
+import { NodeDisplayType, ProteinType } from 'ortho-client/utils/clusterGraph';
 import { addCytoscapeClasses } from 'ortho-client/utils/cytoscapeClasses';
 import {
   makePieStyles,
   makeEdgeData,
   makeHAlignClass,
   makeVAlignClass,
-  nodeEntryToCytoscapeData
+  nodeEntryToCytoscapeData,
 } from 'ortho-client/utils/cytoscapeData';
 import {
   EcNumberEntry,
   GroupLayout,
-  PfamDomainEntry
+  PfamDomainEntry,
 } from 'ortho-client/utils/groupLayout';
 import { TaxonUiMetadata } from 'ortho-client/utils/taxons';
 
@@ -32,8 +24,8 @@ const MAX_PIE_SLICES = 16;
 export type CytoscapeConfig = ReturnType<typeof useCytoscapeConfig>[0];
 
 interface CyEffectCallback {
-  (cy: Core): (void | (() => void | undefined));
-};
+  (cy: Core): void | (() => void | undefined);
+}
 
 export function useCytoscapeConfig(
   layout: GroupLayout,
@@ -45,7 +37,10 @@ export function useCytoscapeConfig(
   const ecNumberNPieSlices = Math.min(orderedEcNumbers.length, MAX_PIE_SLICES);
 
   const orderedPfamDomains = useOrderedPfamDomains(layout);
-  const pfamDomainNPieSlices = Math.min(orderedPfamDomains.length, MAX_PIE_SLICES);
+  const pfamDomainNPieSlices = Math.min(
+    orderedPfamDomains.length,
+    MAX_PIE_SLICES
+  );
 
   const nodes = useNodes(
     layout,
@@ -60,10 +55,7 @@ export function useCytoscapeConfig(
 
   const edges = useEdges(layout);
 
-  const elements = useMemo(
-    () => [ ...nodes, ...edges ],
-    [ nodes, edges ]
-  );
+  const elements = useMemo(() => [...nodes, ...edges], [nodes, edges]);
 
   const stylesheet = useStylesheet(
     ecNumberNPieSlices,
@@ -75,10 +67,17 @@ export function useCytoscapeConfig(
   const initialCytoscapeConfig = {
     elements,
     stylesheet,
-    layout: { name: 'fcose', 
-       animate: false,       
-       idealEdgeLength: function( edge ){ if(edge.data.score) {return edge.data.score + 500;} return 600; }
-       },
+    layout: {
+      name: 'fcose',
+      animate: false,
+      nodeSeparation: 500,
+      idealEdgeLength: function (edge) {
+        if (edge.data('score')) {
+          return edge.data('score') + 500;
+        }
+        return 500;
+      },
+    },
     panningEnabled: true,
     userPanningEnabled: true,
     zoom: 1,
@@ -86,7 +85,7 @@ export function useCytoscapeConfig(
     userZoomingEnabled: true,
     boxSelectionEnabled: false,
     autoungrabify: false,
-    autounselectify: true
+    autounselectify: true,
   };
 
   return useState(initialCytoscapeConfig);
@@ -97,34 +96,39 @@ export function useCyEffect(
   effect: CyEffectCallback,
   deps?: React.DependencyList
 ) {
-  useEffect(() => {
-    if (cyRef.current == null) {
-      return noop;
-    }
+  useEffect(
+    () => {
+      if (cyRef.current == null) {
+        return noop;
+      }
 
-    return effect(cyRef.current);
-  }, deps == null ? [ cyRef.current ] : [ cyRef.current, ...deps ]);
+      return effect(cyRef.current);
+    },
+    deps == null ? [cyRef.current] : [cyRef.current, ...deps]
+  );
 }
 
 function useOrderedEcNumbers(layout: GroupLayout) {
   return useMemo(
-    () => orderBy(
-      Object.values(layout.group.ecNumbers),
-      [ ecNumber => ecNumber.count, ecNumber => ecNumber.index ],
-      [ 'desc', 'asc' ]
-    ),
-    [ layout ]
+    () =>
+      orderBy(
+        Object.values(layout.group.ecNumbers),
+        [(ecNumber) => ecNumber.count, (ecNumber) => ecNumber.index],
+        ['desc', 'asc']
+      ),
+    [layout]
   );
 }
 
 function useOrderedPfamDomains(layout: GroupLayout) {
   return useMemo(
-    () => orderBy(
-      Object.values(layout.group.pfamDomains),
-      [ pfamDomain => pfamDomain.count, pfamDomain => pfamDomain.index ],
-      [ 'desc', 'asc' ]
-    ),
-    [ layout ]
+    () =>
+      orderBy(
+        Object.values(layout.group.pfamDomains),
+        [(pfamDomain) => pfamDomain.count, (pfamDomain) => pfamDomain.index],
+        ['desc', 'asc']
+      ),
+    [layout]
   );
 }
 
@@ -140,33 +144,25 @@ function useNodes(
 ): NodeDefinition[] {
   return useMemo(
     () =>
-      Object.values(layout.nodes).map(
-        nodeEntry =>
-          ({
-            group: 'nodes',
-            classes: addCytoscapeClasses(
-              undefined,
-              [
-                selectedNodeDisplayType,
-                makeHAlignClass(Number(nodeEntry.x), layout.size),
-                makeVAlignClass(Number(nodeEntry.y), layout.size)
-              ]
-            ),
-            data: (
-              nodeEntryToCytoscapeData(
-                nodeEntry,
-                layout,
-                corePeripheralMap,
-                taxonUiMetadata,
-                orderedEcNumbers,
-                ecNumberNPieSlices,
-                orderedPfamDomains,
-                pfamDomainNPieSlices
-              )
-            ),
-          })
-      ),
-      [ layout ]
+      Object.values(layout.nodes).map((nodeEntry) => ({
+        group: 'nodes',
+        classes: addCytoscapeClasses(undefined, [
+          selectedNodeDisplayType,
+          makeHAlignClass(Number(nodeEntry.x), layout.size),
+          makeVAlignClass(Number(nodeEntry.y), layout.size),
+        ]),
+        data: nodeEntryToCytoscapeData(
+          nodeEntry,
+          layout,
+          corePeripheralMap,
+          taxonUiMetadata,
+          orderedEcNumbers,
+          ecNumberNPieSlices,
+          orderedPfamDomains,
+          pfamDomainNPieSlices
+        ),
+      })),
+    [layout]
   );
 }
 
@@ -174,15 +170,16 @@ function useEdges(layout: GroupLayout): EdgeDefinition[] {
   return useMemo(
     () =>
       Object.entries(layout.edges)
-        .map(([ edgeId, edgeEntry ]) =>
-          ({
-            group: 'edges',
-            data: makeEdgeData(edgeId, edgeEntry),
-            selectable: false
-          }) as const
+        .map(
+          ([edgeId, edgeEntry]) =>
+            ({
+              group: 'edges',
+              data: makeEdgeData(edgeId, edgeEntry),
+              selectable: false,
+            } as const)
         )
         .sort((e1, e2) => e2.data.score - e1.data.score),
-    [ layout.edges ]
+    [layout.edges]
   );
 }
 
@@ -197,51 +194,51 @@ function useStylesheet(
       {
         selector: 'node',
         css: {
-          'shape': 'ellipse',
-          'width': 15,
-          'height': 15,
+          shape: 'ellipse',
+          width: 15,
+          height: 15,
           'border-color': 'black',
           'border-width': 1,
           'z-index-compare': 'manual',
-          'z-index': 2
-        }
+          'z-index': 2,
+        },
       },
       {
         selector: 'node.taxa',
         css: {
-          'width': 12,
-          'height': 12,
+          width: 12,
+          height: 12,
           'background-color': 'data(speciesColor)',
           'border-color': 'data(groupColor)',
-          'border-width': 4
-        }
+          'border-width': 4,
+        },
       },
       {
         selector: 'node.ec-numbers',
         css: {
           'background-color': 'white',
-          ...makePieStyles(ecNumberNPieSlices, 'ec')
-        }
+          ...makePieStyles(ecNumberNPieSlices, 'ec'),
+        },
       },
       {
         selector: 'node.pfam-domains',
         css: {
           'background-color': 'white',
-          ...makePieStyles(pfamDomainNPieSlices, 'pfam')
-        }
+          ...makePieStyles(pfamDomainNPieSlices, 'pfam'),
+        },
       },
       {
         selector: 'node.core-peripheral',
         css: {
-          'background-color': 'data(corePeripheralColor)'
-        }
+          'background-color': 'data(corePeripheralColor)',
+        },
       },
       {
         selector: 'node.highlighted',
         css: {
-          'label': 'data(id)',
-          'width': 23,
-          'height': 23,
+          label: 'data(id)',
+          width: 23,
+          height: 23,
           'text-outline-color': 'white',
           'text-outline-width': 2,
           'text-halign': 'right',
@@ -250,84 +247,84 @@ function useStylesheet(
           'text-margin-y': -6,
           'z-index': 4,
           'font-size': 15,
-          'font-weight': 'bold'
-        }
+          'font-weight': 'bold',
+        },
       },
       {
         selector: 'node.taxa.highlighted',
         css: {
-          'width': 20,
-          'height': 20
-        }
+          width: 20,
+          height: 20,
+        },
       },
       {
         selector: 'node.highlighted.left',
         css: {
-          'text-halign': 'left'
-        }
+          'text-halign': 'left',
+        },
       },
       {
         selector: 'node.highlighted.right',
         css: {
-          'text-halign': 'right'
-        }
+          'text-halign': 'right',
+        },
       },
       {
         selector: 'node.highlighted.top',
         css: {
           'text-valign': 'top',
-          'text-margin-y': 5
-        }
+          'text-margin-y': 5,
+        },
       },
       {
         selector: 'node.highlighted.bottom',
         css: {
           'text-valign': 'bottom',
-          'text-margin-y': -8
-        }
+          'text-margin-y': -8,
+        },
       },
       {
         selector: 'edge',
         css: {
           'curve-style': 'straight',
           'line-color': `mapData(score, ${maxEvalueExp}, ${minEvalueExp}, #e9e9e9, black)`,
-          'width': 1,
+          width: 1,
           'z-index-compare': 'manual',
-          'z-index': 1
-        }
+          'z-index': 1,
+        },
       },
       {
         selector: 'edge.highlighted',
         css: {
-          'width': 3,
-          'label': 'data(label)',
+          width: 3,
+          label: 'data(label)',
           'text-outline-color': 'white',
           'text-outline-width': 2,
           'z-index': 3,
           'font-size': 15,
-          'font-weight': 'bold'
-        }
+          'font-weight': 'bold',
+        },
       },
       {
         selector: 'edge.type-highlighted',
         css: {
-          'line-color': 'red'
-        }
+          'line-color': 'red',
+        },
       },
       {
         selector: 'edge.filtered-out',
         css: {
-          'display': 'none'
-        }
+          display: 'none',
+        },
       },
       {
         selector: 'edge.filtered-out.highlighted',
         css: {
           // FIXME: This is necessary to bypass an incorrect type definition
           // in @types/cytoscape; we should open a PR to DefinitelyTyped
-          'display': 'element' as any
-        }
-      }
+          display: 'element' as any,
+        },
+      },
     ],
     []
   );


### PR DESCRIPTION
Applies two commits from https://github.com/VEuPathDB/web-monorepo/pull/261 into a patch for the live ortho site.

Notes:
- this branch was made from `v1.0.16-patch.2` which was made from `v1.0.16-patch.1`
- picked only the two commits from the PR that were not merging main into the branch

Testing: 
- the cluster that was giving us headaches looks good! 

<img width="1036" alt="Screen Shot 2023-06-22 at 7 20 18 PM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/26509234-cefe-4aec-b063-177d14308405">
