### PR TITLE
Add search history menu to site search input

### DIFF
--- a/packages/libs/web-common/src/components/SiteSearch/SiteSearch.scss
+++ b/packages/libs/web-common/src/components/SiteSearch/SiteSearch.scss
@@ -157,10 +157,13 @@
           padding: 0.2em 0 0.2em 1em;
           text-align: left;
 
-          &:focus,
-          &:active,
-          &:hover {
-            background: #dedede;
+          &[tabindex] {
+            cursor: pointer;
+            &:focus,
+            &:active,
+            &:hover {
+              background: #dedede;
+            }
           }
 
           &:first-child {
@@ -184,7 +187,7 @@
       }
     }
 
-    button {
+    > button {
       border: none;
       border-radius: 0;
       background: #6c757d;

--- a/packages/libs/web-common/src/components/SiteSearch/SiteSearchHooks.ts
+++ b/packages/libs/web-common/src/components/SiteSearch/SiteSearchHooks.ts
@@ -1,0 +1,16 @@
+import { useStorageBackedState } from '@veupathdb/wdk-client/lib/Hooks/StorageBackedState';
+import {
+  arrayOf,
+  decodeOrElse,
+  string,
+} from '@veupathdb/wdk-client/lib/Utils/Json';
+
+export function useRecentSearches() {
+  return useStorageBackedState(
+    window.localStorage,
+    [],
+    'site-search/history',
+    JSON.stringify,
+    (value) => decodeOrElse(arrayOf(string), [], value)
+  );
+}

--- a/packages/libs/web-common/src/components/SiteSearch/SiteSearchInput.tsx
+++ b/packages/libs/web-common/src/components/SiteSearch/SiteSearchInput.tsx
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty, uniq } from 'lodash';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Tooltip } from '@veupathdb/wdk-client/lib/Components';
@@ -14,9 +14,10 @@ import {
   ORGANISM_PARAM,
   FILTERS_PARAM,
 } from './SiteSearchConstants';
+import { TypeAheadInput } from './TypeAheadInput';
+import { useRecentSearches } from './SiteSearchHooks';
 
 import './SiteSearch.scss';
-import { TypeAheadInput } from './TypeAheadInput';
 
 const cx = makeClassNameHelper('SiteSearch');
 
@@ -58,6 +59,8 @@ export const SiteSearchInput = wrappable(function ({
   const hasFilters =
     !isEmpty(docType) || !isEmpty(organisms) || !isEmpty(fields);
 
+  const [recentSearches, setRecentSearches] = useRecentSearches();
+
   const onSearch = useCallback(
     (queryString: string) => {
       history.push(`${SITE_SEARCH_ROUTE}?${queryString}`);
@@ -65,20 +68,40 @@ export const SiteSearchInput = wrappable(function ({
     [history]
   );
 
+  const saveSearchString = useCallback(() => {
+    if (inputRef.current?.value) {
+      setRecentSearches(uniq([inputRef.current.value].concat(recentSearches)));
+    }
+  }, [setRecentSearches, recentSearches]);
+
   const handleSubmitWithFilters = useCallback(() => {
     const { current } = formRef;
     if (current == null) return;
     const formData = new FormData(current);
     const queryString = new URLSearchParams(formData as any).toString();
     onSearch(queryString);
-  }, [onSearch]);
+    saveSearchString();
+  }, [onSearch, saveSearchString]);
 
   const handleSubmitWithoutFilters = useCallback(() => {
     const queryString = `q=${encodeURIComponent(
       inputRef.current?.value || ''
     )}`;
     onSearch(queryString);
-  }, [onSearch]);
+    saveSearchString();
+  }, [onSearch, saveSearchString]);
+
+  const handleSubmitWithRecentSearch = useCallback(
+    (searchString: string) => {
+      const queryString = `q=${encodeURIComponent(searchString)}`;
+      onSearch(queryString);
+    },
+    [onSearch]
+  );
+
+  const clearRecentSearches = useCallback(() => {
+    setRecentSearches([]);
+  }, [setRecentSearches]);
 
   const [lastSearchQueryString, setLastSearchQueryString] =
     useSessionBackedState<string>(
@@ -132,6 +155,9 @@ export const SiteSearchInput = wrappable(function ({
         inputReference={inputRef}
         searchString={searchString}
         placeHolderText={placeholderText}
+        recentSearches={recentSearches}
+        onRecentSearchSelect={handleSubmitWithRecentSearch}
+        onClearRecentSearches={clearRecentSearches}
       />
       {location.pathname !== SITE_SEARCH_ROUTE && lastSearchQueryString && (
         <Tooltip content="Go back to your last search result">

--- a/packages/libs/web-common/src/components/SiteSearch/SiteSearchInput.tsx
+++ b/packages/libs/web-common/src/components/SiteSearch/SiteSearchInput.tsx
@@ -70,7 +70,9 @@ export const SiteSearchInput = wrappable(function ({
 
   const saveSearchString = useCallback(() => {
     if (inputRef.current?.value) {
-      setRecentSearches(uniq([inputRef.current.value].concat(recentSearches)));
+      setRecentSearches(
+        uniq([inputRef.current.value].concat(recentSearches)).slice(0, 10)
+      );
     }
   }, [setRecentSearches, recentSearches]);
 


### PR DESCRIPTION
This PR adds a search history menu to the site search input. It will be visible if the user has clicked the input, and either the input is empty or its value matches the query param in the url. The menu will disappear if the user selects an option, changes the input value, or clicks outside of the input widget.

![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/739a196b-dc86-4015-aa42-a9deff847c69)
