### PR TITLE
Added filter- and subset-sensitivity to timeslider

### DIFF
--- a/packages/libs/eda/src/lib/core/utils/trim.ts
+++ b/packages/libs/eda/src/lib/core/utils/trim.ts
@@ -1,0 +1,10 @@
+import { dropRightWhile, dropWhile } from 'lodash';
+
+/**
+ * Something that should be in lodash!  Oh, it nearly is.
+ *
+ * Trim an array from the start and end, removing elements for which the filter function returns true
+ */
+export function trimArray<T>(array: Array<T>, filter: (val: T) => boolean) {
+  return dropRightWhile(dropWhile(array, filter), filter);
+}

--- a/packages/libs/eda/src/lib/map/analysis/EZTimeFilter.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/EZTimeFilter.tsx
@@ -44,7 +44,7 @@ export default function EZTimeFilter({
   config,
   updateConfig,
 }: Props) {
-  const findEntityAndVariable = useFindEntityAndVariable(filters); // filter aware
+  const findEntityAndVariable = useFindEntityAndVariable(filters); // filter sensitivity
   const [minimized, setMinimized] = useState(true);
 
   const { variable, active, selectedRange } = config;
@@ -100,6 +100,7 @@ export default function EZTimeFilter({
   const timeFilterData: EZTimeFilterDataProp[] = useMemo(
     () =>
       trimArray(
+        // remove leading and trailing zeroes (subset sensitivity)
         !getTimeSliderData.pending && getTimeSliderData.value != null
           ? zip(getTimeSliderData.value.x, getTimeSliderData.value.y)
               .map(([xValue, yValue]) => ({ x: xValue, y: yValue }))
@@ -109,7 +110,7 @@ export default function EZTimeFilter({
                   val.x != null && val.y != null
               )
           : [],
-        ({ y }) => y === 0 // remove leading and trailing zeroes (filter sensitivity)
+        ({ y }) => y === 0
       ),
     [getTimeSliderData]
   );

--- a/packages/libs/eda/src/lib/map/analysis/EZTimeFilter.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/EZTimeFilter.tsx
@@ -19,6 +19,7 @@ import { useFindEntityAndVariable, Filter } from '../../core';
 import { zip } from 'lodash';
 import { AppState } from './appState';
 import { timeSliderVariableConstraints } from './config/eztimeslider';
+import { trimArray } from '../../core/utils/trim';
 
 interface Props {
   studyId: string;
@@ -43,7 +44,7 @@ export default function EZTimeFilter({
   config,
   updateConfig,
 }: Props) {
-  const findEntityAndVariable = useFindEntityAndVariable();
+  const findEntityAndVariable = useFindEntityAndVariable(filters); // filter aware
   const [minimized, setMinimized] = useState(true);
 
   const { variable, active, selectedRange } = config;
@@ -98,15 +99,18 @@ export default function EZTimeFilter({
   // converting data to visx format
   const timeFilterData: EZTimeFilterDataProp[] = useMemo(
     () =>
-      !getTimeSliderData.pending && getTimeSliderData.value != null
-        ? zip(getTimeSliderData.value.x, getTimeSliderData.value.y)
-            .map(([xValue, yValue]) => ({ x: xValue, y: yValue }))
-            // and a type guard filter to avoid any `!` assertions.
-            .filter(
-              (val): val is EZTimeFilterDataProp =>
-                val.x != null && val.y != null
-            )
-        : [],
+      trimArray(
+        !getTimeSliderData.pending && getTimeSliderData.value != null
+          ? zip(getTimeSliderData.value.x, getTimeSliderData.value.y)
+              .map(([xValue, yValue]) => ({ x: xValue, y: yValue }))
+              // and a type guard filter to avoid any `!` assertions.
+              .filter(
+                (val): val is EZTimeFilterDataProp =>
+                  val.x != null && val.y != null
+              )
+          : [],
+        ({ y }) => y === 0 // remove leading and trailing zeroes (filter sensitivity)
+      ),
     [getTimeSliderData]
   );
 


### PR DESCRIPTION
Fixes #514 

As suggested in https://veupathdb.atlassian.net/wiki/spaces/WG/pages/367951873/2023-09-14+Map+UX by @dmfalke and others. The timeslider will now honour the "big filters" but not the viewport or any "little filters".

In theory we don't need the filter-sensitive part, but it will reduce the number of bins coming back from the `distribution` service call and thus help marginally with performance.