### PR TITLE
Ensure the correct searchName and recordClassName are used

### DIFF
--- a/packages/libs/wdk-client/src/Controllers/QuestionController.tsx
+++ b/packages/libs/wdk-client/src/Controllers/QuestionController.tsx
@@ -377,9 +377,9 @@ const enhance = connect<
   (stateProps, dispatchProps, ownProps) => ({
     ...stateProps,
     ...dispatchProps,
+    ...omit(ownProps, ['question', 'recordClass']),
     searchName: ownProps.question,
     recordClassName: ownProps.recordClass,
-    ...omit(ownProps, ['question', 'recordClass']),
   })
 );
 


### PR DESCRIPTION
This PR fixes an issue where search forms are not loading on internal dataset pages (e.g., RNA Seq)