### PR TITLE
Fix 471 appconstraints

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -150,14 +150,18 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
   );
 
   const collectionVarItems = useMemo(() => {
-    return collections.map((collectionVar) => ({
-      value: {
-        variableId: collectionVar.id,
-        entityId: collectionVar.entityId,
-      },
-      display:
-        collectionVar.entityDisplayName + ' > ' + collectionVar.displayName,
-    }));
+    return collections
+      .filter((collectionVar) => {
+        return collectionVar.normalizationMethod !== 'NULL';
+      })
+      .map((collectionVar) => ({
+        value: {
+          variableId: collectionVar.id,
+          entityId: collectionVar.entityId,
+        },
+        display:
+          collectionVar.entityDisplayName + ' > ' + collectionVar.displayName,
+      }));
   }, [collections]);
 
   const selectedCollectionVar = useMemo(() => {

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -152,7 +152,9 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
   const collectionVarItems = useMemo(() => {
     return collections
       .filter((collectionVar) => {
-        return collectionVar.normalizationMethod !== 'NULL';
+        return collectionVar.normalizationMethod
+          ? collectionVar.normalizationMethod !== 'NULL'
+          : true;
       })
       .map((collectionVar) => ({
         value: {

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -135,7 +135,9 @@ export function AlphaDivConfiguration(props: ComputationConfigProps) {
   const collectionVarItems = useMemo(() => {
     return collections
       .filter((collectionVar) => {
-        return collectionVar.normalizationMethod !== 'NULL';
+        return collectionVar.normalizationMethod
+          ? collectionVar.normalizationMethod !== 'NULL'
+          : true;
       })
       .map((collectionVar) => ({
         value: {

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -133,14 +133,18 @@ export function AlphaDivConfiguration(props: ComputationConfigProps) {
   );
 
   const collectionVarItems = useMemo(() => {
-    return collections.map((collectionVar) => ({
-      value: {
-        variableId: collectionVar.id,
-        entityId: collectionVar.entityId,
-      },
-      display:
-        collectionVar.entityDisplayName + ' > ' + collectionVar.displayName,
-    }));
+    return collections
+      .filter((collectionVar) => {
+        return collectionVar.normalizationMethod !== 'NULL';
+      })
+      .map((collectionVar) => ({
+        value: {
+          variableId: collectionVar.id,
+          entityId: collectionVar.entityId,
+        },
+        display:
+          collectionVar.entityDisplayName + ' > ' + collectionVar.displayName,
+      }));
   }, [collections]);
 
   const selectedCollectionVar = useMemo(() => {

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -136,14 +136,18 @@ export function BetaDivConfiguration(props: ComputationConfigProps) {
   );
 
   const collectionVarItems = useMemo(() => {
-    return collections.map((collectionVar) => ({
-      value: {
-        variableId: collectionVar.id,
-        entityId: collectionVar.entityId,
-      },
-      display:
-        collectionVar.entityDisplayName + ' > ' + collectionVar.displayName,
-    }));
+    return collections
+      .filter((collectionVar) => {
+        return collectionVar.normalizationMethod !== 'NULL';
+      })
+      .map((collectionVar) => ({
+        value: {
+          variableId: collectionVar.id,
+          entityId: collectionVar.entityId,
+        },
+        display:
+          collectionVar.entityDisplayName + ' > ' + collectionVar.displayName,
+      }));
   }, [collections]);
 
   const selectedCollectionVar = useMemo(() => {

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -138,7 +138,9 @@ export function BetaDivConfiguration(props: ComputationConfigProps) {
   const collectionVarItems = useMemo(() => {
     return collections
       .filter((collectionVar) => {
-        return collectionVar.normalizationMethod !== 'NULL';
+        return collectionVar.normalizationMethod
+          ? collectionVar.normalizationMethod !== 'NULL'
+          : true;
       })
       .map((collectionVar) => ({
         value: {

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -179,7 +179,8 @@ export function DifferentialAbundanceConfiguration(
       .filter((collectionVar) => {
         return (
           !collectionVar.isProportion &&
-          collectionVar.normalizationMethod === 'NULL'
+          collectionVar.normalizationMethod === 'NULL' &&
+          !collectionVar.displayName?.includes('pathway')
         );
       })
       .map((collectionVar) => ({

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -175,14 +175,21 @@ export function DifferentialAbundanceConfiguration(
     );
 
   const collectionVarItems = useMemo(() => {
-    return collections.map((collectionVar) => ({
-      value: {
-        variableId: collectionVar.id,
-        entityId: collectionVar.entityId,
-      },
-      display:
-        collectionVar.entityDisplayName + ' > ' + collectionVar.displayName,
-    }));
+    return collections
+      .filter((collectionVar) => {
+        return (
+          !collectionVar.isProportion &&
+          collectionVar.normalizationMethod === 'NULL'
+        );
+      })
+      .map((collectionVar) => ({
+        value: {
+          variableId: collectionVar.id,
+          entityId: collectionVar.entityId,
+        },
+        display:
+          collectionVar.entityDisplayName + ' > ' + collectionVar.displayName,
+      }));
   }, [collections]);
 
   const selectedCollectionVar = useMemo(() => {

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -177,11 +177,11 @@ export function DifferentialAbundanceConfiguration(
   const collectionVarItems = useMemo(() => {
     return collections
       .filter((collectionVar) => {
-        return (
-          !collectionVar.isProportion &&
-          collectionVar.normalizationMethod === 'NULL' &&
-          !collectionVar.displayName?.includes('pathway')
-        );
+        return collectionVar.normalizationMethod
+          ? !collectionVar.isProportion &&
+              collectionVar.normalizationMethod === 'NULL' &&
+              !collectionVar.displayName?.includes('pathway')
+          : true;
       })
       .map((collectionVar) => ({
         value: {

--- a/packages/libs/eda/src/lib/core/types/study.ts
+++ b/packages/libs/eda/src/lib/core/types/study.ts
@@ -220,6 +220,9 @@ export const CollectionVariableTreeNode = t.intersection([
     units: t.string,
     entityId: t.string,
     entityDisplayName: t.string,
+    isCompositional: t.boolean,
+    isProportion: t.boolean,
+    normalizationMethod: t.string,
   }),
 ]);
 


### PR DESCRIPTION
Resolves #471 and must have for b65

This PR adds a temporary frontend filtering mechanism for the collection variables. In our new database we have both Relative Abundance data and Absolute Abundance data (along wiht lots of other data types). Each app can only handle _either_ the relative abundance or absolute abundance data. The collection vars now include some added properties that we can use to do this filtering on the frontend. 

However, the frontend is _not_ where this filtering should go long term! The infra team is hoping to work on a mechanism for the backend to declare which collections are appropriate for which app, in a way that's similar to how the vizs say they can take categorical but not continuous vars on the x axis, for example. So, #472 was created to ensure we delete these frontend filtering steps when the real solution is ready :) 

To check to ensure my logic is correct, each app should have only one set of Kingdom, Phylum, Class, etc. in the data dropdown. The differential abundance app should _only_ have these options, and no others (no pathway abundance or coverage or anything else). The other three apps can have options that include pathway abundance and coverage and such.

Also note that I can't (or not sure how to?) test these constraints for DIY datasets until it's merged and on qa. The DIY datasets shouldn't have any of these nice annotations, so i've just said if the annotation does not exist go ahead and pass the collection along. 

