### PR TITLE
Fix problem with filtered date variables breaking visualization axis variables

### DIFF
--- a/packages/libs/eda/src/lib/core/hooks/workspace.ts
+++ b/packages/libs/eda/src/lib/core/hooks/workspace.ts
@@ -130,11 +130,11 @@ export function useStudyEntities(filters?: Filter[]) {
                             min:
                               filter.type === 'numberRange'
                                 ? filter.min
-                                : filter.min.split('T00:00:00Z')[0],
+                                : filter.min.split(/T00:00:00(?:\.000)?Z?/)[0],
                             max:
                               filter.type === 'numberRange'
                                 ? filter.max
-                                : filter.max.split('T00:00:00Z')[0],
+                                : filter.max.split(/T00:00:00(?:\.000)?Z?/)[0],
                           }
                         : undefined;
 


### PR DESCRIPTION
Fixes #324 

Turned out to be relatively simple.

In our "augmented study metadata" somehow some dates are appended `T00:00:00Z` and others `T00:00:00.000Z`. I'm not sure why. But I thought it was wise to handle both. I made the `Z` optional while I was at it.