### PR TITLE
Change rounding algorithm in bubble size legend

### DIFF
--- a/packages/libs/components/src/components/plotControls/PlotBubbleLegend.tsx
+++ b/packages/libs/components/src/components/plotControls/PlotBubbleLegend.tsx
@@ -30,11 +30,13 @@ export default function PlotBubbleLegend({
     // The largest circle's value will be the first number that's larger than
     // legendMax and has only one significant digit. Each smaller circle will
     // be half the size of the last (rounded and >= 1)
-    const legendMaxLog10 = Math.floor(Math.log10(legendMax));
+    const roundedOneSigFig = Number(legendMax.toPrecision(1));
     const largestCircleValue =
       legendMax <= 10
         ? legendMax
-        : (Number(legendMax.toPrecision(1)[0]) + 1) * 10 ** legendMaxLog10;
+        : roundedOneSigFig < legendMax
+        ? roundedOneSigFig + 10 ** Math.floor(Math.log10(legendMax)) // effectively rounding up
+        : roundedOneSigFig; // no need to adjust - already rounded up
     const circleValues = _.uniq(
       range(numCircles)
         .map((i) => Math.round(largestCircleValue / 2 ** i))


### PR DESCRIPTION
This issue was that the maxSizeValue from the back end was 196,503. The `toPrecision(1)` rounded this up.  If it had been 149,999, it would have been rounded down and the max bubble size would have been 200,000 as desired.  I've changed the algorithm a bit to hopefully do the right thing.

Before:
![image](https://github.com/VEuPathDB/web-monorepo/assets/308639/e31d44d9-22db-4b2b-bd90-e74c37196d26)

After:
![image](https://github.com/VEuPathDB/web-monorepo/assets/308639/af90e544-6d02-4cfe-9e7e-fde6f41b8b94)
