### PR TITLE
Fix lost selection state in value picker

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -258,7 +258,7 @@ export function DifferentialAbundanceConfiguration(
         <div style={{ justifySelf: 'end', fontWeight: 500 }}>Group A</div>
         <ValuePicker
           allowedValues={selectedComparatorVariable?.variable.vocabulary}
-          selectedValues={configuration?.comparator?.groupA ?? []}
+          selectedValues={configuration?.comparator?.groupA}
           onSelectedValuesChange={(newValues) =>
             changeConfigHandler('comparator', {
               variable: configuration?.comparator?.variable ?? undefined,
@@ -270,7 +270,7 @@ export function DifferentialAbundanceConfiguration(
         <div style={{ justifySelf: 'end', fontWeight: 500 }}>Group B</div>
         <ValuePicker
           allowedValues={selectedComparatorVariable?.variable.vocabulary}
-          selectedValues={configuration?.comparator?.groupB ?? []}
+          selectedValues={configuration?.comparator?.groupB}
           onSelectedValuesChange={(newValues) =>
             changeConfigHandler('comparator', {
               variable: configuration?.comparator?.variable ?? undefined,


### PR DESCRIPTION
Fixes a bug with the `ValuePicker`s for Group A and Group B values.

<h3>The bug</h3>
Changing the comparator var resets the group A and group B values and the component will re-render a handful of times. As a result, the `selectedValues` will be assigned a new empty array literal during <strong><em>each render</em></strong> due to this line: <br /><br />
<code>selectedValues={configuration?.comparator?.groupA ?? []}</code>
<br /><br />
The `ValuePicker` component sees this as a new state due to object equality/reference reasons and thus it will re-render and reset its state back to an empty array.

<h3>Steps to reproduce the bug</h3>
<ol>
  <li>Select a comparator var</li>
  <li>Quickly-ish open a group selection list and make a selection</li>
  <li>Notice  selection state disappears</li>
</ol>




<h3>Solution</h3>
By removing the nullish coalescing operator (`??`), we can <a href="https://github.com/VEuPathDB/web-monorepo/blob/d0e102ebc29d465050177e0f76878d7b88572364/packages/libs/eda/src/lib/core/components/visualizations/implementations/ValuePicker.tsx#L16">let `ValuePicker` assign an undefined value the default `EMPTY_ARRAY` array reference</a>, which will be stable.