### PR TITLE
Check dynamic attribute for known columns

### DIFF
--- a/packages/libs/wdk-client/src/Utils/UserPreferencesUtils.ts
+++ b/packages/libs/wdk-client/src/Utils/UserPreferencesUtils.ts
@@ -65,7 +65,9 @@ export async function getResultTableColumnsPref(
 
   const [knownColumns, unknownColumns] = partition(
     columns,
-    (columnName) => columnName in recordClass.attributesMap
+    (columnName) =>
+      recordClass.attributes.some((a) => a.name === columnName) ||
+      question.dynamicAttributes.some((a) => a.name === columnName)
   );
 
   if (unknownColumns.length > 0) {


### PR DESCRIPTION
Dynamic attributes are currently ignored. This PR fixes that.

Test with https://qa.plasmodb.org/plasmo.b65/app/workspace/strategies/import/8a60c52662fdffc0

**Before**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/235566c4-17eb-46e5-ba49-c31dea8f457c)

**After**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/4ea52458-a33a-4952-aa46-a347cb9d0523)
