### PR TITLE
Fix filter param initialization in revise form

### DIFF
--- a/packages/libs/wdk-client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
+++ b/packages/libs/wdk-client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
@@ -139,6 +139,8 @@ const observeInitialParamData: Observer = (action$, state$, services) => {
           } as Filter);
         }
       }
+      // If filters is empty, assume there is no initialParamData for this param.
+      if (filters.length === 0) return EMPTY;
       return of(
         updateParamValue({
           paramValue: JSON.stringify({ filters }),


### PR DESCRIPTION
closes https://redmine.apidb.org/issues/51399

This PR fixes a bug where the filter param clobbers the parameter's value on revise.