### PR TITLE
Add row counts to record page tables

### DIFF
--- a/packages/libs/wdk-client/src/Components/DataTable/DataTable.css
+++ b/packages/libs/wdk-client/src/Components/DataTable/DataTable.css
@@ -136,3 +136,8 @@
   top: -3em;
   margin-left: 310px;
 }
+
+.wdk-DataTableCountsContainer {
+  margin: auto 0 auto 1em;
+  font-size: 0.9em;
+}

--- a/packages/libs/wdk-client/src/Components/DataTable/DataTable.tsx
+++ b/packages/libs/wdk-client/src/Components/DataTable/DataTable.tsx
@@ -124,6 +124,8 @@ interface State {
   childRows: [HTMLElement, ChildRowProps][];
   selectedColumnFilters: string[];
   showFieldSelector: boolean;
+  /** Used to display row counts to user */
+  numberOfRowsVisible: number | null;
 }
 
 /**
@@ -158,6 +160,7 @@ class DataTable extends PureComponent<Props, State> {
     childRows: [],
     selectedColumnFilters: [],
     showFieldSelector: false,
+    numberOfRowsVisible: null,
   };
 
   _childRowContainers: Map<HTMLTableRowElement, HTMLElement> = new Map();
@@ -430,6 +433,11 @@ class DataTable extends PureComponent<Props, State> {
         .search(searchTermRegex, true, false, true)
         .draw();
     }
+    /** set row count after .draw() for correct count */
+    this.setState((state) => ({
+      ...state,
+      numberOfRowsVisible: dataTable.page.info().recordsDisplay,
+    }));
   }
 
   _updateSorting(dataTable: DataTables.Api) {
@@ -662,6 +670,21 @@ class DataTable extends PureComponent<Props, State> {
                   </ul>
                 </div>
               </HelpIcon>
+              <div className="wdk-DataTableCountsContainer">
+                <span>
+                  <strong>
+                    {this.state.numberOfRowsVisible ?? this.props.data.length}
+                  </strong>{' '}
+                  rows
+                </span>{' '}
+                {(this.state.numberOfRowsVisible === 0 ||
+                  this.state.numberOfRowsVisible) &&
+                  this.state.numberOfRowsVisible < this.props.data.length && (
+                    <span className="MesaComponent faded">
+                      (filtered from a total of {this.props.data.length})
+                    </span>
+                  )}
+              </div>
             </div>
             {this.state.showFieldSelector && (
               <DataTableFilterSelector


### PR DESCRIPTION
Resolves [redmine#51970](https://redmine.apidb.org/issues/51970).

**NOTE**: I opted against using [Mesa's `RowCounter` component](https://github.com/VEuPathDB/web-monorepo/blob/main/packages/libs/wdk-client/src/Components/Mesa/Ui/RowCounter.jsx). I felt the props in `RowCounter` would have required more paging state to be held in `DataTables` than we really need.

Screenshots of this work:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/308ae316-1d0d-49f0-a387-92ad01e833ba)
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/938d4811-ae6c-4617-b97b-cac97060c1ef)
