### PR TITLE
Remove entity from function call, so that featured variables are checked for the entire entity tree

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/appState.ts
+++ b/packages/libs/eda/src/lib/map/analysis/appState.ts
@@ -119,11 +119,8 @@ export function useAppState(uiStateKey: string, analysisState: AnalysisState) {
     getOrElseW(() => undefined)
   );
 
-  const studyMetadata = useStudyMetadata();
   const getDefaultVariableDescriptor = useGetDefaultVariableDescriptor();
-  const defaultVariable = getDefaultVariableDescriptor(
-    studyMetadata.rootEntity.id
-  );
+  const defaultVariable = getDefaultVariableDescriptor();
 
   const defaultAppState: AppState = useMemo(
     () => ({


### PR DESCRIPTION
This PR fixes an issue where non-root-entity featured variables are not used as the default map variable.