### PR TITLE
Add a "Read more" link to tall cells in InternalDataset pages

### DIFF
--- a/packages/libs/wdk-client/src/Components/Mesa/Ui/DataCell.jsx
+++ b/packages/libs/wdk-client/src/Components/Mesa/Ui/DataCell.jsx
@@ -20,7 +20,7 @@ class DataCell extends React.PureComponent {
     const cellProps = { key, value, row, column, rowIndex, columnIndex };
 
     if ('renderCell' in column) {
-      return column.renderCell(cellProps);
+      return <column.renderCell {...cellProps} />;
     }
 
     if (!column.type) return Templates.textCell(cellProps);
@@ -28,16 +28,17 @@ class DataCell extends React.PureComponent {
 
     switch (column.type.toLowerCase()) {
       case 'wdklink':
-        return Templates.wdkLinkCell(cellProps);
+        return <Templates.wdkLinkCell {...cellProps} />;
       case 'link':
-        return Templates.linkCell(cellProps);
+        return <Templates.linkCell {...cellProps} />;
       case 'number':
-        return Templates.numberCell(cellProps);
+        return <Templates.numberCell {...cellProps} />;
       case 'html':
-        return Templates[inline ? 'textCell' : 'htmlCell'](cellProps);
+        const Component = Templates[inline ? 'textCell' : 'htmlCell'];
+        return <Component {...cellProps} />;
       case 'text':
       default:
-        return Templates.textCell(cellProps);
+        return <Templates.textCell {...cellProps} />;
     }
   }
 

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
@@ -2,7 +2,7 @@
   margin: auto;
   max-width: 81.25rem; // same max-width as .wdk-QuestionForm
 
-  >.wdk-QuestionFormQuestionHeader {
+  > .wdk-QuestionFormQuestionHeader {
     position: inherit;
   }
 
@@ -43,10 +43,17 @@
   }
 
   tr.DataRow {
+    .DataCell:nth-child(1) {
+      position: relative;
+      > button {
+        position: absolute;
+        top: 1ex;
+        right: 1em;
+        font-weight: bold;
+      }
+    }
     .DataCell:nth-child(3) {
-      display: flex;
-      justify-content: center;
-
+      text-align: center;
       div {
         display: inline-block;
         width: 36px;
@@ -78,7 +85,7 @@
     background-image: -moz-linear-gradient(to bottom, #ffffff, #e6e6e6);
     background-image: -o-linear-gradient(to bottom, #ffffff, #e6e6e6);
     background-image: -webkit-linear-gradient(top, #ffffff, #e6e6e6);
-    filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr=#ffffff, endColorStr=#e6e6e6)";
+    filter: 'progid:DXImageTransform.Microsoft.Gradient(startColorStr=#ffffff, endColorStr=#e6e6e6)';
     background-repeat: repeat-x;
 
     &:hover,
@@ -96,7 +103,7 @@
     background-image: -moz-linear-gradient(to bottom, #5bc0de, #2f96b4);
     background-image: -o-linear-gradient(to bottom, #5bc0de, #2f96b4);
     background-image: -webkit-linear-gradient(top, #5bc0de, #2f96b4);
-    -ms-filter: "progid:DXImageTransform.Microsoft.Gradient(startColorStr=#5bc0de, endColorStr=#2f96b4)";
+    -ms-filter: 'progid:DXImageTransform.Microsoft.Gradient(startColorStr=#5bc0de, endColorStr=#2f96b4)';
   }
 
   .bttn:active,

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useRef,
 } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation, useHistory } from 'react-router';
@@ -16,6 +17,7 @@ import {
 } from '@veupathdb/wdk-client/lib/Components';
 import { TabbedDisplay } from '@veupathdb/coreui';
 import { CommonResultTable as InternalGeneDatasetTable } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
+import { useIsRefOverflowingVertically } from '@veupathdb/wdk-client/lib/Hooks/Overflow';
 import QuestionController, {
   useSetSearchDocumentTitle,
   Props,
@@ -55,6 +57,7 @@ import { isPreferredDataset } from '../../util/preferredOrganisms';
 import { PageLoading } from '../common/PageLoading';
 
 import './InternalGeneDataset.scss';
+import { CSSProperties } from '@material-ui/core/styles/withStyles';
 
 const cx = makeClassNameHelper('wdk-InternalGeneDatasetForm');
 
@@ -312,10 +315,10 @@ function InternalGeneDatasetContent(props: Props) {
           {
             key: 'organism_prefix',
             name: 'Organism',
-            type: 'html',
             sortable: true,
             sortType: 'htmlText',
             helpText: 'Organism data is aligned to',
+            renderCell: OrganismCell,
           },
           {
             key: 'display_name',
@@ -820,4 +823,31 @@ function makeLinkClickHandler(
       setSelectedSearch(categorySearchName);
     }
   };
+}
+
+function OrganismCell(props: { value: string }) {
+  const containerRef = useRef<HTMLElement>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const maxHeight: CSSProperties['maxHeight'] = isExpanded
+    ? 'fit-content'
+    : '2em';
+  const isOverflowingV = useIsRefOverflowingVertically(containerRef);
+  return (
+    <>
+      {safeHtml(
+        props.value,
+        { ref: containerRef, style: { maxHeight, overflow: 'hidden' } },
+        'div'
+      )}
+      {isOverflowingV && (
+        <button
+          type="button"
+          className="link"
+          onClick={() => setIsExpanded((v) => !v)}
+        >
+          {isExpanded ? 'Read less' : 'Read more'}
+        </button>
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
### Description

Fixes r51417

This PR includes

- Add "Read more/less" button to overflowing Organism cells
- Removes `display: flex` from the searches table column cells
- Uses Mesa cell renderers as React Components

### Screenshots

**Collapsed**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/1859288b-0685-4cf7-b8e0-66bd46030cbb)

**Expanded**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/894ada58-ef7c-4e7a-a7f2-a197f5821349)
