### PR TITLE
Add step prop to NumberInput component and use in VolcanoPlot

### DIFF
--- a/packages/libs/components/src/components/widgets/NumberAndDateInputs.tsx
+++ b/packages/libs/components/src/components/widgets/NumberAndDateInputs.tsx
@@ -34,7 +34,7 @@ type BaseProps<M extends NumberOrDate> = {
   disabled?: boolean;
 };
 
-export type NumberInputProps = BaseProps<number>;
+export type NumberInputProps = BaseProps<number> & { step?: number };
 
 export function NumberInput(props: NumberInputProps) {
   return <BaseInput {...props} valueType="number" />;
@@ -82,6 +82,7 @@ function BaseInput({
   containerStyles,
   displayRangeViolationWarnings = true,
   disabled = false,
+  ...props
 }: BaseInputProps) {
   if (validator && (required || minValue != null || maxValue != null))
     console.log(
@@ -184,6 +185,9 @@ function BaseInput({
     [boundsCheckedValue, debouncedOnChange]
   );
 
+  const step =
+    valueType === 'number' && 'step' in props ? props.step : undefined;
+
   return (
     <div
       // containerStyles is not used here - but bin control uses this!
@@ -202,6 +206,7 @@ function BaseInput({
       <div style={{ display: 'flex', flexDirection: 'row' }}>
         <TextField
           InputProps={{ classes }}
+          inputProps={{ step }}
           value={
             localValue == null
               ? ''

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -218,6 +218,7 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
           minValue={0}
           value={vizConfig.significanceThreshold ?? DEFAULT_SIG_THRESHOLD}
           containerStyles={{ flex: 1 }}
+          step={0.001}
         />
       </LabelledGroup>
 


### PR DESCRIPTION
Relates to second-to-last item in https://github.com/VEuPathDB/web-monorepo/issues/358

Note: I passed `step={0.001}` to the `P-Value` input but the `Fold Change` step remains undefined, thus remains the same default behavior (step of 1).