### PR TITLE
plot resize with draggable panel

### DIFF
--- a/packages/libs/components/src/stories/plots/Barplot.stories.tsx
+++ b/packages/libs/components/src/stories/plots/Barplot.stories.tsx
@@ -6,6 +6,9 @@ import FacetedBarplot from '../../plots/facetedPlots/FacetedBarplot';
 import AxisRangeControl from '../../components/plotControls/AxisRangeControl';
 import { NumberRange, NumberOrDateRange } from '../../types/general';
 import { Toggle } from '@veupathdb/coreui';
+import DraggablePanel, {
+  HeightAndWidthInPixels,
+} from '@veupathdb/coreui/lib/components/containers/DraggablePanel';
 
 export default {
   title: 'Plots/Barplot',
@@ -184,4 +187,48 @@ LogScale.args = {
     height: '450px',
     width: '750px',
   },
+};
+
+// demo plot resize with draggable panel
+export const PlotResizeWithDraggablePanel: Story<BarplotProps> = (args) => {
+  const panelTitle = 'Panel 1';
+  const draggablePanelHeight = 600;
+  const draggablePanelWidth = 900;
+
+  const [panelDimension, setPanelDimension] = useState<HeightAndWidthInPixels>({
+    height: draggablePanelHeight,
+    width: draggablePanelWidth,
+  });
+
+  return (
+    <DraggablePanel
+      defaultPosition={{ x: 200, y: 200 }}
+      confineToParentContainer
+      key={panelTitle}
+      isOpen
+      panelTitle={panelTitle}
+      showPanelTitle={true}
+      styleOverrides={{
+        resize: 'both',
+      }}
+      onPanelResize={(dimensions: HeightAndWidthInPixels) => {
+        setPanelDimension(dimensions);
+      }}
+    >
+      <Barplot
+        data={dataSet}
+        dependentAxisLabel={'Awesomeness'}
+        independentAxisLabel={'Animal'}
+        displayLegend={false}
+        containerStyles={{
+          // perhaps plot height may be set to be proportional to to plot width
+          // as mostly resize invloves the change of width
+          // Otherwise, if DraggablePanel has other elements like InputVariables, Plot controls,
+          // then, height should substract heights of those elements to be better represented
+          height: panelDimension.height,
+          width: panelDimension.width,
+        }}
+      />
+    </DraggablePanel>
+  );
 };

--- a/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
+++ b/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode, useEffect, useState } from 'react';
+import { CSSProperties, ReactNode, useEffect, useState, useMemo } from 'react';
 import Draggable, { DraggableEvent, DraggableData } from 'react-draggable';
 import { css } from '@emotion/react';
 import useResizeObserver from 'use-resize-observer';
@@ -102,6 +102,15 @@ export default function DraggablePanel({
     }
   }
 
+  // convert rem to px
+  const dragHandleHeightValue = 2;
+  const dragHandleHeight = useMemo(() => {
+    return (
+      dragHandleHeightValue *
+      parseFloat(getComputedStyle(document.documentElement).fontSize)
+    );
+  }, []);
+
   const { ref, height, width } = useResizeObserver();
 
   useEffect(
@@ -109,11 +118,15 @@ export default function DraggablePanel({
       if (!onPanelResize || !height || !width) return;
 
       onPanelResize({
-        height: height,
+        // Note: since height from useResizeObserver includes dragHandle's height, 2rem,
+        // dragHandle's height should be substracted from height to compute main panel size
+        // without this, the use of useResizeObserver's height may lead to infinite loop
+        // when changing plot size inside the pannel
+        height: height - dragHandleHeight,
         width: width,
       });
     },
-    [height, width, onPanelResize]
+    [height, width]
   );
 
   const finalPosition = confineToParentContainer
@@ -162,7 +175,9 @@ export default function DraggablePanel({
             background: ${theme?.palette?.primary?.hue[100] ?? gray[100]};
             cursor: ${isDragging ? 'grabbing' : 'grab'};
             display: flex;
-            height: 2rem;
+            height: ${dragHandleHeightValue != null
+              ? dragHandleHeightValue + 'rem'
+              : '2rem'};
             justify-content: center;
             // Because the panels are positioned absolutely and overflow auto,
             // the handle will get lost when the user scrolls down. We can pin the


### PR DESCRIPTION
This is a test for resizing plotly's plot embedded in a draggable (and resizable) panel, like used in SAM. 
Tested several ways to make it happen but the only way I could do was to use draggable panel's onPanelResize() that returns current size of the panel. Then, a plot size in which a barplot is utilized for test purpose is determined by the current panel size. Please note that current format has an issue for the actual panel size, thus it is modified to avoid infinite loop of plot resize.

Here is a demo video:

https://github.com/VEuPathDB/web-monorepo/assets/12802305/3f0a971a-ae15-4371-87fe-fe2eba23a092

