### PR TITLE
Resolve marker preview bugs w/ bar plot map type 

### DIFF
--- a/packages/libs/components/src/map/ChartMarker.tsx
+++ b/packages/libs/components/src/map/ChartMarker.tsx
@@ -323,7 +323,12 @@ export function getChartMarkerDependentAxisRange(
   isLogScale: boolean
 ) {
   return {
-    min: isLogScale ? 0.1 : 0, // matches what we pass into map markers
+    min: isLogScale
+      ? Math.min(
+          0.1,
+          ...data.filter(({ value }) => value > 0).map(({ value }) => value)
+        )
+      : 0,
     max: Math.max(...data.map((d) => d.value)),
   };
 }

--- a/packages/libs/components/src/map/ChartMarker.tsx
+++ b/packages/libs/components/src/map/ChartMarker.tsx
@@ -315,3 +315,13 @@ function chartMarkerSVGIcon(props: ChartMarkerStandaloneProps): {
     sumValuesString,
   };
 }
+
+export function getChartMarkerDependentAxisRange(
+  data: ChartMarkerProps['data'],
+  isLogScale: boolean
+) {
+  return {
+    min: isLogScale ? 0.1 : 0, // matches what we pass into map markers
+    max: Math.max(...data.map((d) => d.value)),
+  };
+}

--- a/packages/libs/components/src/map/ChartMarker.tsx
+++ b/packages/libs/components/src/map/ChartMarker.tsx
@@ -23,6 +23,7 @@ export interface ChartMarkerProps
   borderWidth?: number;
   data: {
     value: number;
+    count?: number;
     label: string;
     color?: string;
   }[];

--- a/packages/libs/components/src/map/ChartMarker.tsx
+++ b/packages/libs/components/src/map/ChartMarker.tsx
@@ -15,18 +15,19 @@ import {
   MarkerScaleDefault,
 } from '../types/plots';
 
+export type BaseMarkerData = {
+  value: number;
+  label: string;
+  color?: string;
+};
+
 export interface ChartMarkerProps
   extends BoundsDriftMarkerProps,
     MarkerScaleAddon,
     DependentAxisLogScaleAddon {
   borderColor?: string;
   borderWidth?: number;
-  data: {
-    value: number;
-    count?: number;
-    label: string;
-    color?: string;
-  }[];
+  data: BaseMarkerData[];
   isAtomic?: boolean; // add a special thumbtack icon if this is true (it's a marker that won't disaggregate if zoomed in further)
   // changed to dependentAxisRange
   dependentAxisRange?: NumberRange | null; // y-axis range for setting global max

--- a/packages/libs/components/src/map/DonutMarker.tsx
+++ b/packages/libs/components/src/map/DonutMarker.tsx
@@ -11,17 +11,13 @@ import {
 } from '../types/plots';
 
 import { last } from 'lodash';
+import { BaseMarkerData } from './ChartMarker';
 
 // ts definition for HistogramMarkerSVGProps: need some adjustment but for now, just use Donut marker one
 export interface DonutMarkerProps
   extends BoundsDriftMarkerProps,
     MarkerScaleAddon {
-  data: {
-    value: number;
-    count?: number;
-    label: string;
-    color?: string;
-  }[];
+  data: BaseMarkerData[];
   // isAtomic: add a special thumbtack icon if this is true
   isAtomic?: boolean;
   onClick?: (event: L.LeafletMouseEvent) => void | undefined;

--- a/packages/libs/components/src/map/DonutMarker.tsx
+++ b/packages/libs/components/src/map/DonutMarker.tsx
@@ -18,6 +18,7 @@ export interface DonutMarkerProps
     MarkerScaleAddon {
   data: {
     value: number;
+    count?: number;
     label: string;
     color?: string;
   }[];

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -103,6 +103,7 @@ import DonutMarkerComponent, {
 import ChartMarkerComponent, {
   ChartMarkerProps,
   ChartMarkerStandalone,
+  getChartMarkerDependentAxisRange,
 } from '@veupathdb/components/lib/map/ChartMarker';
 import { sharedStandaloneMarkerProperties } from './MarkerConfiguration/CategoricalMarkerPreview';
 import { mFormatter, kFormatter } from '../../core/utils/big-number-formatters';
@@ -512,16 +513,21 @@ function MapAnalysisImpl(props: ImplProps) {
         />
       );
     } else {
+      const dependentAxisLogScale =
+        activeMarkerConfiguration &&
+        'dependentAxisLogScale' in activeMarkerConfiguration
+          ? activeMarkerConfiguration.dependentAxisLogScale
+          : false;
       return (
         <ChartMarkerStandalone
           data={finalData}
           markerLabel={mFormatter(finalData.reduce((p, c) => p + c.value, 0))}
-          dependentAxisLogScale={
-            activeMarkerConfiguration &&
-            'dependentAxisLogScale' in activeMarkerConfiguration
-              ? activeMarkerConfiguration.dependentAxisLogScale
-              : false
-          }
+          dependentAxisLogScale={dependentAxisLogScale}
+          // pass in an axis range to mimic map markers, especially in log scale
+          dependentAxisRange={getChartMarkerDependentAxisRange(
+            finalData,
+            dependentAxisLogScale
+          )}
           {...sharedStandaloneMarkerProperties}
         />
       );

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import {
   InputVariables,
   Props as InputVariablesProps,
@@ -133,6 +133,7 @@ export function BarPlotMarkerConfigurationMenu({
         color: '#333',
       };
     }, [
+      studyId,
       overlayVariable,
       overlayConfiguration?.overlayType,
       subsettingClient,

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerPreview.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerPreview.tsx
@@ -1,6 +1,9 @@
 import { AllValuesDefinition, OverlayConfig } from '../../../core';
 import { ColorPaletteDefault } from '@veupathdb/components/lib/types/plots';
-import { ChartMarkerStandalone } from '@veupathdb/components/lib/map/ChartMarker';
+import {
+  ChartMarkerStandalone,
+  getChartMarkerDependentAxisRange,
+} from '@veupathdb/components/lib/map/ChartMarker';
 import { DonutMarkerStandalone } from '@veupathdb/components/lib/map/DonutMarker';
 import { UNSELECTED_TOKEN } from '../..';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
@@ -68,6 +71,10 @@ export function CategoricalMarkerPreview({
             0,
     }));
     if (mapType === 'barplot') {
+      const dependentAxisRange = getChartMarkerDependentAxisRange(
+        plotData,
+        isDependentAxisLogScaleActive
+      );
       return (
         <div
           style={{
@@ -79,6 +86,8 @@ export function CategoricalMarkerPreview({
             data={plotData}
             markerLabel={mFormatter(plotData.reduce((p, c) => p + c.value, 0))}
             dependentAxisLogScale={isDependentAxisLogScaleActive}
+            // pass in an axis range to mimic map markers, especially in log scale
+            dependentAxisRange={dependentAxisRange}
             {...sharedStandaloneMarkerProperties}
           />
         </div>

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
@@ -32,7 +32,10 @@ import { VariableDescriptor } from '../../../core/types/variable';
 import { useDeepValue } from '../../../core/hooks/immutability';
 import { UNSELECTED_DISPLAY_TEXT, UNSELECTED_TOKEN } from '../..';
 import { DonutMarkerProps } from '@veupathdb/components/lib/map/DonutMarker';
-import { ChartMarkerProps } from '@veupathdb/components/lib/map/ChartMarker';
+import {
+  ChartMarkerProps,
+  BaseMarkerData,
+} from '@veupathdb/components/lib/map/ChartMarker';
 import { BubbleMarkerProps } from '@veupathdb/components/lib/map/BubbleMarker';
 import { validateProportionValues } from '../MarkerConfiguration/BubbleMarkerConfigurationMenu';
 import _ from 'lodash';
@@ -80,12 +83,28 @@ export interface StandaloneMapMarkersProps {
   dependentAxisLogScale?: boolean;
 }
 
+/** We use the count data in the marker previews for continuous vars */
+interface DonutMarkerDataWithCounts extends BaseMarkerData {
+  count: number;
+}
+interface ChartMarkerDataWithCounts extends BaseMarkerData {
+  count: number;
+}
+
+export type DonutMarkerPropsWithCounts = Omit<DonutMarkerProps, 'data'> & {
+  data: DonutMarkerDataWithCounts[];
+};
+
+export type ChartMarkerPropsWithCounts = Omit<ChartMarkerProps, 'data'> & {
+  data: ChartMarkerDataWithCounts[];
+};
+
 // what this hook returns
 interface MapMarkers {
   /** the markers */
   markersData:
-    | DonutMarkerProps[]
-    | ChartMarkerProps[]
+    | DonutMarkerPropsWithCounts[]
+    | ChartMarkerPropsWithCounts[]
     | BubbleMarkerProps[]
     | undefined;
   /** `totalVisibleEntityCount` tells you how many entities are visible at a given viewport. But not necessarily with data for the overlay variable. */

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
@@ -600,9 +600,10 @@ const processRawMarkersData = (
 
       const donutData =
         vocabulary && overlayValues && overlayValues.length
-          ? overlayValues.map(({ binLabel, value }) => ({
+          ? overlayValues.map(({ binLabel, value, count }) => ({
               label: binLabel,
-              value: value,
+              value,
+              count,
               color:
                 overlayType === 'categorical'
                   ? ColorPaletteDefault[vocabulary.indexOf(binLabel)]
@@ -626,6 +627,7 @@ const processRawMarkersData = (
                 donutData.find(({ label }) => label === overlayLabel) ?? {
                   label: fixLabelForOtherValues(overlayLabel),
                   value: 0,
+                  count: 0,
                 }
             )
           : // however, if there is no overlay data


### PR DESCRIPTION
Resolves #326 

This PR addresses two bugs in marker previews:

### log scale bug
- the map markers receive a `dependentAxisRange` that the marker previews were not receiving
- providing the same `dependentAxisRange` to the marker preview appears to resolve this issue

### proportion mode w/ continuous vars
- in proportion mode, the data was erroneously adding together (in a reduce function) _**proportion**_ values that corresponded to the same overlay label in the same manner that we do for counts values; this resulted in an erroneous number displayed as `totalCount` in the marker preview
- now, we add a `count` property to the data that is used to determine `totalCount` irrespective of the plot mode
