### PR TITLE
proof of concept bipartite network

### DIFF
--- a/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
+++ b/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
@@ -1,0 +1,118 @@
+import VolcanoPlot, { VolcanoPlotProps } from '../../plots/VolcanoPlot';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { range } from 'lodash';
+import { NumberRange } from '../../types/general';
+import { Graph, DefaultLink, DefaultNode } from '@visx/network';
+import { Label } from '@visx/annotation';
+import { Text } from '@visx/text';
+
+export default {
+  title: 'Plots/BipartiteNetwork',
+  component: VolcanoPlot,
+} as Meta;
+
+interface TemplateProps {
+  nNodesColumn1: number;
+  nNodesColumn2: number;
+}
+
+const Template: Story<TemplateProps> = (args) => {
+  const nodesCol1 = [...Array(args.nNodesColumn1).keys()].map((i) => {
+    return {
+      x: 100,
+      y: 15 + 20 * i,
+    };
+  });
+
+  const nodesCol2 = [...Array(args.nNodesColumn2).keys()].map((i) => {
+    return {
+      x: 300,
+      y: 15 + 20 * i,
+    };
+  });
+
+  const nodes = nodesCol1.concat(nodesCol2);
+
+  const links = [...Array(nodes.length).keys()].map(() => {
+    return {
+      source: nodes[Math.floor(Math.random() * args.nNodesColumn1)],
+      target:
+        nodes[
+          args.nNodesColumn1 + Math.floor(Math.random() * args.nNodesColumn2)
+        ],
+    };
+  });
+
+  const dataSample = {
+    nodes,
+    links,
+  };
+
+  return (
+    <svg width={500} height={nodes.length * 20 + 50}>
+      <Graph
+        graph={dataSample}
+        linkComponent={({ link: { source, target } }) => (
+          <line
+            x1={source.x}
+            y1={source.y}
+            x2={target.x}
+            y2={target.y}
+            strokeWidth={Math.random() * 2}
+            stroke={Math.random() > 0.5 ? '#adf' : '#faa'}
+            strokeOpacity={Math.random()}
+            onClick={() => console.log('click link')}
+          />
+        )}
+        nodeComponent={() => (
+          <DefaultNode
+            r={4}
+            fill="#aaa"
+            onClick={() => console.log('click node')}
+          />
+        )}
+      />
+      {nodes.map((node, ind) => {
+        // Why is this text part so slow? The nodes and links are fast but text is slow
+        return (
+          <Text
+            x={ind < args.nNodesColumn1 ? node.x - 6 : node.x + 6}
+            y={node.y}
+            textAnchor={ind < args.nNodesColumn1 ? 'end' : 'start'}
+            fontSize="0.8em"
+            verticalAnchor="middle"
+          >
+            Label
+          </Text>
+        );
+      })}
+    </svg>
+  );
+};
+
+/**
+ * Stories
+ */
+
+// A small volcano plot. Proof of concept
+export const Simple = Template.bind({});
+Simple.args = {
+  nNodesColumn1: 20,
+  nNodesColumn2: 10,
+};
+
+// Most volcano plots will have thousands of points, since each point
+// represents a gene or taxa. Make a volcano plot with
+// a lot of points.
+export const ManyPoints = Template.bind({});
+ManyPoints.args = {
+  nNodesColumn1: 5000,
+  nNodesColumn2: 1000,
+};
+
+// Add story for truncation
+// export const Truncation = Template.bind({})
+// Truncation.args = {
+//   data: dataSetVolcano,
+//   independentAxisRange: []
+// }


### PR DESCRIPTION
Work towards a correlation app for mbio. Gathering information.

Current screenshots:

small size
<img width="392" alt="Screen Shot 2023-07-12 at 7 18 19 AM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/513322b5-e131-493f-84e2-e8afb78b6d9f">

lots and lots of points (scrolls vertically)
<img width="318" alt="Screen Shot 2023-07-12 at 7 18 51 AM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/cccf07df-2756-40f8-aed4-15a5b82c58dd">


Open Questions:
1. Let's say we let the user filter nodes and edges out of the network. Is that a part of the viz request? Or does the client do that? I could see either right now
2. I think this will be a separate component from the unipartite network (hairball), but i'd like the data structure to be the same. This seems acheivable.

Current idea of data coming in from the backend:
```
[{
nodeA: "node A name or id"
nodeB: "node B name or id"
edgeWeight?: number
edgeOpacity?: number
}]
```

I'm thinking about using visx `Graph`, but i haven't totally ruled out the `XYChart` approach for consistency with other vizs. 

More thoughts in the confluence doc [Networks](https://veupathdb.atlassian.net/wiki/spaces/FG/pages/198082575/Networks)