### PR TITLE
Hardcode map link

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -37,6 +37,11 @@
         "^build-npm-modules"
       ]
     },
+    "compile:check": {
+      "dependsOn": [
+        "^build-npm-modules"
+      ]
+    },
     "bundle:dev": {
       "dependsOn": [
         "^build-npm-modules"

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -368,8 +368,9 @@ const useHeaderMenuItems = (
       (q) => q.urlSegment === QUESTION_FOR_MAP_DATASETS
     )
   );
-  const showInteractiveMaps = mapMenuItemsQuestion != null;
-  const mapMenuItems = useMapMenuItems(mapMenuItemsQuestion);
+  // const showInteractiveMaps = mapMenuItemsQuestion != null;
+  // const mapMenuItems = useMapMenuItems(mapMenuItemsQuestion);
+  const showInteractiveMaps = projectId === VectorBase && !!useEda;
 
   // type: reactRoute, webAppRoute, externalLink, subMenu, custom
   const fullMenuItemEntries: HeaderMenuItemEntry[] = [
@@ -577,24 +578,37 @@ const useHeaderMenuItems = (
             include: [EuPathDB, UniDB],
           },
         },
+        // {
+        //   key: 'maps-alpha',
+        //   display: (
+        //     <>
+        //       Interactive maps <img alt="BETA" src={betaImage} />
+        //     </>
+        //   ),
+        //   type: 'subMenu',
+        //   metadata: {
+        //     test: () => showInteractiveMaps,
+        //   },
+        //   items: mapMenuItems ?? [
+        //     {
+        //       key: 'maps-loading',
+        //       type: 'custom',
+        //       display: <Loading radius={4} />,
+        //     },
+        //   ],
+        // },
         {
-          key: 'maps-alpha',
+          type: 'reactRoute',
           display: (
             <>
-              Interactive maps <img alt="BETA" src={betaImage} />
+              <img alt="BETA" src={betaImage} /> Multi-study Interactive Map
             </>
           ),
-          type: 'subMenu',
+          key: 'map--mega-study',
+          url: '/workspace/maps/DS_480c976ef9/new',
           metadata: {
             test: () => showInteractiveMaps,
           },
-          items: mapMenuItems ?? [
-            {
-              key: 'maps-loading',
-              type: 'custom',
-              display: <Loading radius={4} />,
-            },
-          ],
         },
         {
           key: 'pubcrawler',


### PR DESCRIPTION
This is a quick workaround to deal with an error that is thrown for non-eda enabled genomic sites.