### PR TITLE
Remove legacy range types

### DIFF
--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -758,9 +758,9 @@ export const MapMarkersOverlayResponse = type({
 export type BinDefinitions = TypeOf<typeof BinDefinitions>;
 export const BinDefinitions = array(
   type({
-    binStart: string,
-    binEnd: string,
-    binLabel: string,
+    min: string,
+    max: string,
+    label: string,
   })
 );
 
@@ -823,13 +823,12 @@ export const StandaloneMapMarkersResponse = type({
         overlayValues: array(
           intersection([
             type({
-              binLabel: string,
+              label: string,
               value: number,
-              count: number,
             }),
             partial({
-              binStart: string,
-              binEnd: string,
+              min: string,
+              max: string,
             }),
           ])
         ),


### PR DESCRIPTION
This is to address some proposed backend changes described below.  Decided NOT to implement those changes at this time (Aug 2023) because of the client impact and possible DB migration (gross).  But wanted to document what would be needed.  Note if we move forward the client dev should revert these and then use an IDE to redo them to make the change in all the dependent locations.  This code as is will not compile.
```

// removed

  BinRange:
      binStart: string
      binEnd: string
      binLabel: string
  BinRangeWithValue: BinRange
      value: number
  RangeWithCountAndValue: BinRangeWithValue
      count: number

// added

  Range:
      min: string
      max: string
  LabeledRange: Range
      label: string
  LabeledRangeWithValue: LabeledRange
      value: number

// changed

// I believe this is service-side only
AllBinRanges: BinRange -> LabeledRange

ContinousOverlayConfig: overlayValues BinRange[] -> LabeledRange[]

StandaloneMapElementInfo: overlayValues RangeWithCountAndValue[] -> LabeledRangeWithValue[]
```