### PR TITLE
Remove redux middleware that is no longer needed

### DIFF
--- a/packages/libs/eda/src/index.tsx
+++ b/packages/libs/eda/src/index.tsx
@@ -39,7 +39,6 @@ import { wrapWdkDependencies } from '@veupathdb/study-data-access/lib/shared/wra
 import {
   disableRestriction,
   enableRestriction,
-  reduxMiddleware,
 } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUtils';
 
 import { edaEndpoint, wdkEndpoint, rootElement, rootUrl } from './constants';
@@ -224,7 +223,6 @@ initialize({
     },
   }),
   endpoint: wdkEndpoint,
-  additionalMiddleware: [reduxMiddleware],
 } as any);
 
 // If you want to start measuring performance in your app, pass a function

--- a/packages/libs/study-data-access/src/data-restriction/DataRestrictionUtils.js
+++ b/packages/libs/study-data-access/src/data-restriction/DataRestrictionUtils.js
@@ -1,30 +1,28 @@
-import { get, isPlainObject } from 'lodash';
 import React from 'react';
-import { BasketActions, ResultPanelActions, ResultTableSummaryViewActions } from '@veupathdb/wdk-client/lib/Actions';
-import {getResultTypeDetails} from '@veupathdb/wdk-client/lib/Utils/WdkResult';
 
-import { getStudyId, getStudyPolicyUrl, getStudyRequestNeedsApproval } from '../shared/studies';
-import { isUserApprovedForAction, isUserFullyApprovedForStudy } from '../study-access/permission';
-
-import { attemptAction } from './DataRestrictionActionCreators';
 import {
-  Action,
-  strictActions,
-} from './DataRestrictionUiActions';
+  getStudyId,
+  getStudyPolicyUrl,
+  getStudyRequestNeedsApproval,
+} from '../shared/studies';
+import {
+  isUserApprovedForAction,
+  isUserFullyApprovedForStudy,
+} from '../study-access/permission';
+
+import { Action, strictActions } from './DataRestrictionUiActions';
 
 // Getters!   =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
-export function getPolicyUrl (study = {}) {
-  return !study
-    ? null
-    : getStudyPolicyUrl(study);
+export function getPolicyUrl(study = {}) {
+  return !study ? null : getStudyPolicyUrl(study);
 }
 
-export function getRequestNeedsApproval (study = {}) {
+export function getRequestNeedsApproval(study = {}) {
   return getStudyRequestNeedsApproval(study);
 }
 
-export function getActionVerb (action) {
+export function getActionVerb(action) {
   if (typeof action !== 'string') return null;
   switch (action) {
     case Action.search:
@@ -43,28 +41,33 @@ export function getActionVerb (action) {
     case Action.download:
       return 'download data';
     case Action.basket:
-      return 'add to your basket'
-    default: 
+      return 'add to your basket';
+    default:
       return action;
   }
 }
 
-export function getRequirement ({ action, permissions, study, user }) {
+export function getRequirement({ action, permissions, study, user }) {
   //if (actionRequiresLogin({ action, study })) return 'login or create an account';
-  if ( getRequestNeedsApproval(study)=="0" ) return 'submit an access request';
-  if (actionRequiresApproval({ action, permissions, study, user })) return 'acquire research approval';
+  if (getRequestNeedsApproval(study) == '0') return 'submit an access request';
+  if (actionRequiresApproval({ action, permissions, study, user }))
+    return 'acquire research approval';
   return 'contact us';
 }
 
-export function getRestrictionMessage ({ action, permissions, study, user }) {
+export function getRestrictionMessage({ action, permissions, study, user }) {
   const intention = getActionVerb(action);
   const requirement = getRequirement({ action, permissions, study, user });
-  return <span>Please <b>{requirement}</b> in order to {intention}.</span>;
+  return (
+    <span>
+      Please <b>{requirement}</b> in order to {intention}.
+    </span>
+  );
 }
 
 // CHECKERS! =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-export function isAllowedAccess ({ permissions, action, study }) {
+export function isAllowedAccess({ permissions, action, study }) {
   const id = getStudyId(study);
   if (sessionStorage.getItem('restriction_override') === 'true') return true;
   if (isUserApprovedForAction(permissions, id, action)) return true;
@@ -75,7 +78,7 @@ export function isAllowedAccess ({ permissions, action, study }) {
 // the UI in (1) home page study card, (2) study menu, (3) study record page is different when
 // - the study.access is prerelease
 // - the user doesnt have access
-export function isPrereleaseStudy (access, studyId, permissions) {
+export function isPrereleaseStudy(access, studyId, permissions) {
   return (
     access === 'prerelease' &&
     !isUserFullyApprovedForStudy(permissions, studyId)
@@ -83,133 +86,34 @@ export function isPrereleaseStudy (access, studyId, permissions) {
 }
 
 // we will request the user to request approval if explicit approval needed (guest or not)
-export function actionRequiresApproval ({ action, permissions, study, user }) {
+export function actionRequiresApproval({ action, permissions, study, user }) {
   const datasetId = getStudyId(study);
 
-  return isUserApprovedForAction(
-    permissions,
-    datasetId,
-    action
-  ) === false;
+  return isUserApprovedForAction(permissions, datasetId, action) === false;
 }
 
-export function disableRestriction () {
+export function disableRestriction() {
   sessionStorage.setItem('restriction_override', true);
 }
 window._disableRestriction = disableRestriction;
 
-export function enableRestriction () {
+export function enableRestriction() {
   sessionStorage.removeItem('restriction_override');
 }
 window._enableRestriction = enableRestriction;
 
-export function isActionStrict (action) {
+export function isActionStrict(action) {
   return strictActions.has(action);
 }
 
-export function getIdFromRecordClassName (recordClassName) {
+export function getIdFromRecordClassName(recordClassName) {
   if (typeof recordClassName !== 'string') return null;
-  if (recordClassName.length > 13) recordClassName = recordClassName.slice(0, 13);
+  if (recordClassName.length > 13)
+    recordClassName = recordClassName.slice(0, 13);
   const result = recordClassName.match(/^DS_[^_]+/g);
-  return result === null
-    ? null
-    : result[0];
+  return result === null ? null : result[0];
 }
 
 export function isStudyRecordClass(recordClass) {
   return recordClass == null || recordClass.fullName.startsWith('DS_');
-}
-
-
-// Redux Middleware
-// ----------------
-
-/**
- * Redux middleware for applying restrictions to specific redux actions.
- */
-export const reduxMiddleware = store => next => action => {
-  if (!isPlainObject(action) || action.type == null) return next(action);
-  const restrictedAction = getDataRestrictionActionAndRecordClass(
-    store.getState(),
-    action,
-    (dataRestrictionAction, recordClassName) =>
-      attemptAction(dataRestrictionAction,{
-        studyId: getIdFromRecordClassName(recordClassName),
-        onAllow: () => next(action)
-      })
-  );
-  return restrictedAction == null ? next(action) : store.dispatch(restrictedAction);
-}
-
-/**
- * Checks if a redux action should be restricted, and if so, calls `callback`
- * with the restriction Action, and the record class name associated with the
- * action.
- * 
- * Return null to indicate that the redux action does not need to be
- * restricted.
- */
-function getDataRestrictionActionAndRecordClass(state, action, callback) {
-  if (!isPlainObject(action)) return null;
-  
-  switch(action.type || '') {
-    case ResultPanelActions.openTabListing.type:
-      return getRecordClassNameByResultType(action.payload.resultType, recordClassName =>
-        callback(Action.results, recordClassName));
-
-    case 'step-analysis/select-tab':
-    case 'step-analysis/create-new-tab': {
-      return  getRecordClassNameByStepId(state.stepAnalysis.stepId, recordClassName =>
-        callback(Action.analysis, recordClassName));
-    }
-
-    case BasketActions.requestUpdateBasket.type:
-      return callback(Action.basket, action.payload.recordClassName);
-
-    case BasketActions.requestAddStepToBasket.type:
-      return getRecordClassNameByStepId(action.payload.stepId, recordClassName =>
-        callback(Action.basket, recordClassName));
-
-    case ResultTableSummaryViewActions.requestPageSizeUpdate.type:
-    case ResultTableSummaryViewActions.requestSortingUpdate.type:
-      return getRecordClassNameByResultType(getResultTypeByViewId(action.payload.viewId, state), recordClassName =>
-        callback(Action.paginate, recordClassName));
-
-    case ResultTableSummaryViewActions.viewPageNumber.type:
-      return action.payload.page === 1
-        ? null
-        : getRecordClassNameByResultType(getResultTypeByViewId(action.payload.viewId, state), recordClassName =>
-            callback(Action.paginate, recordClassName));
-
-    default:
-        return null;
-  }
-}
-
-function getResultTypeByViewId(viewId, state) {
-  return get(state, ['resultTableSummaryView', viewId, 'resultType']);
-}
-
-function getRecordClassNameByStepId(stepId, callback) {
-  return async function run({ wdkService }) {
-    try {
-      const step = await wdkService.findStep(stepId);
-      return callback(step.recordClassName);
-    }
-    catch(error) {
-      return callback(null);
-    }
-  };
-}
-
-function getRecordClassNameByResultType(resultType, callback) {
-  return async function run({ wdkService }) {
-    try {
-      const { recordClassName } = await getResultTypeDetails(wdkService, resultType)
-      return callback(recordClassName);
-    }
-    catch(error) {
-      return callback(null);
-    }
-  };
 }

--- a/packages/sites/clinepi-site/webapp/js/client/main.js
+++ b/packages/sites/clinepi-site/webapp/js/client/main.js
@@ -1,6 +1,5 @@
 import { partial } from 'lodash';
 
-import { reduxMiddleware } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUtils';
 import { wrapWdkDependencies } from '@veupathdb/study-data-access/lib/shared/wrapWdkDependencies';
 
 import { initialize } from '@veupathdb/web-common/lib/bootstrap';
@@ -21,5 +20,4 @@ initialize({
   wrapWdkService,
   wrapStoreModules,
   wrapRoutes,
-  additionalMiddleware: [ reduxMiddleware ]
 });

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/bootstrap.js
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/bootstrap.js
@@ -8,9 +8,7 @@ import wrapStoreModules from './wrapStoreModules';
 import { wrapWdkService } from './wrapWdkService';
 import pluginConfig from './pluginConfig';
 
-import { reduxMiddleware } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUtils';
 import { wrapWdkDependencies } from '@veupathdb/study-data-access/lib/shared/wrapWdkDependencies';
-
 
 // import CSS files
 import '@veupathdb/web-common/lib/styles/client.scss';
@@ -19,13 +17,15 @@ import 'site/css/AllApiSites.css';
 import 'site/wdkCustomization/css/client.scss';
 
 // Initialize the application.
-export const initialize =  initializeWdk => initializeEbrc({
-  initializeWdk,
-  componentWrappers,
-  wrapRoutes,
-  wrapStoreModules,
-  wrapWdkService,
-  wrapWdkDependencies: useEda ? partial(wrapWdkDependencies, edaServiceUrl) : undefined,
-  pluginConfig,
-  additionalMiddleware: useEda ? [ reduxMiddleware ] : undefined,
-})
+export const initialize = (initializeWdk) =>
+  initializeEbrc({
+    initializeWdk,
+    componentWrappers,
+    wrapRoutes,
+    wrapStoreModules,
+    wrapWdkService,
+    wrapWdkDependencies: useEda
+      ? partial(wrapWdkDependencies, edaServiceUrl)
+      : undefined,
+    pluginConfig,
+  });


### PR DESCRIPTION
This PR remove redux middleware used for data restrictions. Need to make sure we won't need this in the future, before merging.

This was requested by JB (on slack) when qa.vectorbase , eda-enabled, had eda-rbld missing some tables needed for the permissions endpoint  and searches were breaking.  