### PR TITLE
turn off diff abund

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/index.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/index.ts
@@ -12,7 +12,7 @@ export const plugins: Record<string, ComputationPlugin> = {
   abundance,
   alphadiv,
   betadiv,
-  differentialabundance,
+  // differentialabundance,
   countsandproportions,
   distributions,
   pass,


### PR DESCRIPTION
For b65, we need to release the site with differential abundance turned off. There is a change we can turn it back on with a patch later, but initially at least it should be turned off.