### PR TITLE
add maximum width to viz picker title

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
+++ b/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
@@ -165,6 +165,7 @@
       font-weight: 500;
       text-align: center;
       font-size: 1.2em;
+      max-width: 200px;
     }
   }
   &-FullScreenContainer {


### PR DESCRIPTION
With https://github.com/VEuPathDB/EdaDataService/pull/292, resolves data service [issue 288](https://github.com/VEuPathDB/EdaDataService/issues/288).

Goal of 288: Change beta div scatter name to Dimensional reduction scatter plot. The data service PR changes the name, but then the viz picker title is super long. This PR adds a max width so that the name wraps. 

An alternative route was to use the same strategy as the mosaic and 2x2 plots, where we break on ', '. But it doesn't really make sense to have a comma in the Dimensional reduction scatter plot name when it's all written out (like on the visualization page itself). 
