### PR TITLE
use variable display name in tooltip

### DIFF
--- a/packages/libs/components/src/plots/VolcanoPlot.tsx
+++ b/packages/libs/components/src/plots/VolcanoPlot.tsx
@@ -363,8 +363,8 @@ function VolcanoPlot(props: VolcanoPlotProps, ref: Ref<HTMLDivElement>) {
                   }}
                 >
                   <ul>
-                    {data?.displayLabel
-                      ? data.displayLabel.map((label) => (
+                    {data?.displayLabels
+                      ? data.displayLabels.map((label) => (
                           <li key={label}>
                             <span>{label}</span>
                           </li>

--- a/packages/libs/components/src/plots/VolcanoPlot.tsx
+++ b/packages/libs/components/src/plots/VolcanoPlot.tsx
@@ -363,11 +363,17 @@ function VolcanoPlot(props: VolcanoPlotProps, ref: Ref<HTMLDivElement>) {
                   }}
                 >
                   <ul>
-                    {data?.pointIDs?.map((id) => (
-                      <li key={id}>
-                        <span>{id}</span>
-                      </li>
-                    ))}
+                    {data?.displayLabel
+                      ? data.displayLabel.map((label) => (
+                          <li key={label}>
+                            <span>{label}</span>
+                          </li>
+                        ))
+                      : data?.pointIDs?.map((id) => (
+                          <li key={id}>
+                            <span>{id}</span>
+                          </li>
+                        ))}
                   </ul>
                   <div
                     className="pseudo-hr"

--- a/packages/libs/components/src/types/plots/volcanoplot.ts
+++ b/packages/libs/components/src/types/plots/volcanoplot.ts
@@ -12,7 +12,7 @@ export type VolcanoPlotDataPoint = {
   // Used to determine color of data point in the plot
   significanceColor?: string;
   // Optional user-friendly label. One for each pointID
-  displayLabel?: string[];
+  displayLabels?: string[];
 };
 
 export type VolcanoPlotData = Array<VolcanoPlotDataPoint>;

--- a/packages/libs/components/src/types/plots/volcanoplot.ts
+++ b/packages/libs/components/src/types/plots/volcanoplot.ts
@@ -11,6 +11,8 @@ export type VolcanoPlotDataPoint = {
   pointIDs?: string[];
   // Used to determine color of data point in the plot
   significanceColor?: string;
+  // Optional user-friendly label. One for each pointID
+  displayLabel?: string[];
 };
 
 export type VolcanoPlotData = Array<VolcanoPlotDataPoint>;

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -282,7 +282,7 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
           return {
             ...remainingProperties,
             pointIDs: pointID ? [pointID] : undefined,
-            displayLabel: displayLabel ? [displayLabel] : undefined,
+            displayLabels: displayLabel ? [displayLabel] : undefined,
             significanceColor: assignSignificanceColor(
               Number(d.log2foldChange),
               Number(d.pValue),
@@ -309,7 +309,7 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
         if (foundIndex === -1) {
           aggregatedData.push(entry);
         } else {
-          const { pointIDs } = aggregatedData[foundIndex];
+          const { pointIDs, displayLabels } = aggregatedData[foundIndex];
           if (pointIDs) {
             aggregatedData[foundIndex] = {
               ...aggregatedData[foundIndex],
@@ -317,11 +317,16 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
                 ...pointIDs,
                 ...(entry.pointIDs ? entry.pointIDs : []),
               ],
+              displayLabels: displayLabels && [
+                ...displayLabels,
+                ...(entry.displayLabels ? entry.displayLabels : []),
+              ],
             };
           } else {
             aggregatedData[foundIndex] = {
               ...aggregatedData[foundIndex],
               pointIDs: entry.pointIDs,
+              displayLabels: entry.displayLabels,
             };
           }
         }

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -52,6 +52,7 @@ import SliderWidget, {
 } from '@veupathdb/components/lib/components/widgets/Slider';
 import { ResetButtonCoreUI } from '../../ResetButton';
 import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
+import { fixVarIdLabel } from '../../../utils/visualization';
 // end imports
 
 const DEFAULT_SIG_THRESHOLD = 0.05;
@@ -270,9 +271,18 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
          */
         .map((d) => {
           const { pointID, ...remainingProperties } = d;
+          // Try to find a user-friendly label for the point. Note that pointIDs are in entityID.variableID format.
+          const displayLabel =
+            pointID &&
+            fixVarIdLabel(
+              pointID.split('.')[1],
+              pointID.split('.')[0],
+              entities
+            );
           return {
             ...remainingProperties,
             pointIDs: pointID ? [pointID] : undefined,
+            displayLabel: displayLabel ? [displayLabel] : undefined,
             significanceColor: assignSignificanceColor(
               Number(d.log2foldChange),
               Number(d.pValue),


### PR DESCRIPTION
Resolves #433 

This PR adds a `displayLabel` to the `VolcanoDataPoint` so that if defined, the tooltip can show the user-friendly name instead of the pointID we get from the backend. The pointID is formatted {entityID}.{variableID}, so we can use this to find a display label.

Not too much else to say about this one i think!

<img width="887" alt="Screen Shot 2023-08-18 at 7 15 17 AM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/648a7800-f0de-4f2c-a718-3582c02942f8">

