### PR TITLE
slim down donut and bar plots panels

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
@@ -207,9 +207,9 @@ export function BarPlotMarkerConfigurationMenu({
         />
       </div>
       <div style={{ margin: '5px 0 0 0' }}>
-        <span style={{ fontWeight: 'bold' }}>
+        <div style={{ fontWeight: 'bold', marginBottom: '0.5em' }}>
           Summary marker (all filtered data)
-        </span>
+        </div>
         {overlayConfiguration?.overlayType === 'categorical' ? (
           <>
             <CategoricalMarkerPreview

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
@@ -16,7 +16,6 @@ import { CategoricalMarkerConfigurationTable } from './CategoricalMarkerConfigur
 import { CategoricalMarkerPreview } from './CategoricalMarkerPreview';
 import Barplot from '@veupathdb/components/lib/plots/Barplot';
 import { SubsettingClient } from '../../../core/api';
-import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
 import { Toggle } from '@veupathdb/coreui';
 import { SharedMarkerConfigurations } from './PieMarkerConfigurationMenu';
 import { useUncontrolledSelections } from '../hooks/uncontrolledSelections';
@@ -25,6 +24,7 @@ import {
   SelectedCountsOption,
   SelectedValues,
 } from '../appState';
+import { gray } from '@veupathdb/coreui/lib/definitions/colors';
 
 interface MarkerConfiguration<T extends string> {
   type: T;
@@ -185,22 +185,27 @@ export function BarPlotMarkerConfigurationMenu({
       >
         Color:
       </p>
-      <InputVariables
-        inputs={[
-          {
-            name: 'overlayVariable',
-            label: 'Variable',
-            titleOverride: ' ',
-            isNonNullable: true,
-          },
-        ]}
-        entities={entities}
-        selectedVariables={{ overlayVariable: configuration.selectedVariable }}
-        onChange={handleInputVariablesOnChange}
-        starredVariables={starredVariables}
-        toggleStarredVariable={toggleStarredVariable}
-        constraints={constraints}
-      />
+      {/* limit inputVariables width */}
+      <div style={{ maxWidth: '350px' }}>
+        <InputVariables
+          inputs={[
+            {
+              name: 'overlayVariable',
+              label: 'Variable',
+              titleOverride: ' ',
+              isNonNullable: true,
+            },
+          ]}
+          entities={entities}
+          selectedVariables={{
+            overlayVariable: configuration.selectedVariable,
+          }}
+          onChange={handleInputVariablesOnChange}
+          starredVariables={starredVariables}
+          toggleStarredVariable={toggleStarredVariable}
+          constraints={constraints}
+        />
+      </div>
       <div style={{ margin: '5px 0 0 0' }}>
         <span style={{ fontWeight: 'bold' }}>
           Summary marker (all filtered data)
@@ -221,7 +226,17 @@ export function BarPlotMarkerConfigurationMenu({
           continuousMarkerPreview
         )}
       </div>
-      <LabelledGroup label="Marker X-axis controls">
+      <div style={{ maxWidth: '360px', marginTop: '1em' }}>
+        <div
+          style={{
+            color: gray[900],
+            fontWeight: 500,
+            fontSize: '1.2em',
+            marginBottom: '0.5em',
+          }}
+        >
+          Marker X-axis controls
+        </div>
         <RadioButtonGroup
           containerStyles={
             {
@@ -231,13 +246,9 @@ export function BarPlotMarkerConfigurationMenu({
           label="Binning method"
           selectedOption={configuration.binningMethod ?? 'equalInterval'}
           options={['equalInterval', 'quantile', 'standardDeviation']}
-          optionLabels={[
-            'Equal interval',
-            'Quantile (10)',
-            'Standard deviation',
-          ]}
+          optionLabels={['Equal interval', 'Quantile (10)', 'Std. dev.']}
           buttonColor={'primary'}
-          // margins={['0em', '0', '0', '1em']}
+          // margins={['-1em', '0', '0', '0em']}
           onOptionSelected={handleBinningMethodSelection}
           disabledList={
             overlayConfiguration?.overlayType === 'continuous'
@@ -245,8 +256,18 @@ export function BarPlotMarkerConfigurationMenu({
               : ['equalInterval', 'quantile', 'standardDeviation']
           }
         />
-      </LabelledGroup>
-      <LabelledGroup label="Marker Y-axis controls">
+      </div>
+      <div style={{ maxWidth: '360px', marginTop: '1em', marginBottom: '1em' }}>
+        <div
+          style={{
+            color: gray[900],
+            fontWeight: 500,
+            fontSize: '1.2em',
+            marginBottom: '0.5em',
+          }}
+        >
+          Marker Y-axis controls
+        </div>
         <RadioButtonGroup
           containerStyles={
             {
@@ -258,7 +279,7 @@ export function BarPlotMarkerConfigurationMenu({
           options={['count', 'proportion']}
           optionLabels={['Count', 'Proportion']}
           buttonColor={'primary'}
-          // margins={['0em', '0', '0', '1em']}
+          // margins={['-1em', '0', '0', '1em']}
           onOptionSelected={handlePlotModeSelection}
         />
         <Toggle
@@ -267,21 +288,23 @@ export function BarPlotMarkerConfigurationMenu({
           value={configuration.dependentAxisLogScale}
           onChange={handleLogScaleChange}
         />
-      </LabelledGroup>
+      </div>
       {overlayConfiguration?.overlayType === 'categorical' && (
-        <CategoricalMarkerConfigurationTable
-          overlayValues={overlayConfiguration.overlayValues}
-          configuration={configuration}
-          onChange={onChange}
-          uncontrolledSelections={uncontrolledSelections}
-          setUncontrolledSelections={setUncontrolledSelections}
-          allCategoricalValues={
-            configuration.selectedCountsOption === 'filtered'
-              ? allFilteredCategoricalValues
-              : allVisibleCategoricalValues
-          }
-          selectedCountsOption={configuration.selectedCountsOption}
-        />
+        <div style={{ maxWidth: '360px', marginTop: '1em' }}>
+          <CategoricalMarkerConfigurationTable
+            overlayValues={overlayConfiguration.overlayValues}
+            configuration={configuration}
+            onChange={onChange}
+            uncontrolledSelections={uncontrolledSelections}
+            setUncontrolledSelections={setUncontrolledSelections}
+            allCategoricalValues={
+              configuration.selectedCountsOption === 'filtered'
+                ? allFilteredCategoricalValues
+                : allVisibleCategoricalValues
+            }
+            selectedCountsOption={configuration.selectedCountsOption}
+          />
+        </div>
       )}
       {overlayConfiguration?.overlayType === 'continuous' && barplotData.value && (
         <div style={{ margin: '5px 0 0 0' }}>
@@ -301,8 +324,8 @@ export function BarPlotMarkerConfigurationMenu({
               marginBottom: 0,
             }}
             containerStyles={{
-              height: 250,
-              width: 400,
+              height: '300px',
+              maxWidth: '360px',
             }}
           />
         </div>

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
@@ -194,14 +194,14 @@ export function CategoricalMarkerConfigurationTable<T>({
   return (
     <div
       style={{
-        padding: 15,
+        padding: 10,
         border: `1px solid rgb(204,204,204)`,
         width: 'fit-content',
       }}
     >
       <div
         style={{
-          maxWidth: '50vw',
+          maxWidth: '340px',
           maxHeight: 300,
           overflow: 'auto',
         }}
@@ -221,7 +221,7 @@ export function CategoricalMarkerConfigurationTable<T>({
         options={['filtered', 'visible']}
         optionLabels={['Filtered', 'Visible']}
         buttonColor={'primary'}
-        // margins={['0em', '0', '0', '1em']}
+        margins={['1em', '0', '0', '0em']}
         onOptionSelected={handleCountsSelection}
       />
     </div>

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
@@ -169,6 +169,10 @@ export function CategoricalMarkerConfigurationTable<T>({
          */
         key: 'label',
         name: 'Values',
+        style: {
+          wordBreak: 'break-word',
+          hyphens: 'auto',
+        },
         sortable: true,
         renderCell: (data: { row: AllValuesDefinition }) => (
           <>{data.row.label}</>

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerPreview.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerPreview.tsx
@@ -19,7 +19,7 @@ type Props = {
 };
 
 export const sharedStandaloneMarkerProperties = {
-  markerScale: 3,
+  markerScale: 2.5,
   containerStyles: {
     width: 'fit-content',
     height: 'fit-content',

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
@@ -214,10 +214,10 @@ export function PieMarkerConfigurationMenu({
               // marginTop: 20,
             }
           }
-          label="Binning method (Dev. = Deviation)"
+          label="Binning method"
           selectedOption={configuration.binningMethod ?? 'equalInterval'}
           options={['equalInterval', 'quantile', 'standardDeviation']}
-          optionLabels={['Equal interval', 'Quantile (10)', 'Standard dev.']}
+          optionLabels={['Equal interval', 'Quantile (10)', 'Std. dev.']}
           buttonColor={'primary'}
           // margins={['0em', '0', '0', '1em']}
           onOptionSelected={handleBinningMethodSelection}

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
@@ -193,9 +193,9 @@ export function PieMarkerConfigurationMenu({
         />
       </div>
       <div style={{ margin: '5px 0 0 0' }}>
-        <span style={{ fontWeight: 'bold' }}>
+        <div style={{ fontWeight: 'bold', marginBottom: '0.5em' }}>
           Summary marker (all filtered data)
-        </span>
+        </div>
         {overlayConfiguration?.overlayType === 'categorical' ? (
           <CategoricalMarkerPreview
             overlayConfiguration={overlayConfiguration}

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
@@ -17,7 +17,6 @@ import { CategoricalMarkerPreview } from './CategoricalMarkerPreview';
 import Barplot from '@veupathdb/components/lib/plots/Barplot';
 import { SubsettingClient } from '../../../core/api';
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
-import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
 import { useUncontrolledSelections } from '../hooks/uncontrolledSelections';
 import {
   BinningMethod,
@@ -172,22 +171,27 @@ export function PieMarkerConfigurationMenu({
       >
         Color:
       </p>
-      <InputVariables
-        inputs={[
-          {
-            name: 'overlayVariable',
-            label: 'Variable',
-            titleOverride: ' ',
-            isNonNullable: true,
-          },
-        ]}
-        entities={entities}
-        selectedVariables={{ overlayVariable: configuration.selectedVariable }}
-        onChange={handleInputVariablesOnChange}
-        starredVariables={starredVariables}
-        toggleStarredVariable={toggleStarredVariable}
-        constraints={constraints}
-      />
+      {/* limit inputVariables width */}
+      <div style={{ maxWidth: '350px' }}>
+        <InputVariables
+          inputs={[
+            {
+              name: 'overlayVariable',
+              label: 'Variable',
+              titleOverride: ' ',
+              isNonNullable: true,
+            },
+          ]}
+          entities={entities}
+          selectedVariables={{
+            overlayVariable: configuration.selectedVariable,
+          }}
+          onChange={handleInputVariablesOnChange}
+          starredVariables={starredVariables}
+          toggleStarredVariable={toggleStarredVariable}
+          constraints={constraints}
+        />
+      </div>
       <div style={{ margin: '5px 0 0 0' }}>
         <span style={{ fontWeight: 'bold' }}>
           Summary marker (all filtered data)
@@ -203,21 +207,17 @@ export function PieMarkerConfigurationMenu({
           continuousMarkerPreview
         )}
       </div>
-      <LabelledGroup label="Donut marker controls">
+      {overlayConfiguration?.overlayType === 'continuous' && (
         <RadioButtonGroup
           containerStyles={
             {
               // marginTop: 20,
             }
           }
-          label="Binning method"
+          label="Binning method (Dev. = Deviation)"
           selectedOption={configuration.binningMethod ?? 'equalInterval'}
           options={['equalInterval', 'quantile', 'standardDeviation']}
-          optionLabels={[
-            'Equal interval',
-            'Quantile (10)',
-            'Standard deviation',
-          ]}
+          optionLabels={['Equal interval', 'Quantile (10)', 'Standard dev.']}
           buttonColor={'primary'}
           // margins={['0em', '0', '0', '1em']}
           onOptionSelected={handleBinningMethodSelection}
@@ -227,7 +227,7 @@ export function PieMarkerConfigurationMenu({
               : ['equalInterval', 'quantile', 'standardDeviation']
           }
         />
-      </LabelledGroup>
+      )}
       {overlayConfiguration?.overlayType === 'categorical' && (
         <CategoricalMarkerConfigurationTable
           overlayValues={overlayConfiguration.overlayValues}
@@ -261,7 +261,9 @@ export function PieMarkerConfigurationMenu({
               marginBottom: 0,
             }}
             containerStyles={{
-              height: 300,
+              // set barplot maxWidth
+              height: '300px',
+              maxWidth: '360px',
             }}
           />
         </div>


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/426. Detailed descriptions are listed in the following:

- requirements (taken from the ticket)
- [x] remove Binning method radio buttons for variable types that don't need it (presumably categorical)
: addressed

- [x] narrow the radio buttons for when they are needed - the default featured variable could be continuous
: I think that one of the best approach is to use acronym for certain radio button label: there are not much room for reducing the spacing in the radio buttons, I suppose. I chose deviation as dev. as it is commonly used as a short word: or we may use Std as the acronym of the standard deviation. Just in case, full word is explained at button title, but perhaps a text below the radio buttons can be utilized as well.

- [x] Remove the "Donut marker controls" heading? It doesn't save any width but it does save height and is not telling the user anything useful
: addressed

- [x] Think about long variable names in the variable picker (max width/ellipsis if not already implemented?)
- [x] Think about long value names (in the categorical config table) (ellipsis or wrap?)
: for both cases, there were no implementation on the ellipsis for both variable picker and data table. After seeking out a solution, perhaps the easiest solution is to set max width, then lengthy strings are naturally wrapped

In addition, barplot width is also adjusted so that it can be fitted to the max width. And some margins are changed so that it can be better displayed overall.

Screenshots are attached in the following for demonstrating above changes:

- original layout
![sam donut layout01](https://github.com/VEuPathDB/web-monorepo/assets/12802305/eef0e856-c2bb-4097-b335-fdef9ed45f6a)

- after changing: categorical variable with lengthy table values
![sam donut layout01-2](https://github.com/VEuPathDB/web-monorepo/assets/12802305/64419661-9967-49b9-90f7-fd8a7cce3415)


- after changing: continuous variable (with lengthy variable at the variable picker). As mentioned above, (Dev. = Deviation) may be located in the bottom of the radio buttons
![SAM donut layout02](https://github.com/VEuPathDB/web-monorepo/assets/12802305/decd3973-81d3-47f3-9be1-6647bdf06eab)


