### PR TITLE
Tweak mbio layouts

### DIFF
--- a/packages/libs/components/src/components/widgets/LabelledGroup.tsx
+++ b/packages/libs/components/src/components/widgets/LabelledGroup.tsx
@@ -10,6 +10,8 @@ export interface LabelledGroupProps {
   label: ReactNode;
   /** Additional styles to apply to the widget container. */
   containerStyles?: React.CSSProperties;
+  /** Aligns children horizontally beneath the label; defaults to false */
+  alignChildrenHorizontally?: boolean;
 }
 
 /**
@@ -18,7 +20,12 @@ export interface LabelledGroupProps {
  * But renders nothing if no children are contained within it.
  */
 export default function LabelledGroup(props: LabelledGroupProps) {
-  const { children, label, containerStyles } = props;
+  const {
+    children,
+    label,
+    containerStyles,
+    alignChildrenHorizontally = false,
+  } = props;
 
   // don't render anything if all the children (or no children) are null
   if (every(React.Children.toArray(children), (child) => child == null))
@@ -40,11 +47,22 @@ export default function LabelledGroup(props: LabelledGroupProps) {
       }}
     >
       {/* wrapper div to prevent from inline-flex */}
-      <div>
+      <div
+        style={
+          alignChildrenHorizontally
+            ? { display: 'flex', width: '100%', flexWrap: 'wrap' }
+            : undefined
+        }
+      >
         {label && (
           <Typography
             variant="button"
-            style={{ color: DARKEST_GRAY, fontWeight: 500, fontSize: '1.2em' }}
+            style={{
+              color: DARKEST_GRAY,
+              fontWeight: 500,
+              fontSize: '1.2em',
+              ...(alignChildrenHorizontally ? { width: '100%' } : {}),
+            }}
           >
             {label}
           </Typography>

--- a/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
+++ b/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
@@ -145,6 +145,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    width: 13em;
     button {
       height: 10em;
       width: 10em;
@@ -165,7 +166,6 @@
       font-weight: 500;
       text-align: center;
       font-size: 1.2em;
-      max-width: 200px;
     }
   }
   &-FullScreenContainer {

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -339,6 +339,7 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
     dependentAxisRange,
     significanceThreshold,
     log2FoldChangeThreshold,
+    entities,
   ]);
 
   // For the legend, we need the counts of the data

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -588,7 +588,7 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <LabelledGroup label="Threshold lines">
+      <LabelledGroup label="Threshold lines" alignChildrenHorizontally={true}>
         <NumberInput
           onValueChange={(newValue?: NumberOrDate) =>
             updateVizConfig({ log2FoldChangeThreshold: Number(newValue) })
@@ -596,7 +596,7 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
           label="log2(Fold Change)"
           minValue={0}
           value={vizConfig.log2FoldChangeThreshold ?? DEFAULT_FC_THRESHOLD}
-          containerStyles={{ flex: 1 }}
+          containerStyles={{ marginRight: 10 }}
         />
 
         <NumberInput
@@ -606,7 +606,7 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
           }
           minValue={0}
           value={vizConfig.significanceThreshold ?? DEFAULT_SIG_THRESHOLD}
-          containerStyles={{ flex: 1 }}
+          containerStyles={{ marginLeft: 10 }}
           step={0.001}
         />
       </LabelledGroup>


### PR DESCRIPTION
Resolves #443 and #357

Regarding issue 357 (viz picker alignment), I opted to set the width of the container to `13em`, which enforces a similar wrapping of our longest description string on the live site while fixing the icon misalignment. Personally, it doesn't bother me that the text extends beyond the icon, which is why I opted not to set the container's width to `10em`, equal to the button's width.

![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/af9e3f7c-6e50-4c11-a296-be826a6d493a)

And here's a screenshot that reflects the changes for issue 447:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/c3c829b3-2192-4c64-aff5-42885f8d7ec4)
