### PR TITLE
Save organism param value and state across searches

### DIFF
--- a/packages/libs/multi-blast/src/lib/controllers/BlastQuestionController.tsx
+++ b/packages/libs/multi-blast/src/lib/controllers/BlastQuestionController.tsx
@@ -1,5 +1,5 @@
 import QuestionController, {
-  OwnProps as Props,
+  Props,
 } from '@veupathdb/wdk-client/lib/Controllers/QuestionController';
 
 export function BlastQuestionController(props: Props) {

--- a/packages/libs/preferred-organisms/src/lib/components/OrganismParam.tsx
+++ b/packages/libs/preferred-organisms/src/lib/components/OrganismParam.tsx
@@ -126,7 +126,7 @@ function TreeBoxOrganismEnumParam(
       renderNode,
       searchPredicate,
     }),
-    [renderNode, searchPredicate]
+    [maxSelectedCount, renderNode, searchPredicate]
   );
 
   return hasEmptyVocabularly(paramWithPrunedVocab) ? (

--- a/packages/libs/wdk-client/src/Actions/QuestionActions.ts
+++ b/packages/libs/wdk-client/src/Actions/QuestionActions.ts
@@ -45,17 +45,13 @@ export interface UpdateActiveQuestionAction {
     initialParamData?: Record<string, string>;
     stepId: number | undefined;
     submissionMetadata?: SubmissionMetadata;
+    globalParamMapping?: Record<string, string>;
   }>;
 }
 
-export function updateActiveQuestion(payload: {
-  searchName: string;
-  autoRun: boolean;
-  prepopulateWithLastParamValues: boolean;
-  initialParamData?: Record<string, string>;
-  stepId: number | undefined;
-  submissionMetadata?: SubmissionMetadata;
-}): UpdateActiveQuestionAction {
+export function updateActiveQuestion(
+  payload: UpdateActiveQuestionAction['payload']
+): UpdateActiveQuestionAction {
   return {
     type: UPDATE_ACTIVE_QUESTION,
     payload,

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/component-wrappers/QuestionController.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/component-wrappers/QuestionController.tsx
@@ -1,0 +1,41 @@
+import React, { useMemo } from 'react';
+import { DerivedProps } from '@veupathdb/wdk-client/lib/Controllers/QuestionController';
+/**
+ * Wrap QuestionController to provide an initial value for an organism parameter
+ */
+
+import { ComponentType } from 'react';
+import { isOrganismParam } from '@veupathdb/preferred-organisms/lib/components/OrganismParam';
+import { useWdkServiceWithRefresh } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
+import { GlobalParamMapping } from '@veupathdb/wdk-client/lib/Utils/ParamValueStore';
+
+export function QuestionController(
+  WrappedComponent: ComponentType<DerivedProps>
+) {
+  return function WrappedQuestionController(props: DerivedProps) {
+    const question = useWdkServiceWithRefresh(
+      (s) => s.getQuestionAndParameters(props.searchName),
+      [props.searchName]
+    );
+
+    const organismParam = question?.parameters.find((param) =>
+      isOrganismParam(param)
+    );
+
+    const globalParamMapping = useMemo((): GlobalParamMapping | undefined => {
+      if (organismParam) {
+        return {
+          [organismParam.name]: 'globalOrgnamismParamValue',
+        };
+      }
+      return undefined;
+    }, [organismParam]);
+
+    // Return null to prevent the search loading without the correct globalParamMapping
+    if (question == null) return null;
+
+    return (
+      <WrappedComponent {...props} globalParamMapping={globalParamMapping} />
+    );
+  };
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
@@ -524,3 +524,5 @@ export function Page() {
 export { SiteSearchInput } from './component-wrappers/SiteSearchInput';
 
 export { AnswerController } from './component-wrappers/AnswerController';
+
+export { QuestionController } from './component-wrappers/QuestionController';

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -18,7 +18,7 @@ import { TabbedDisplay } from '@veupathdb/coreui';
 import { CommonResultTable as InternalGeneDatasetTable } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
 import QuestionController, {
   useSetSearchDocumentTitle,
-  OwnProps as Props,
+  Props,
 } from '@veupathdb/wdk-client/lib/Controllers/QuestionController';
 import { RootState } from '@veupathdb/wdk-client/lib/Core/State/Types';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';


### PR DESCRIPTION
### Description

This PR adds functionality that saves and reuses the value of organism parameters across searches.

### TODO

- [x] Provide a mechanism to declare certain parameters as having a shared cache key (`GlobalParamMapping`)
- [x] Declare a shared cache key for organism params (`GlobalParamMapping`)
- [ ] ~Save tree state for organism param~ _Created an [issue](https://github.com/VEuPathDB/web-monorepo/issues/321)_

### Testing
This can be tested on https://dfalke-b.vectorbase.org