### PR TITLE
Add condition to deleting marker floaters logic

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MapVizManagement.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapVizManagement.tsx
@@ -243,7 +243,12 @@ function VisualizationsList({
                               analysisState.deleteVisualization(
                                 viz.visualizationId
                               );
-                              setActiveVisualizationId(undefined);
+                              if (
+                                activeVisualization?.visualizationId ===
+                                viz.visualizationId
+                              ) {
+                                setActiveVisualizationId(undefined);
+                              }
                             }}
                           >
                             <i aria-hidden className="fa fa-trash"></i>


### PR DESCRIPTION
Resolves #427 

Previously, deleting a floater always invoked `setActiveVisualizationId(undefined)`. Now, we'll only do so if the viz being deleted is the active viz.

**NOTE**
The deletion will update `analysisState`, causing the loader to spin on the active viz. This may be another thing to consider when we have our deep think about our data requests. As a user, I'd be a bit confused why deleting a non-active viz results in a loading state. This issue feels a bit out of scope for this ticket, but perhaps it's not? Thoughts on if I should investigate further in the context of this ticket, or should it wait until our proper deep think?