### PR TITLE
Make sure page footer is not on top of main content elements

### DIFF
--- a/packages/libs/web-common/src/styles/AllSites.scss
+++ b/packages/libs/web-common/src/styles/AllSites.scss
@@ -58,7 +58,7 @@ html {
 
 .main-stack footer {
   position: relative;
-  z-index: 1;
+  z-index: 0;
 }
 
 ._BodyLayer {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/styles/home-page-layout.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/styles/home-page-layout.scss
@@ -55,6 +55,7 @@ body.vpdb-Body .vpdb-RootContainer {
         position: fixed;
         bottom: 0;
         width: 100%;
+        z-index: 1;
       }
 
       .vpdb-Footer__thin {


### PR DESCRIPTION
fixes #458

After:
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/961f2f27-adcc-4aef-a1e6-170b2663edc5)
