### PR TITLE
Adjust diff abundance configuration layout

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
@@ -1,4 +1,4 @@
-.StepOneConfigurationContainer {
+.AppStepConfigurationContainer {
   display: flex;
   gap: 0 2em;
   padding: 1em 0;

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
@@ -33,3 +33,14 @@
     }
   }
 }
+
+.ConfigDescriptionContainer {
+  margin-left: 20px;
+  margin-top: 15px;
+  h4 {
+    padding: 0;
+    span {
+      font-weight: 300;
+    }
+  }
+}

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
@@ -1,0 +1,35 @@
+.StepOneConfigurationContainer {
+  display: flex;
+  gap: 0 2em;
+  padding: 1em 0;
+  align-items: center;
+  margin-left: 3em;
+
+  &-DiffAbundanceOuterConfigContainer {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75em;
+    span {
+      white-space: nowrap;
+    }
+    &GroupComparison {
+      display: flex;
+      gap: 1.5em;
+    }
+  }
+
+  &-InputContainer {
+    display: flex;
+    gap: 0.75em;
+    align-items: center;
+    span {
+      font-weight: 500;
+    }
+    &__disabled {
+      cursor: not-allowed;
+      span {
+        opacity: 0.5;
+      }
+    }
+  }
+}

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -99,10 +99,10 @@ function AbundanceConfigDescriptionComponent({
     )
   );
   return (
-    <>
-      <h4 style={{ padding: '15px 0 0 0', marginLeft: 20 }}>
+    <div className="ConfigDescriptionContainer">
+      <h4>
         Data:{' '}
-        <span style={{ fontWeight: 300 }}>
+        <span>
           {updatedCollectionVariable ? (
             `${updatedCollectionVariable?.entityDisplayName} > ${updatedCollectionVariable?.displayName}`
           ) : (
@@ -110,9 +110,9 @@ function AbundanceConfigDescriptionComponent({
           )}
         </span>
       </h4>
-      <h4 style={{ padding: 0, marginLeft: 20 }}>
+      <h4>
         Method:{' '}
-        <span style={{ fontWeight: 300 }}>
+        <span>
           {rankingMethod ? (
             rankingMethod[0].toUpperCase() + rankingMethod.slice(1)
           ) : (
@@ -120,7 +120,7 @@ function AbundanceConfigDescriptionComponent({
           )}
         </span>
       </h4>
-    </>
+    </div>
   );
 }
 

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -11,14 +11,10 @@ import { Computation } from '../../../types/visualization';
 import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
 import { useMemo } from 'react';
 import { ComputationStepContainer } from '../ComputationStepContainer';
+import './Plugins.scss';
+import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 
-export const sharedConfigCssStyles = {
-  display: 'flex',
-  gap: '0 2em',
-  padding: '1em 0',
-  alignItems: 'center',
-  marginLeft: '3em',
-};
+const cx = makeClassNameHelper('StepOneConfigurationContainer');
 
 export type AbundanceConfig = t.TypeOf<typeof AbundanceConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -188,16 +184,9 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
         stepTitle: `Configure ${computationAppOverview.displayName}`,
       }}
     >
-      <div style={sharedConfigCssStyles}>
-        <div
-          style={{
-            display: 'flex',
-            gap: '1em',
-            justifyItems: 'start',
-            alignItems: 'center',
-          }}
-        >
-          <span style={{ justifySelf: 'end', fontWeight: 500 }}>Data</span>
+      <div className={cx()}>
+        <div className={cx('-InputContainer')}>
+          <span>Data</span>
           <SingleSelect
             value={
               selectedCollectionVar
@@ -212,7 +201,9 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
             items={collectionVarItems}
             onSelect={partial(changeConfigHandler, 'collectionVariable')}
           />
-          <span style={{ justifySelf: 'end', fontWeight: 500 }}>Method</span>
+        </div>
+        <div className={cx('-InputContainer')}>
+          <span>Method</span>
           <SingleSelect
             value={rankingMethod ?? 'Select a method'}
             buttonDisplayContent={rankingMethod ?? 'Select a method'}

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -14,7 +14,7 @@ import { ComputationStepContainer } from '../ComputationStepContainer';
 import './Plugins.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 
-const cx = makeClassNameHelper('StepOneConfigurationContainer');
+const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
 export type AbundanceConfig = t.TypeOf<typeof AbundanceConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -82,10 +82,10 @@ function AlphaDivConfigDescriptionComponent({
     )
   );
   return (
-    <>
-      <h4 style={{ padding: '15px 0 0 0', marginLeft: 20 }}>
+    <div className="ConfigDescriptionContainer">
+      <h4>
         Data:{' '}
-        <span style={{ fontWeight: 300 }}>
+        <span>
           {updatedCollectionVariable ? (
             `${updatedCollectionVariable?.entityDisplayName} > ${updatedCollectionVariable?.displayName}`
           ) : (
@@ -93,9 +93,9 @@ function AlphaDivConfigDescriptionComponent({
           )}
         </span>
       </h4>
-      <h4 style={{ padding: 0, marginLeft: 20 }}>
+      <h4>
         Method:{' '}
-        <span style={{ fontWeight: 300 }}>
+        <span>
           {alphaDivMethod ? (
             alphaDivMethod[0].toUpperCase() + alphaDivMethod.slice(1)
           ) : (
@@ -103,7 +103,7 @@ function AlphaDivConfigDescriptionComponent({
           )}
         </span>
       </h4>
-    </>
+    </div>
   );
 }
 

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -13,7 +13,7 @@ import { ComputationStepContainer } from '../ComputationStepContainer';
 import './Plugins.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 
-const cx = makeClassNameHelper('StepOneConfigurationContainer');
+const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
 export type AlphaDivConfig = t.TypeOf<typeof AlphaDivConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -10,7 +10,10 @@ import { Computation } from '../../../types/visualization';
 import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
 import { useMemo } from 'react';
 import { ComputationStepContainer } from '../ComputationStepContainer';
-import { sharedConfigCssStyles } from './abundance';
+import './Plugins.scss';
+import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+
+const cx = makeClassNameHelper('StepOneConfigurationContainer');
 
 export type AlphaDivConfig = t.TypeOf<typeof AlphaDivConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -165,16 +168,9 @@ export function AlphaDivConfiguration(props: ComputationConfigProps) {
         stepTitle: `Configure ${computationAppOverview.displayName}`,
       }}
     >
-      <div style={sharedConfigCssStyles}>
-        <div
-          style={{
-            display: 'flex',
-            gap: '1em',
-            justifyItems: 'start',
-            alignItems: 'center',
-          }}
-        >
-          <div style={{ justifySelf: 'end', fontWeight: 500 }}>Data</div>
+      <div className={cx()}>
+        <div className={cx('-InputContainer')}>
+          <span>Data</span>
           <SingleSelect
             value={
               selectedCollectionVar
@@ -189,7 +185,9 @@ export function AlphaDivConfiguration(props: ComputationConfigProps) {
             items={collectionVarItems}
             onSelect={partial(changeConfigHandler, 'collectionVariable')}
           />
-          <div style={{ justifySelf: 'end', fontWeight: 500 }}>Method</div>
+        </div>
+        <div className={cx('-InputContainer')}>
+          <span>Method</span>
           <SingleSelect
             value={alphaDivMethod ?? 'Select a method'}
             buttonDisplayContent={alphaDivMethod ?? 'Select a method'}

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -10,7 +10,10 @@ import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
 import { useMemo } from 'react';
 import ScatterBetadivSVG from '../../visualizations/implementations/selectorIcons/ScatterBetadivSVG';
 import { ComputationStepContainer } from '../ComputationStepContainer';
-import { sharedConfigCssStyles } from './abundance';
+import './Plugins.scss';
+import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+
+const cx = makeClassNameHelper('StepOneConfigurationContainer');
 
 export type BetaDivConfig = t.TypeOf<typeof BetaDivConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -168,16 +171,9 @@ export function BetaDivConfiguration(props: ComputationConfigProps) {
         stepTitle: `Configure ${computationAppOverview.displayName}`,
       }}
     >
-      <div style={sharedConfigCssStyles}>
-        <div
-          style={{
-            display: 'flex',
-            gap: '1em',
-            justifyItems: 'start',
-            alignItems: 'center',
-          }}
-        >
-          <div style={{ justifySelf: 'end', fontWeight: 500 }}>Data</div>
+      <div className={cx()}>
+        <div className={cx('-InputContainer')}>
+          <span>Data</span>
           <SingleSelect
             value={
               selectedCollectionVar
@@ -192,9 +188,9 @@ export function BetaDivConfiguration(props: ComputationConfigProps) {
             items={collectionVarItems}
             onSelect={partial(changeConfigHandler, 'collectionVariable')}
           />
-          <div style={{ justifySelf: 'end', fontWeight: 500 }}>
-            Dissimilarity method
-          </div>
+        </div>
+        <div className={cx('-InputContainer')}>
+          <span>Dissimilarity method</span>
           <SingleSelect
             value={betaDivDissimilarityMethod ?? 'Select a method'}
             buttonDisplayContent={

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -84,10 +84,10 @@ function BetaDivConfigDescriptionComponent({
     )
   );
   return (
-    <>
-      <h4 style={{ padding: '15px 0 0 0', marginLeft: 20 }}>
+    <div className="ConfigDescriptionContainer">
+      <h4>
         Data:{' '}
-        <span style={{ fontWeight: 300 }}>
+        <span>
           {updatedCollectionVariable ? (
             `${updatedCollectionVariable?.entityDisplayName} > ${updatedCollectionVariable?.displayName}`
           ) : (
@@ -95,9 +95,9 @@ function BetaDivConfigDescriptionComponent({
           )}
         </span>
       </h4>
-      <h4 style={{ padding: 0, marginLeft: 20 }}>
+      <h4>
         Dissimilarity method:{' '}
-        <span style={{ fontWeight: 300 }}>
+        <span>
           {betaDivDissimilarityMethod ? (
             betaDivDissimilarityMethod[0].toUpperCase() +
             betaDivDissimilarityMethod.slice(1)
@@ -106,7 +106,7 @@ function BetaDivConfigDescriptionComponent({
           )}
         </span>
       </h4>
-    </>
+    </div>
   );
 }
 

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -13,7 +13,7 @@ import { ComputationStepContainer } from '../ComputationStepContainer';
 import './Plugins.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 
-const cx = makeClassNameHelper('StepOneConfigurationContainer');
+const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
 export type BetaDivConfig = t.TypeOf<typeof BetaDivConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -18,6 +18,7 @@ import { FloatingButton, H6 } from '@veupathdb/coreui';
 import { SwapHorizOutlined } from '@material-ui/icons';
 import './Plugins.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import { Tooltip } from '@material-ui/core';
 
 const cx = makeClassNameHelper('StepOneConfigurationContainer');
 
@@ -265,77 +266,87 @@ export function DifferentialAbundanceConfiguration(
                 }}
               />
             </div>
-            <div
-              className={cx(
-                '-InputContainer',
-                disableGroupValueSelectors && 'disabled'
-              )}
+            <Tooltip
               title={
                 disableGroupValueSelectors
                   ? 'Please select a Group Comparison variable first'
                   : ''
               }
             >
-              <span>Group A</span>
-              <ValuePicker
-                allowedValues={selectedComparatorVariable?.variable.vocabulary}
-                selectedValues={configuration?.comparator?.groupA}
-                disabledValues={configuration?.comparator?.groupB}
-                onSelectedValuesChange={(newValues) =>
-                  changeConfigHandler('comparator', {
-                    variable: configuration?.comparator?.variable ?? undefined,
-                    groupA: newValues.length ? newValues : undefined,
-                    groupB: configuration?.comparator?.groupB ?? undefined,
-                  })
-                }
-                disabledCheckboxTooltipContent="Values cannot overlap between groups"
-                showClearSelectionButton={false}
-                disableInput={disableGroupValueSelectors}
-              />
-              <FloatingButton
-                icon={SwapHorizOutlined}
-                text=""
-                onPress={() =>
-                  changeConfigHandler('comparator', {
-                    variable: configuration?.comparator?.variable ?? undefined,
-                    groupA: configuration?.comparator?.groupB ?? undefined,
-                    groupB: configuration?.comparator?.groupA ?? undefined,
-                  })
-                }
-                styleOverrides={{
-                  container: {
-                    padding: 0,
-                    margin: '0 5px',
-                  },
-                }}
-                disabled={
-                  disableGroupValueSelectors || disableSwapGroupValuesButton
-                }
-                /**
-                 * For some reason the tooltip content renders when the parent container is in the disabled state.
-                 * To prevent such ghastly behavior, let's not pass in the tooltip prop when the parent is disabled.
-                 */
-                {...(!disableGroupValueSelectors
-                  ? { tooltip: 'Swap Group A and Group B values' }
-                  : {})}
-              />
-              <span>Group B</span>
-              <ValuePicker
-                allowedValues={selectedComparatorVariable?.variable.vocabulary}
-                selectedValues={configuration?.comparator?.groupB}
-                disabledValues={configuration?.comparator?.groupA}
-                onSelectedValuesChange={(newValues) =>
-                  changeConfigHandler('comparator', {
-                    variable: configuration?.comparator?.variable ?? undefined,
-                    groupA: configuration?.comparator?.groupA ?? undefined,
-                    groupB: newValues.length ? newValues : undefined,
-                  })
-                }
-                disabledCheckboxTooltipContent="Values cannot overlap between groups"
-                showClearSelectionButton={false}
-                disableInput={disableGroupValueSelectors}
-              />
-            </div>
+              <div
+                className={cx(
+                  '-InputContainer',
+                  disableGroupValueSelectors && 'disabled'
+                )}
+              >
+                <span>Group A</span>
+                <ValuePicker
+                  allowedValues={
+                    selectedComparatorVariable?.variable.vocabulary
+                  }
+                  selectedValues={configuration?.comparator?.groupA}
+                  disabledValues={configuration?.comparator?.groupB}
+                  onSelectedValuesChange={(newValues) =>
+                    changeConfigHandler('comparator', {
+                      variable:
+                        configuration?.comparator?.variable ?? undefined,
+                      groupA: newValues.length ? newValues : undefined,
+                      groupB: configuration?.comparator?.groupB ?? undefined,
+                    })
+                  }
+                  disabledCheckboxTooltipContent="Values cannot overlap between groups"
+                  showClearSelectionButton={false}
+                  disableInput={disableGroupValueSelectors}
+                />
+                <FloatingButton
+                  icon={SwapHorizOutlined}
+                  text=""
+                  onPress={() =>
+                    changeConfigHandler('comparator', {
+                      variable:
+                        configuration?.comparator?.variable ?? undefined,
+                      groupA: configuration?.comparator?.groupB ?? undefined,
+                      groupB: configuration?.comparator?.groupA ?? undefined,
+                    })
+                  }
+                  styleOverrides={{
+                    container: {
+                      padding: 0,
+                      margin: '0 5px',
+                    },
+                  }}
+                  disabled={
+                    disableGroupValueSelectors || disableSwapGroupValuesButton
+                  }
+                  /**
+                   * For some reason the tooltip content renders when the parent container is in the disabled state.
+                   * To prevent such ghastly behavior, let's not pass in the tooltip prop when the parent is disabled.
+                   */
+                  {...(!disableGroupValueSelectors
+                    ? { tooltip: 'Swap Group A and Group B values' }
+                    : {})}
+                />
+                <span>Group B</span>
+                <ValuePicker
+                  allowedValues={
+                    selectedComparatorVariable?.variable.vocabulary
+                  }
+                  selectedValues={configuration?.comparator?.groupB}
+                  disabledValues={configuration?.comparator?.groupA}
+                  onSelectedValuesChange={(newValues) =>
+                    changeConfigHandler('comparator', {
+                      variable:
+                        configuration?.comparator?.variable ?? undefined,
+                      groupA: configuration?.comparator?.groupA ?? undefined,
+                      groupB: newValues.length ? newValues : undefined,
+                    })
+                  }
+                  disabledCheckboxTooltipContent="Values cannot overlap between groups"
+                  showClearSelectionButton={false}
+                  disableInput={disableGroupValueSelectors}
+                />
+              </div>
+            </Tooltip>
           </div>
         </div>
       </div>

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -10,13 +10,16 @@ import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
 import { useFindEntityAndVariable } from '../../../hooks/workspace';
 import { useMemo } from 'react';
 import { ComputationStepContainer } from '../ComputationStepContainer';
-import { sharedConfigCssStyles } from './abundance';
 import VariableTreeDropdown from '../../variableTrees/VariableTreeDropdown';
 import { ValuePicker } from '../../visualizations/implementations/ValuePicker';
 import { useToggleStarredVariable } from '../../../hooks/starredVariables';
 import { Filter } from '../../..';
-import { FloatingButton } from '@veupathdb/coreui';
+import { FloatingButton, H6 } from '@veupathdb/coreui';
 import { SwapHorizOutlined } from '@material-ui/icons';
+import './Plugins.scss';
+import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+
+const cx = makeClassNameHelper('StepOneConfigurationContainer');
 
 /**
  * Differential abundance
@@ -203,6 +206,10 @@ export function DifferentialAbundanceConfiguration(
     }
   }, [configuration, findEntityAndVariable]);
 
+  const disableSwapGroupValuesButton =
+    !configuration?.comparator?.groupA && !configuration?.comparator?.groupB;
+  const disableGroupValueSelectors = !configuration?.comparator?.variable;
+
   return (
     <ComputationStepContainer
       computationStepInfo={{
@@ -210,97 +217,123 @@ export function DifferentialAbundanceConfiguration(
         stepTitle: `Configure ${computationAppOverview.displayName}`,
       }}
     >
-      <div style={sharedConfigCssStyles}>
-        <div
-          style={{
-            display: 'flex',
-            gap: '1em',
-            justifyItems: 'start',
-            alignItems: 'center',
-          }}
-        >
-          <div style={{ justifySelf: 'end', fontWeight: 500 }}>Data</div>
-          <SingleSelect
-            value={
-              selectedCollectionVar
-                ? selectedCollectionVar.value
-                : 'Select the data'
-            }
-            buttonDisplayContent={
-              selectedCollectionVar
-                ? selectedCollectionVar.display
-                : 'Select the data'
-            }
-            items={collectionVarItems}
-            onSelect={partial(changeConfigHandler, 'collectionVariable')}
-          />
-          <div style={{ justifySelf: 'end', fontWeight: 500 }}>
-            Comparator Variable
+      <div className={cx()}>
+        <div className={cx('-DiffAbundanceOuterConfigContainer')}>
+          <H6>Input Data</H6>
+          <div className={cx('-InputContainer')}>
+            <span>Data</span>
+            <SingleSelect
+              value={
+                selectedCollectionVar
+                  ? selectedCollectionVar.value
+                  : 'Select the data'
+              }
+              buttonDisplayContent={
+                selectedCollectionVar
+                  ? selectedCollectionVar.display
+                  : 'Select the data'
+              }
+              items={collectionVarItems}
+              onSelect={partial(changeConfigHandler, 'collectionVariable')}
+            />
           </div>
-          <VariableTreeDropdown
-            showClearSelectionButton={false}
-            scope="variableTree"
-            showMultiFilterDescendants
-            starredVariables={
-              analysisState.analysis?.descriptor.starredVariables
-            }
-            toggleStarredVariable={toggleStarredVariable}
-            entityId={configuration?.comparator?.variable?.entityId}
-            variableId={configuration?.comparator?.variable?.variableId}
-            variableLinkConfig={{
-              type: 'button',
-              onClick: (variable) => {
-                changeConfigHandler('comparator', {
-                  variable: variable as VariableDescriptor,
-                });
-              },
-            }}
-          />
         </div>
-        <div style={{ justifySelf: 'end', fontWeight: 500 }}>Group A</div>
-        <ValuePicker
-          allowedValues={selectedComparatorVariable?.variable.vocabulary}
-          selectedValues={configuration?.comparator?.groupA}
-          disabledValues={configuration?.comparator?.groupB}
-          onSelectedValuesChange={(newValues) =>
-            changeConfigHandler('comparator', {
-              variable: configuration?.comparator?.variable ?? undefined,
-              groupA: newValues.length ? newValues : undefined,
-              groupB: configuration?.comparator?.groupB ?? undefined,
-            })
-          }
-          disabledCheckboxTooltipContent="Values cannot overlap between groups"
-          showClearSelectionButton={false}
-          disableInput={!configuration?.comparator?.variable}
-        />
-        <FloatingButton
-          icon={SwapHorizOutlined}
-          text=""
-          onPress={() =>
-            changeConfigHandler('comparator', {
-              variable: configuration?.comparator?.variable ?? undefined,
-              groupA: configuration?.comparator?.groupB ?? undefined,
-              groupB: configuration?.comparator?.groupA ?? undefined,
-            })
-          }
-          tooltip="Swap Group A and Group B values"
-        />
-        <div style={{ justifySelf: 'end', fontWeight: 500 }}>Group B</div>
-        <ValuePicker
-          allowedValues={selectedComparatorVariable?.variable.vocabulary}
-          selectedValues={configuration?.comparator?.groupB}
-          disabledValues={configuration?.comparator?.groupA}
-          onSelectedValuesChange={(newValues) =>
-            changeConfigHandler('comparator', {
-              variable: configuration?.comparator?.variable ?? undefined,
-              groupA: configuration?.comparator?.groupA ?? undefined,
-              groupB: newValues.length ? newValues : undefined,
-            })
-          }
-          disabledCheckboxTooltipContent="Values cannot overlap between groups"
-          showClearSelectionButton={false}
-          disableInput={!configuration?.comparator?.variable}
-        />
+        <div className={cx('-DiffAbundanceOuterConfigContainer')}>
+          <H6>Group Comparison</H6>
+          <div
+            className={cx('-DiffAbundanceOuterConfigContainerGroupComparison')}
+          >
+            <div className={cx('-InputContainer')}>
+              <span>Variable</span>
+              <VariableTreeDropdown
+                showClearSelectionButton={false}
+                scope="variableTree"
+                showMultiFilterDescendants
+                starredVariables={
+                  analysisState.analysis?.descriptor.starredVariables
+                }
+                toggleStarredVariable={toggleStarredVariable}
+                entityId={configuration?.comparator?.variable?.entityId}
+                variableId={configuration?.comparator?.variable?.variableId}
+                variableLinkConfig={{
+                  type: 'button',
+                  onClick: (variable) => {
+                    changeConfigHandler('comparator', {
+                      variable: variable as VariableDescriptor,
+                    });
+                  },
+                }}
+              />
+            </div>
+            <div
+              className={cx(
+                '-InputContainer',
+                disableGroupValueSelectors && 'disabled'
+              )}
+              title={
+                disableGroupValueSelectors
+                  ? 'Please select a Group Comparison variable first'
+                  : ''
+              }
+            >
+              <span>Group A</span>
+              <ValuePicker
+                allowedValues={selectedComparatorVariable?.variable.vocabulary}
+                selectedValues={configuration?.comparator?.groupA}
+                disabledValues={configuration?.comparator?.groupB}
+                onSelectedValuesChange={(newValues) =>
+                  changeConfigHandler('comparator', {
+                    variable: configuration?.comparator?.variable ?? undefined,
+                    groupA: newValues.length ? newValues : undefined,
+                    groupB: configuration?.comparator?.groupB ?? undefined,
+                  })
+                }
+                disabledCheckboxTooltipContent="Values cannot overlap between groups"
+                showClearSelectionButton={false}
+                disableInput={disableGroupValueSelectors}
+              />
+              <FloatingButton
+                icon={SwapHorizOutlined}
+                text=""
+                onPress={() =>
+                  changeConfigHandler('comparator', {
+                    variable: configuration?.comparator?.variable ?? undefined,
+                    groupA: configuration?.comparator?.groupB ?? undefined,
+                    groupB: configuration?.comparator?.groupA ?? undefined,
+                  })
+                }
+                styleOverrides={{
+                  container: {
+                    padding: 0,
+                    margin: '0 5px',
+                  },
+                }}
+                disabled={
+                  disableGroupValueSelectors || disableSwapGroupValuesButton
+                }
+                {...(!disableGroupValueSelectors
+                  ? { tooltip: 'Swap Group A and Group B values' }
+                  : {})}
+              />
+              <span>Group B</span>
+              <ValuePicker
+                allowedValues={selectedComparatorVariable?.variable.vocabulary}
+                selectedValues={configuration?.comparator?.groupB}
+                disabledValues={configuration?.comparator?.groupA}
+                onSelectedValuesChange={(newValues) =>
+                  changeConfigHandler('comparator', {
+                    variable: configuration?.comparator?.variable ?? undefined,
+                    groupA: configuration?.comparator?.groupA ?? undefined,
+                    groupB: newValues.length ? newValues : undefined,
+                  })
+                }
+                disabledCheckboxTooltipContent="Values cannot overlap between groups"
+                showClearSelectionButton={false}
+                disableInput={disableGroupValueSelectors}
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </ComputationStepContainer>
   );

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -311,6 +311,10 @@ export function DifferentialAbundanceConfiguration(
                 disabled={
                   disableGroupValueSelectors || disableSwapGroupValuesButton
                 }
+                /**
+                 * For some reason the tooltip content renders when the parent container is in the disabled state.
+                 * To prevent such ghastly behavior, let's not pass in the tooltip prop when the parent is disabled.
+                 */
                 {...(!disableGroupValueSelectors
                   ? { tooltip: 'Swap Group A and Group B values' }
                   : {})}

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -20,7 +20,7 @@ import './Plugins.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { Tooltip } from '@material-ui/core';
 
-const cx = makeClassNameHelper('StepOneConfigurationContainer');
+const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
 /**
  * Differential abundance

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -15,6 +15,8 @@ import VariableTreeDropdown from '../../variableTrees/VariableTreeDropdown';
 import { ValuePicker } from '../../visualizations/implementations/ValuePicker';
 import { useToggleStarredVariable } from '../../../hooks/starredVariables';
 import { Filter } from '../../..';
+import { FloatingButton } from '@veupathdb/coreui';
+import { SwapHorizOutlined } from '@material-ui/icons';
 
 /**
  * Differential abundance
@@ -268,6 +270,20 @@ export function DifferentialAbundanceConfiguration(
             })
           }
           disabledCheckboxTooltipContent="Values cannot overlap between groups"
+          showClearSelectionButton={false}
+          disableInput={!configuration?.comparator?.variable}
+        />
+        <FloatingButton
+          icon={SwapHorizOutlined}
+          text=""
+          onPress={() =>
+            changeConfigHandler('comparator', {
+              variable: configuration?.comparator?.variable ?? undefined,
+              groupA: configuration?.comparator?.groupB ?? undefined,
+              groupB: configuration?.comparator?.groupA ?? undefined,
+            })
+          }
+          tooltip="Swap Group A and Group B values"
         />
         <div style={{ justifySelf: 'end', fontWeight: 500 }}>Group B</div>
         <ValuePicker
@@ -282,6 +298,8 @@ export function DifferentialAbundanceConfiguration(
             })
           }
           disabledCheckboxTooltipContent="Values cannot overlap between groups"
+          showClearSelectionButton={false}
+          disableInput={!configuration?.comparator?.variable}
         />
       </div>
     </ComputationStepContainer>

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -111,10 +111,10 @@ function DifferentialAbundanceConfigDescriptionComponent({
     )
   );
   return (
-    <>
-      <h4 style={{ padding: '15px 0 0 0', marginLeft: 20 }}>
+    <div className="ConfigDescriptionContainer">
+      <h4>
         Data:{' '}
-        <span style={{ fontWeight: 300 }}>
+        <span>
           {updatedCollectionVariable ? (
             `${updatedCollectionVariable?.entityDisplayName} > ${updatedCollectionVariable?.displayName}`
           ) : (
@@ -122,9 +122,9 @@ function DifferentialAbundanceConfigDescriptionComponent({
           )}
         </span>
       </h4>
-      <h4 style={{ padding: 0, marginLeft: 20 }}>
+      <h4>
         Comparator Variable:{' '}
-        <span style={{ fontWeight: 300 }}>
+        <span>
           {comparatorVariable ? (
             comparatorVariable.variable.displayName
           ) : (
@@ -132,7 +132,7 @@ function DifferentialAbundanceConfigDescriptionComponent({
           )}
         </span>
       </h4>
-    </>
+    </div>
   );
 }
 

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ValuePicker.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ValuePicker.tsx
@@ -9,6 +9,8 @@ export type ValuePickerProps = {
   /** Change communicated when [Save] button is clicked. */
   onSelectedValuesChange: (newValues: string[]) => void;
   disabledCheckboxTooltipContent?: ReactNode;
+  disableInput?: boolean;
+  showClearSelectionButton?: boolean;
 };
 
 const EMPTY_ALLOWED_VALUES_ARRAY: string[] = [];
@@ -21,6 +23,8 @@ export function ValuePicker({
   disabledValues = EMPTY_DISABLED_VALUES_ARRAY,
   onSelectedValuesChange,
   disabledCheckboxTooltipContent,
+  disableInput = false,
+  showClearSelectionButton = true,
 }: ValuePickerProps) {
   const items = allowedValues.map((value) => ({
     display: <span>{value}</span>,
@@ -36,12 +40,15 @@ export function ValuePicker({
         onChange={onSelectedValuesChange}
         value={selectedValues}
         disabledCheckboxTooltipContent={disabledCheckboxTooltipContent}
+        isDisabled={disableInput}
       />
-      <ClearSelectionButton
-        onClick={() => onSelectedValuesChange([])}
-        disabled={!selectedValues.length}
-        style={{ marginLeft: '0.5em' }}
-      />
+      {showClearSelectionButton && (
+        <ClearSelectionButton
+          onClick={() => onSelectedValuesChange([])}
+          disabled={!selectedValues.length}
+          style={{ marginLeft: '0.5em' }}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
Resolves 2nd and last items from https://github.com/VEuPathDB/web-monorepo/issues/358

In the process of making these adjustments, I took the opportunity to pay off some tech debt by creating a new SASS file that replaces the inline styling used in our plugin configuration menus and in each plugin's description component.

1. New viz with no selections. Group A, swap button, and Group B disabled. Notice I'm using the native `title` tooltip but would we prefer a tooltip component?
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/2d3992e2-a3ef-40b0-928e-78cf1c898dc9)

2. Group comparison variable now chosen so Group A and Group B are enabled. Notice the swap button remains disabled. Also note that we are unable to render a tooltip explaining why it's disabled due to the way MUI handles disabling their components, but I suspect users will figure it out easily enough.
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/d4926aa7-46b3-4029-863e-7224ac748c19)

3. Swap button enabled by any group value selection, now that there's something to actually swap.
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/cd5d14cd-e501-4ec1-b2f0-c2bb8fa85f03)

Hit me with your best feedback! 👊 