### PR TITLE
Disable floater overlays in bubble mode

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/options/types.ts
+++ b/packages/libs/eda/src/lib/core/components/visualizations/options/types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { OverlayConfig } from '../../../api/DataClient';
 import { Filter } from '../../../types/filter';
 import { VariableDescriptor } from '../../../types/variable';
@@ -11,7 +12,7 @@ export interface OverlayOptions {
   getOverlayVariable?: (
     computeConfig: unknown
   ) => VariableDescriptor | undefined;
-  getOverlayVariableHelp?: () => string;
+  getOverlayVariableHelp?: () => ReactNode;
   getOverlayType?: () => OverlayConfig['overlayType'] | undefined;
   getOverlayVocabulary?: () => string[] | undefined;
   getCheckedLegendItems?: (computeConfig: unknown) => string[] | undefined;

--- a/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
@@ -75,7 +75,7 @@ export default function DraggableVisualization({
       panelTitle={activeVizOverview?.displayName || ''}
       defaultPosition={{
         x: 535,
-        y: 142,
+        y: 220,
       }}
       onPanelDismiss={() => setActiveVisualizationId(undefined)}
     >

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -632,7 +632,14 @@ function MapAnalysisImpl(props: ImplProps) {
   );
 
   const plugins = useStandaloneVizPlugins({
-    selectedOverlayConfig: activeOverlayConfig.value,
+    selectedOverlayConfig:
+      activeMarkerConfigurationType === 'bubble'
+        ? undefined
+        : activeOverlayConfig.value,
+    overlayHelp:
+      activeMarkerConfigurationType === 'bubble'
+        ? 'Overlay variables are not available for this map type'
+        : undefined,
   });
 
   const subsetVariableAndEntity = useMemo(() => {

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import * as t from 'io-ts';
 import { ComputationPlugin } from '../../../core/components/computations/Types';
 import { ZeroConfigWithButton } from '../../../core/components/computations/ZeroConfiguration';
@@ -33,12 +33,14 @@ import _ from 'lodash';
 
 interface Props {
   selectedOverlayConfig?: OverlayConfig | BubbleOverlayConfig;
+  overlayHelp?: ReactNode;
 }
 
 type StandaloneVizOptions = LayoutOptions & OverlayOptions;
 
 export function useStandaloneVizPlugins({
   selectedOverlayConfig,
+  overlayHelp = 'The overlay variable can be selected via the top-right panel.',
 }: Props): Record<string, ComputationPlugin> {
   return useMemo(() => {
     function vizWithOptions(
@@ -67,8 +69,7 @@ export function useStandaloneVizPlugins({
             return overlayValues;
           }
         },
-        getOverlayVariableHelp: () =>
-          'The overlay variable can be selected via the top-right panel.',
+        getOverlayVariableHelp: () => overlayHelp,
       });
     }
 


### PR DESCRIPTION
Fixes #492 

I update the overlay help verbiage for bubbles:
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/2432b7d3-6939-4b00-8186-6cd5a983b824)

ETA, I also updated the default position of the floater so it doesn't overlap with the timeslider.