### PR TITLE
Add traceid to FetchClientError message

### DIFF
--- a/packages/libs/http-utils/src/FetchClient.ts
+++ b/packages/libs/http-utils/src/FetchClient.ts
@@ -104,12 +104,14 @@ export abstract class FetchClient {
 
       return await transformResponse(responseBody);
     }
-    const fetchError = new FetchClientError(
-      `${response.status} ${
-        response.statusText
-      }: ${request.method.toUpperCase()} ${request.url}
-      ${'\n'}${await response.text()}`
-    );
+    const { status, statusText } = response;
+    const { headers, method, url } = request;
+    const traceid = headers.get('traceid');
+    const fetchError = new FetchClientError(`
+      ${status} ${statusText}: ${method.toUpperCase()} ${url}
+      ${traceid != null ? 'Traceid: ' + traceid : ''}
+
+      ${await response.text()}`);
     this.onNonSuccessResponse?.(fetchError);
     throw fetchError;
   }


### PR DESCRIPTION
This PR includes the traceid header value in FetchClient error messages. This is useful for finding associates service logs. 