### PR TITLE
Change null labels to empty strings

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/PathwayRecordClasses.PathwayRecordClass.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/PathwayRecordClasses.PathwayRecordClass.jsx
@@ -535,7 +535,7 @@ function makeCy(
             'font-size': 12,
             'background-image': 'data(smallImage)',
             'background-fit': 'contain',
-            label: null,
+            label: '',
           },
         },
 
@@ -575,7 +575,7 @@ function makeCy(
             'background-color': 'white',
             'border-width': 1,
             'background-image-opacity': 0,
-            label: null,
+            label: '',
           },
         },
 
@@ -634,7 +634,7 @@ function makeCy(
             'background-color': 'white',
             'background-image': 'data(image)',
             'background-fit': 'contain',
-            label: null,
+            label: '',
           },
         },
 


### PR DESCRIPTION
Resolves issue with rendering labels in Cytoscape. The desired behavior is to not render labels until zoomed in at a certain level. Currently, the client passes `null` as the label when zoomed out of the zoom threshold which results in `null` being rendered on the Cytoscape graph.

**Screenshot of the problem as it first renders:**
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/3550ec91-08f5-4f36-830c-acaeb7fbd1a0)

We can instead pass in an empty string when we don't wish to render a label.

**Screenshot of the resolution as it first renders:**
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/164f5e5a-1863-470e-94f6-4e8a006178f3)