### PR TITLE
activate timeline plot

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -193,14 +193,6 @@ export const lineplotVisualization = createVisualizationPlugin({
   createDefaultConfig: createDefaultConfig,
 });
 
-// define timelineplotVisualization for changing SVG icon for timeline plot
-export const timelineplotVisualization = createVisualizationPlugin({
-  //TODO: need TimelineSVG icon
-  selectorIcon: LineSVG,
-  fullscreenComponent: LineplotViz,
-  createDefaultConfig: createDefaultConfig,
-});
-
 // Display names to internal names
 const valueSpecLookup: Record<
   string,

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -651,13 +651,13 @@ function LineplotViz(props: VisualizationProps<Options>) {
     [options, providedOverlayVariable, providedOverlayVariableDescriptor]
   );
 
-  // define showMarginalHistogram
-  const showMarginalHistogram = options?.showMarginalHistogram ?? false;
   // check banner condition
   const showIndependentAxisBanner =
     vizConfig.independentAxisLogScale && vizConfig.useBinning;
   const showDependentAxisBanner =
     vizConfig.dependentAxisLogScale && vizConfig.showErrorBars;
+
+  const showMarginalHistogram = options?.showMarginalHistogram ?? false;
 
   const data = usePromise(
     useCallback(async (): Promise<LinePlotDataWithCoverage | undefined> => {

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -193,6 +193,14 @@ export const lineplotVisualization = createVisualizationPlugin({
   createDefaultConfig: createDefaultConfig,
 });
 
+// define timelineplotVisualization for changing SVG icon for timeline plot
+export const timelineplotVisualization = createVisualizationPlugin({
+  //TODO: need TimelineSVG icon
+  selectorIcon: LineSVG,
+  fullscreenComponent: LineplotViz,
+  createDefaultConfig: createDefaultConfig,
+});
+
 // Display names to internal names
 const valueSpecLookup: Record<
   string,

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -14,7 +14,10 @@ import { VisualizationPlugin } from '../../../core/components/visualizations/Vis
 import { histogramVisualization } from '../../../core/components/visualizations/implementations/HistogramVisualization';
 import { contTableVisualization } from '../../../core/components/visualizations/implementations/MosaicVisualization';
 import { scatterplotVisualization } from '../../../core/components/visualizations/implementations/ScatterplotVisualization';
-import { lineplotVisualization } from '../../../core/components/visualizations/implementations/LineplotVisualization';
+import {
+  lineplotVisualization,
+  timelineplotVisualization,
+} from '../../../core/components/visualizations/implementations/LineplotVisualization';
 import { barplotVisualization } from '../../../core/components/visualizations/implementations/BarplotVisualization';
 import { boxplotVisualization } from '../../../core/components/visualizations/implementations/BoxplotVisualization';
 import { BinDefinitions, OverlayConfig } from '../../../core';
@@ -35,15 +38,14 @@ export function useStandaloneVizPlugins({
 }: Props): Record<string, ComputationPlugin> {
   return useMemo(() => {
     function vizWithOptions(
-      visualization: VisualizationPlugin<StandaloneVizOptions>
+      visualization: VisualizationPlugin<StandaloneVizOptions>,
+      // optional showMarginalHistogram prop: set default showMarginalHistogram to be false
+      showMarginalHistogram = false
     ) {
       return visualization.withOptions({
         hideFacetInputs: true, // will also enable table-only mode for mosaic
         hideShowMissingnessToggle: true,
-        // TODO: need to distinguish lineplot from lineplot with marginal histogram?
-        // perhaps need to make another function only for lineplot with marginal histogram
-        // or define xxx.withOptions({}) directly at corresponding visualizationPlugins below
-        showMarginalHistogram: false,
+        showMarginalHistogram: showMarginalHistogram,
         layoutComponent: FloatingLayout,
         // why are we providing three functions to access the properties of
         // one object? Because in the pre-SAM world, getOverlayVariable was already
@@ -106,6 +108,12 @@ export function useStandaloneVizPlugins({
           ),
           lineplot: vizWithCustomizedGetRequest(
             vizWithOptions(lineplotVisualization),
+            lineplotRequest
+          ),
+          // activate timeplot Viz
+          timeseries: vizWithCustomizedGetRequest(
+            // use timelineplotVisualization and set showMarginalHistogram to be true
+            vizWithOptions(timelineplotVisualization, true),
             lineplotRequest
           ),
         },

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -14,10 +14,7 @@ import { VisualizationPlugin } from '../../../core/components/visualizations/Vis
 import { histogramVisualization } from '../../../core/components/visualizations/implementations/HistogramVisualization';
 import { contTableVisualization } from '../../../core/components/visualizations/implementations/MosaicVisualization';
 import { scatterplotVisualization } from '../../../core/components/visualizations/implementations/ScatterplotVisualization';
-import {
-  lineplotVisualization,
-  timelineplotVisualization,
-} from '../../../core/components/visualizations/implementations/LineplotVisualization';
+import { lineplotVisualization } from '../../../core/components/visualizations/implementations/LineplotVisualization';
 import { barplotVisualization } from '../../../core/components/visualizations/implementations/BarplotVisualization';
 import { boxplotVisualization } from '../../../core/components/visualizations/implementations/BoxplotVisualization';
 import { BinDefinitions, OverlayConfig } from '../../../core';
@@ -26,6 +23,8 @@ import { barplotRequest } from './plugins/barplot';
 import { lineplotRequest } from './plugins/lineplot';
 import { histogramRequest } from './plugins/histogram';
 import { scatterplotRequest } from './plugins/scatterplot';
+//TO DO import timeline SVGIcon
+import LineSVG from '../../../core/components/visualizations/implementations/selectorIcons/LineSVG';
 
 interface Props {
   selectedOverlayConfig?: OverlayConfig;
@@ -38,14 +37,11 @@ export function useStandaloneVizPlugins({
 }: Props): Record<string, ComputationPlugin> {
   return useMemo(() => {
     function vizWithOptions(
-      visualization: VisualizationPlugin<StandaloneVizOptions>,
-      // optional showMarginalHistogram prop: set default showMarginalHistogram to be false
-      showMarginalHistogram = false
+      visualization: VisualizationPlugin<StandaloneVizOptions>
     ) {
       return visualization.withOptions({
         hideFacetInputs: true, // will also enable table-only mode for mosaic
         hideShowMissingnessToggle: true,
-        showMarginalHistogram: showMarginalHistogram,
         layoutComponent: FloatingLayout,
         // why are we providing three functions to access the properties of
         // one object? Because in the pre-SAM world, getOverlayVariable was already
@@ -110,10 +106,17 @@ export function useStandaloneVizPlugins({
             vizWithOptions(lineplotVisualization),
             lineplotRequest
           ),
-          // activate timeplot Viz
+          // activate timeline Viz
           timeseries: vizWithCustomizedGetRequest(
-            // use timelineplotVisualization and set showMarginalHistogram to be true
-            vizWithOptions(timelineplotVisualization, true),
+            vizWithOptions(
+              vizWithOptions(
+                lineplotVisualization
+                  .withOptions({
+                    showMarginalHistogram: true,
+                  })
+                  .withSelectorIcon(LineSVG)
+              )
+            ),
             lineplotRequest
           ),
         },

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -109,13 +109,11 @@ export function useStandaloneVizPlugins({
           // activate timeline Viz
           timeseries: vizWithCustomizedGetRequest(
             vizWithOptions(
-              vizWithOptions(
-                lineplotVisualization
-                  .withOptions({
-                    showMarginalHistogram: true,
-                  })
-                  .withSelectorIcon(LineSVG)
-              )
+              lineplotVisualization
+                .withOptions({
+                  showMarginalHistogram: true,
+                })
+                .withSelectorIcon(LineSVG)
             ),
             lineplotRequest
           ),


### PR DESCRIPTION
This will activate timeline plot by setting timeline plugin. In this initial PR, it is activated for SAM's X-Y Relationship as shown in the screenshot below. 

![sam-timeline00](https://github.com/VEuPathDB/web-monorepo/assets/12802305/c4ea3346-89d3-4084-9ba1-a53a97b5a105)

![sam-timeline01](https://github.com/VEuPathDB/web-monorepo/assets/12802305/74f9fadf-402c-4f3e-bc2e-56265f5473c3)
