### PR TITLE
Do not attempt to reorder series data for continuous x-axis variables

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -768,10 +768,15 @@ function LineplotViz(props: VisualizationProps<Options>) {
           response.completeCasesTable
         );
 
-      const xAxisVocabulary = fixLabelsForNumberVariables(
-        xAxisVariable?.vocabulary,
-        xAxisVariable
-      );
+      // This is used for reordering series data.
+      // We don't want to do this for non-continuous variables.
+      const xAxisVocabulary =
+        xAxisVariable.dataShape === 'continuous'
+          ? []
+          : fixLabelsForNumberVariables(
+              xAxisVariable?.vocabulary,
+              xAxisVariable
+            );
       const overlayVocabulary =
         (overlayVariable && options?.getOverlayVocabulary?.()) ??
         fixLabelsForNumberVariables(


### PR DESCRIPTION
closes #455

This PR adds some logic to prevent reordering series data when the xaxis variables is a low-cardinality continuous variable. I'm not sure if we want to apply this to other visualization types. For now, only lineplot allows continuous variables on the xaxis.