### PR TITLE
Genomics download UI updates

### DIFF
--- a/packages/libs/wdk-client/src/Controllers/ResultTableSummaryViewController.tsx
+++ b/packages/libs/wdk-client/src/Controllers/ResultTableSummaryViewController.tsx
@@ -79,6 +79,7 @@ type OwnProps = {
   resultType: ResultType;
   tableActions?: TableAction[];
   showIdAttributeColumn?: boolean;
+  showCount?: boolean;
 };
 
 type Props = OwnProps &
@@ -96,6 +97,7 @@ function ResultTableSummaryViewController(props: Props) {
     viewId,
     derivedData,
     tableActions,
+    showCount,
     showIdAttributeColumn,
   } = props;
 
@@ -115,6 +117,7 @@ function ResultTableSummaryViewController(props: Props) {
       viewId={viewId}
       resultType={resultType}
       actions={tableActions}
+      showCount={showCount}
       showIdAttributeColumn={showIdAttributeColumn}
       {...viewData}
       {...derivedData}
@@ -279,9 +282,14 @@ const ConnectedController = connect<
   })
 )(wrappable(ResultTableSummaryViewController));
 
+type WithOptionsPropName =
+  | 'tableActions'
+  | 'showIdAttributeColumn'
+  | 'showCount';
+
 export default Object.assign(ConnectedController, {
   withOptions:
-    (options: Pick<OwnProps, 'tableActions' | 'showIdAttributeColumn'>) =>
-    (props: Exclude<OwnProps, 'tableActions' | 'showIdAttributeColumn'>) =>
+    (options: Pick<OwnProps, WithOptionsPropName>) =>
+    (props: Exclude<OwnProps, WithOptionsPropName>) =>
       <ConnectedController {...props} {...options} />,
 });

--- a/packages/libs/wdk-client/src/Views/ResultTableSummaryView/ResultTable.tsx
+++ b/packages/libs/wdk-client/src/Views/ResultTableSummaryView/ResultTable.tsx
@@ -36,6 +36,7 @@ export interface Props {
   resultType: ResultType;
   viewId: string;
   actions?: Action[];
+  showCount?: boolean;
   selectedIds?: string[];
   showIdAttributeColumn: boolean;
   activeAttributeAnalysisName: string | undefined;
@@ -72,6 +73,7 @@ function ResultTable(props: Props) {
     showHideAddColumnsDialog,
     requestAddStepToBasket,
     actions,
+    showCount,
     selectedIds,
     userIsGuest,
     showLoginWarning,
@@ -106,6 +108,7 @@ function ResultTable(props: Props) {
         recordInstance.attributes[recordClass.recordIdAttributeName] as string
       );
     },
+    showCount,
   };
   const tableState = MesaState.create({
     options,

--- a/packages/libs/wdk-client/src/Views/ResultTableSummaryView/ResultTableSummaryView.tsx
+++ b/packages/libs/wdk-client/src/Views/ResultTableSummaryView/ResultTableSummaryView.tsx
@@ -48,6 +48,7 @@ interface Props {
   columnsDialogSearchString?: string;
   columnsDialogExpandedNodes?: string[];
   columnsTree?: CategoryTreeNode;
+  showCount?: boolean;
   requestSortingUpdate: RequestSortingUpdate;
   requestColumnsChoiceUpdate: RequestColumnsChoiceUpdate;
   requestUpdateBasket: RequestUpdateBasket;
@@ -80,6 +81,7 @@ export default function ResultTableSummaryView({
   question,
   userIsGuest,
   basketStatusArray,
+  showCount,
   requestColumnsChoiceUpdate,
   requestSortingUpdate,
   requestUpdateBasket,
@@ -130,6 +132,7 @@ export default function ResultTableSummaryView({
           answer={answer}
           viewId={viewId}
           actions={actions}
+          showCount={showCount}
           selectedIds={selectedIds}
           showIdAttributeColumn={showIdAttributeColumn}
           activeAttributeAnalysisName={activeAttributeAnalysisName}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
@@ -10,13 +10,26 @@
   }
 
   &-Filter-Container {
-    outline: 2px solid #acacac;
-    margin: 2em auto 3em;
-    width: 60vw;
-    border-radius: 8px;
-    // height: 25em;
+    .wdk-QuestionFormParameterList {
+      width: 60vw;
+      margin: auto;
+    }
+
+    .wdk-QuestionFormParameterHeading h2 {
+      font-size: 1.3em;
+    }
+
+    .OrganismParam {
+      max-width: 47em;
+    }
 
     .filter-param {
+      outline: 2px solid #acacac;
+      // margin: 2em auto 3em;
+      // width: 60vw;
+      border-radius: 8px;
+      // height: 25em;
+
       h3 {
         padding: 0.25em 0;
       }
@@ -64,6 +77,10 @@
     }
 
     .TableToolbar {
+      order: -3;
+    }
+
+    .TableToolbar-Children {
       display: none;
     }
 

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsFilter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsFilter.tsx
@@ -2,9 +2,13 @@ import { SubmissionMetadata } from '@veupathdb/wdk-client/lib/Actions/QuestionAc
 import { QuestionController } from '@veupathdb/wdk-client/lib/Controllers';
 import { RootState } from '@veupathdb/wdk-client/lib/Core/State/Types';
 import { SearchConfig } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
-import { Props as FormProps } from '@veupathdb/wdk-client/lib/Views/Question/DefaultQuestionForm';
+import {
+  ParameterList,
+  Props as FormProps,
+} from '@veupathdb/wdk-client/lib/Views/Question/DefaultQuestionForm';
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { mapValues } from 'lodash';
 
 interface Props {
   recordName: string;
@@ -43,6 +47,32 @@ export function DownloadsFilter(props: Props) {
 }
 
 function FormComponent(props: FormProps) {
-  const { parameterElements } = props;
-  return <>{Object.values(parameterElements)}</>;
+  const { state } = props;
+  // Need to add `isSearchPage` prop so that organism prefs are used
+  const parameterElements = mapValues(
+    props.parameterElements,
+    (parameterElement) => {
+      return React.isValidElement(parameterElement)
+        ? React.cloneElement(
+            parameterElement,
+            {
+              pluginProps: {
+                ...parameterElement.props.pluginProps,
+                isSearchPage: true,
+              },
+            } as any,
+            parameterElement.props.chilren
+          )
+        : parameterElement;
+    }
+  );
+  return (
+    <ParameterList
+      parameterElements={parameterElements}
+      parameterMap={state.question.parametersByName}
+      parameters={state.question.groups[0].parameters}
+      paramDependenciesUpdating={state.paramsUpdatingDependencies}
+    />
+  );
+  // return <>{Object.values(parameterElements)}</>;
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsTable.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/DownloadsTable.tsx
@@ -18,6 +18,8 @@ interface Props {
   bulkSearchName: string;
 }
 
+const R = ResultTableSummaryViewController.withOptions({ showCount: true });
+
 export function DownloadsTable(props: Props) {
   const { searchConfig, tableSearchName, bulkSearchName } = props;
   const { wdkService } = useNonNullableContext(WdkDependenciesContext);
@@ -78,11 +80,13 @@ export function DownloadsTable(props: Props) {
   }, [bulkSearchName, wdkService]);
 
   return (
-    <ResultTableSummaryViewController
-      tableActions={tableActions}
-      viewId="DownloadPage"
-      resultType={tableResultType}
-      showIdAttributeColumn={false}
-    />
+    <>
+      <R
+        tableActions={tableActions}
+        viewId="DownloadPage"
+        resultType={tableResultType}
+        showIdAttributeColumn={false}
+      />
+    </>
   );
 }


### PR DESCRIPTION
### Description

This PR updates the UI of the downloads page to better handle the organism parameter:

- Move the organism param to the top
- Integrate preferred organisms
- Add headings above params
- Add counts to table

Note, this requires some model changes before it can be merged, which I will take care of when this is approved.

### Screenshots

#### Before
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/605c4d42-46fa-4ba4-9b02-07368314228d)

#### After
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/5fb8901b-ab82-43bd-ae2e-729fa953da00)
