### PR TITLE
added correlation plugin

### DIFF
--- a/packages/libs/components/src/plots/BipartiteNetwork.tsx
+++ b/packages/libs/components/src/plots/BipartiteNetwork.tsx
@@ -1,8 +1,4 @@
-import {
-  BipartiteNetworkData,
-  LinkData,
-  NodeData,
-} from '../types/plots/network';
+import { BipartiteNetworkData, NodeData } from '../types/plots/network';
 import { partition } from 'lodash';
 import { LabelPosition, Link, NodeWithLabel } from './Network';
 import { Graph } from '@visx/network';
@@ -16,7 +12,6 @@ import {
 } from 'react';
 import { DEFAULT_CONTAINER_HEIGHT } from './PlotlyPlot';
 import Spinner from '../components/Spinner';
-import { twoColorPalette } from '../types/plots/addOns';
 import { ToImgopts } from 'plotly.js';
 import domToImage from 'dom-to-image';
 

--- a/packages/libs/components/src/plots/BipartiteNetwork.tsx
+++ b/packages/libs/components/src/plots/BipartiteNetwork.tsx
@@ -1,4 +1,8 @@
-import { BipartiteNetworkData, NodeData } from '../types/plots/network';
+import {
+  BipartiteNetworkData,
+  LinkData,
+  NodeData,
+} from '../types/plots/network';
 import { partition } from 'lodash';
 import { LabelPosition, Link, NodeWithLabel } from './Network';
 import { Graph } from '@visx/network';
@@ -6,6 +10,7 @@ import { Text } from '@visx/text';
 import { CSSProperties } from 'react';
 import { DEFAULT_CONTAINER_HEIGHT } from './PlotlyPlot';
 import Spinner from '../components/Spinner';
+import { twoColorPalette } from '../types/plots/addOns';
 
 export interface BipartiteNetworkProps {
   /** Bipartite network data */

--- a/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
+++ b/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
@@ -8,7 +8,7 @@ import {
   BipartiteNetwork,
   BipartiteNetworkProps,
 } from '../../plots/BipartiteNetwork';
-import { twoColorPalette } from '../../types/plots';
+import { twoColorPalette } from '../../types/plots/addOns';
 
 export default {
   title: 'Plots/Network/BipartiteNetwork',

--- a/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
+++ b/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
@@ -1,11 +1,11 @@
+import { useState, useEffect, useRef } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import {
   NodeData,
   LinkData,
   BipartiteNetworkData,
 } from '../../types/plots/network';
-import {
-  BipartiteNetwork,
+import BipartiteNetwork, {
   BipartiteNetworkProps,
 } from '../../plots/BipartiteNetwork';
 import { twoColorPalette } from '../../types/plots/addOns';
@@ -20,17 +20,41 @@ interface TemplateProps {
   column1Name?: string;
   column2Name?: string;
   loading?: boolean;
+  showThumbnail?: boolean;
 }
 
 // Template for showcasing our BipartiteNetwork component.
 const Template: Story<TemplateProps> = (args) => {
+  // Generate a jpeg version of the network (svg).
+  // Mimicks the makePlotThumbnailUrl process in web-eda.
+  const ref = useRef<any>(null);
+  const [img, setImg] = useState('');
+  useEffect(() => {
+    setTimeout(() => {
+      ref.current
+        ?.toImage({ format: 'jpeg', height: 400, width: 600 })
+        .then((src: string) => setImg(src));
+    }, 2000);
+  }, []);
+
   const bipartiteNetworkProps: BipartiteNetworkProps = {
     data: args.data,
     column1Name: args.column1Name,
     column2Name: args.column2Name,
     showSpinner: args.loading,
   };
-  return <BipartiteNetwork {...bipartiteNetworkProps} />;
+  return (
+    <>
+      <BipartiteNetwork ref={ref} {...bipartiteNetworkProps} />
+      {args.showThumbnail && (
+        <>
+          <br></br>
+          <h3>A snapshot of the plot will appear below after two sconds...</h3>
+          <img src={img} />
+        </>
+      )}
+    </>
+  );
 };
 
 /**
@@ -66,6 +90,15 @@ Loading.args = {
   column1Name: 'Column 1',
   column2Name: 'Column 2',
   loading: true,
+};
+
+// Show thumbnail
+export const Thumbnail = Template.bind({});
+Thumbnail.args = {
+  data: genBipartiteNetwork(10, 10),
+  column1Name: 'Column 1',
+  column2Name: 'Column 2',
+  showThumbnail: true,
 };
 
 // Gerenate a bipartite network with a given number of nodes and random edges

--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -25,7 +25,6 @@ import {
 } from '../../types/general';
 import { VariableDescriptor, StringVariableValue } from '../../types/variable';
 import { ComputationAppOverview } from '../../types/visualization';
-import { BipartiteNetworkData } from '@veupathdb/components/lib/types/plots/network';
 
 export const AppsResponse = type({
   apps: array(ComputationAppOverview),

--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -25,6 +25,7 @@ import {
 } from '../../types/general';
 import { VariableDescriptor, StringVariableValue } from '../../types/variable';
 import { ComputationAppOverview } from '../../types/visualization';
+import { BipartiteNetworkData } from '@veupathdb/components/lib/types/plots/network';
 
 export const AppsResponse = type({
   apps: array(ComputationAppOverview),
@@ -371,6 +372,36 @@ export interface VolcanoPlotRequestParams {
   studyId: string;
   filters: Filter[];
   config: {}; // Empty viz config because there are no viz input vars
+}
+
+// Bipartite network
+export type BipartiteNetworkResponse = TypeOf<typeof BipartiteNetworkResponse>;
+
+const NodeData = type({
+  id: string,
+});
+
+export const BipartiteNetworkResponse = type({
+  column1NodeIDs: array(string),
+  column2NodeIDs: array(string),
+  nodes: array(NodeData),
+  links: array(
+    type({
+      source: NodeData,
+      target: NodeData,
+      strokeWidth: number,
+      color: string,
+    })
+  ),
+});
+
+export interface BipartiteNetworkRequestParams {
+  studyId: string;
+  filters: Filter[];
+  config: {
+    correlationCoefThreshold?: number;
+    significanceThreshold?: number;
+  };
 }
 
 ////////////////

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -8,7 +8,6 @@ import { Computation } from '../../../types/visualization';
 import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
 import { useMemo } from 'react';
 import { ComputationStepContainer } from '../ComputationStepContainer';
-import { Filter } from '../../..';
 import './Plugins.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { H6 } from '@veupathdb/coreui';

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -112,6 +112,9 @@ export function CorrelationAssayMetadataConfiguration(
     visualizationId,
   } = props;
 
+  console.log(computation);
+  console.log(computationAppOverview);
+
   const configuration = computation.descriptor
     .configuration as CorrelationAssayMetadataConfig;
   const studyMetadata = useStudyMetadata();

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -1,0 +1,193 @@
+import { useCollectionVariables, useStudyMetadata } from '../../..';
+import { VariableDescriptor } from '../../../types/variable';
+import { ComputationConfigProps, ComputationPlugin } from '../Types';
+import { isEqual, partial } from 'lodash';
+import { useConfigChangeHandler, assertComputationWithConfig } from '../Utils';
+import * as t from 'io-ts';
+import { Computation } from '../../../types/visualization';
+import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
+import { useMemo } from 'react';
+import { ComputationStepContainer } from '../ComputationStepContainer';
+import { Filter } from '../../..';
+import './Plugins.scss';
+import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import { H6 } from '@veupathdb/coreui';
+import { bipartiteNetworkVisualization } from '../../visualizations/implementations/BipartiteNetworkVisualization';
+
+const cx = makeClassNameHelper('AppStepConfigurationContainer');
+
+/**
+ * Correlation
+ *
+ * info...
+ */
+
+export type CorrelationAssayMetadataConfig = t.TypeOf<
+  typeof CorrelationAssayMetadataConfig
+>;
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const CorrelationAssayMetadataConfig = t.type({
+  collectionVariable: VariableDescriptor,
+  correlationMethod: t.string,
+});
+
+export const plugin: ComputationPlugin = {
+  configurationComponent: CorrelationAssayMetadataConfiguration,
+  configurationDescriptionComponent:
+    CorrelationAssayMetadataConfigDescriptionComponent,
+  createDefaultConfiguration: () => undefined,
+  isConfigurationValid: CorrelationAssayMetadataConfig.is,
+  visualizationPlugins: {
+    bipartitenetwork: bipartiteNetworkVisualization, // Must match name in data service and in visualization.tsx
+  },
+};
+
+// Yikes what a name
+function CorrelationAssayMetadataConfigDescriptionComponent({
+  computation,
+}: {
+  computation: Computation;
+}) {
+  const studyMetadata = useStudyMetadata();
+  const collections = useCollectionVariables(studyMetadata.rootEntity);
+  assertComputationWithConfig<CorrelationAssayMetadataConfig>(
+    computation,
+    Computation
+  );
+
+  const { configuration } = computation.descriptor;
+  const collectionVariable =
+    'collectionVariable' in configuration
+      ? configuration.collectionVariable
+      : undefined;
+  const correlationMethod =
+    'correlationMethod' in configuration
+      ? configuration.correlationMethod
+      : undefined;
+
+  const updatedCollectionVariable = collections.find((collectionVar) =>
+    isEqual(
+      {
+        variableId: collectionVar.id,
+        entityId: collectionVar.entityId,
+      },
+      collectionVariable
+    )
+  );
+
+  return (
+    <div className="ConfigDescriptionContainer">
+      <h4>
+        Data:{' '}
+        <span>
+          {updatedCollectionVariable ? (
+            `${updatedCollectionVariable?.entityDisplayName} > ${updatedCollectionVariable?.displayName}`
+          ) : (
+            <i>Not selected</i>
+          )}
+        </span>
+      </h4>
+      <h4>
+        Method:{' '}
+        <span>
+          {correlationMethod ? (
+            correlationMethod[0].toUpperCase() + correlationMethod.slice(1)
+          ) : (
+            <i>Not selected</i>
+          )}
+        </span>
+      </h4>
+    </div>
+  );
+}
+
+export function CorrelationAssayMetadataConfiguration(
+  props: ComputationConfigProps
+) {
+  const {
+    computationAppOverview,
+    computation,
+    analysisState,
+    visualizationId,
+  } = props;
+
+  const configuration = computation.descriptor
+    .configuration as CorrelationAssayMetadataConfig;
+  const studyMetadata = useStudyMetadata();
+
+  // For now, set the method to 'spearman'. When we add the next method, we can just add it here (no api change!)
+  if (configuration) configuration.correlationMethod = 'spearman';
+
+  // Include known collection variables in this array.
+  const collections = useCollectionVariables(studyMetadata.rootEntity);
+  if (collections.length === 0)
+    throw new Error('Could not find any collections for this app.');
+
+  assertComputationWithConfig<CorrelationAssayMetadataConfig>(
+    computation,
+    Computation
+  );
+
+  const changeConfigHandler =
+    useConfigChangeHandler<CorrelationAssayMetadataConfig>(
+      analysisState,
+      computation,
+      visualizationId
+    );
+
+  const collectionVarItems = useMemo(() => {
+    return collections.map((collectionVar) => ({
+      value: {
+        variableId: collectionVar.id,
+        entityId: collectionVar.entityId,
+      },
+      display:
+        collectionVar.entityDisplayName + ' > ' + collectionVar.displayName,
+    }));
+  }, [collections]);
+
+  const selectedCollectionVar = useMemo(() => {
+    if (configuration && 'collectionVariable' in configuration) {
+      const selectedItem = collectionVarItems.find((item) =>
+        isEqual(item.value, {
+          variableId: configuration.collectionVariable.variableId,
+          entityId: configuration.collectionVariable.entityId,
+        })
+      );
+      return selectedItem;
+    }
+  }, [collectionVarItems, configuration]);
+
+  return (
+    <ComputationStepContainer
+      computationStepInfo={{
+        stepNumber: 1,
+        stepTitle: `Configure ${computationAppOverview.displayName}`,
+      }}
+    >
+      <div className={cx()}>
+        <div className={cx('-CorrelationAssayMetadataOuterConfigContainer')}>
+          <H6>Input Data</H6>
+          <div className={cx('-InputContainer')}>
+            <span>Data</span>
+            <SingleSelect
+              value={
+                selectedCollectionVar
+                  ? selectedCollectionVar.value
+                  : 'Select the data'
+              }
+              buttonDisplayContent={
+                selectedCollectionVar
+                  ? selectedCollectionVar.display
+                  : 'Select the data'
+              }
+              items={collectionVarItems}
+              onSelect={partial(changeConfigHandler, 'collectionVariable')}
+            />
+          </div>
+        </div>
+      </div>
+    </ComputationStepContainer>
+  );
+}

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -18,7 +18,13 @@ const cx = makeClassNameHelper('AppStepConfigurationContainer');
 /**
  * Correlation
  *
- * info...
+ * The Correlation Assay vs Metadata app takes in a user-selected collection (ex. Species) and
+ * runs a correlation of that data against all appropriate metadata in the study. The result is
+ * a correlation coefficient and significance value for each (assay member, metadata variable) pair.
+ *
+ * Importantly, this is the first of a few correlation-type apps that are coming along in the near future.
+ * There will also be an Assay vs Assay app and a Metadata vs Metadata correlation app. It's possible that
+ * when those roll out we'll be able to do a little refactoring to make the code a bit nicer.
  */
 
 export type CorrelationAssayMetadataConfig = t.TypeOf<
@@ -42,7 +48,7 @@ export const plugin: ComputationPlugin = {
   },
 };
 
-// Yikes what a name
+// Renders on the thumbnail page to give a summary of the app instance
 function CorrelationAssayMetadataConfigDescriptionComponent({
   computation,
 }: {
@@ -101,6 +107,7 @@ function CorrelationAssayMetadataConfigDescriptionComponent({
   );
 }
 
+// Shows as Step 1 in the full screen visualization page
 export function CorrelationAssayMetadataConfiguration(
   props: ComputationConfigProps
 ) {
@@ -110,9 +117,6 @@ export function CorrelationAssayMetadataConfiguration(
     analysisState,
     visualizationId,
   } = props;
-
-  console.log(computation);
-  console.log(computationAppOverview);
 
   const configuration = computation.descriptor
     .configuration as CorrelationAssayMetadataConfig;

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/index.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/index.ts
@@ -7,12 +7,13 @@ import { plugin as countsandproportions } from './countsAndProportions';
 import { plugin as abundance } from './abundance';
 import { plugin as differentialabundance } from './differentialabundance';
 import { plugin as xyrelationships } from './xyRelationships';
-
+import { plugin as correlationassaymetadata } from './correlationAssayMetadata';
 export const plugins: Record<string, ComputationPlugin> = {
   abundance,
   alphadiv,
   betadiv,
   differentialabundance,
+  correlationassaymetadata,
   countsandproportions,
   distributions,
   pass,

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
@@ -4,6 +4,10 @@ import VolcanoPlot, {
   assignSignificanceColor,
   RawDataMinMaxValues,
 } from '@veupathdb/components/lib/plots/VolcanoPlot';
+import {
+  BipartiteNetwork,
+  BipartiteNetworkProps,
+} from '@veupathdb/components/lib/plots/BipartiteNetwork';
 
 import * as t from 'io-ts';
 import { useCallback, useMemo } from 'react';
@@ -22,37 +26,22 @@ import { VisualizationProps } from '../VisualizationTypes';
 // concerning axis range control
 import { useVizConfig } from '../../../hooks/visualizations';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
-import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
-import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
 
 import { LayoutOptions } from '../../layouts/types';
 import { RequestOptions } from '../options/types';
 
-// Volcano plot imports
-import DataClient, {
-  VolcanoPlotRequestParams,
-  VolcanoPlotResponse,
-} from '../../../api/DataClient';
-import {
-  VolcanoPlotData,
-  VolcanoPlotDataPoint,
-} from '@veupathdb/components/lib/types/plots/volcanoplot';
+// Bipartite network imports
 import VolcanoSVG from './selectorIcons/VolcanoSVG';
-import { NumberOrDate } from '@veupathdb/components/lib/types/general';
 import { DifferentialAbundanceConfig } from '../../computations/plugins/differentialabundance';
-import { yellow } from '@material-ui/core/colors';
-import PlotLegend from '@veupathdb/components/lib/components/plotControls/PlotLegend';
-import { significanceColors } from '@veupathdb/components/lib/types/plots';
-import { NumberOrDateRange, NumberRange } from '../../../types/general';
-import { max, min } from 'lodash';
-
-// plot controls
-import SliderWidget, {
-  plotsSliderOpacityGradientColorSpec,
-} from '@veupathdb/components/lib/components/widgets/Slider';
-import { ResetButtonCoreUI } from '../../ResetButton';
-import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
-import { fixVarIdLabel } from '../../../utils/visualization';
+import { NumberRange } from '../../../types/general';
+import { VolcanoPlotRequestParams } from '../../../api/DataClient/types';
+import {
+  BipartiteNetworkData,
+  LinkData,
+  NodeData,
+} from '@veupathdb/components/lib/types/plots/network';
+import DataClient from '../../../api/DataClient';
+import { twoColorPalette } from '@veupathdb/components/lib/types/plots/addOns';
 // end imports
 
 const DEFAULT_SIG_THRESHOLD = 0.05;
@@ -119,8 +108,6 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
     updateConfiguration,
     updateThumbnail,
     filters,
-    dataElementConstraints,
-    dataElementDependencyOrder,
     filteredCounts,
     computeJobStatus,
   } = props;
@@ -139,492 +126,29 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
     updateConfiguration
   );
 
-  // Get the volcano plot data!
-  const data = usePromise(
-    useCallback(async (): Promise<VolcanoPlotResponse | undefined> => {
-      // Only need to check compute job status and filter status, since there are no
-      // viz input variables.
-      if (computeJobStatus !== 'complete') return undefined;
-      if (filteredCounts.pending || filteredCounts.value == null)
-        return undefined;
+  // Fake data
+  const data: BipartiteNetworkData = genBipartiteNetwork(100, 10);
 
-      // There are _no_ viz request params for the volcano plot (config: {}).
-      // The data service streams the volcano data directly from the compute service.
-      const params = {
-        studyId,
-        filters,
-        config: {},
-        computeConfig: computationConfiguration,
-      };
-      const response = await dataClient.getVisualizationData(
-        computation.descriptor.type,
-        visualization.descriptor.type,
-        params,
-        VolcanoPlotResponse
-      );
-
-      return response;
-    }, [
-      computeJobStatus,
-      filteredCounts.pending,
-      filteredCounts.value,
-      filters,
-      studyId,
-      computationConfiguration,
-      computation.descriptor.type,
-      dataClient,
-      visualization.descriptor.type,
-    ])
-  );
-
-  /**
-   * Find mins and maxes of the data and for the plot.
-   * The standard x axis is the log2 fold change. The standard
-   * y axis is -log10 raw p value.
-   */
-
-  // Find maxes and mins of the data itself
-  const rawDataMinMaxValues: RawDataMinMaxValues = useMemo(() => {
-    if (!data.value)
-      return {
-        x: { min: 0, max: 0 },
-        y: { min: 1, max: 1 },
-      };
-    const dataXMin = min(data.value.map((d) => Number(d.log2foldChange))) ?? 0;
-    const dataXMax = max(data.value.map((d) => Number(d.log2foldChange))) ?? 0;
-    const dataYMin = min(data.value.map((d) => Number(d.pValue))) ?? 0;
-    const dataYMax = max(data.value.map((d) => Number(d.pValue))) ?? 0;
-    return {
-      x: { min: dataXMin, max: dataXMax },
-      y: { min: dataYMin, max: dataYMax },
-    };
-  }, [data.value]);
-
-  // Determine mins, maxes of axes in the plot. These are different than the data mins/maxes because
-  // of the log transform and the little bit of padding, or because axis ranges are supplied.
-  const independentAxisRange = useMemo(() => {
-    if (!data.value) return undefined;
-    if (vizConfig.independentAxisRange) {
-      return vizConfig.independentAxisRange;
-    } else {
-      const {
-        x: { min: dataXMin, max: dataXMax },
-      } = rawDataMinMaxValues;
-      // We can use the dataMin and dataMax here because we don't have a further transform
-      // Add a little padding to prevent clipping the glyph representing the extreme points
-      return {
-        min: Math.floor(dataXMin - (dataXMax - dataXMin) * AXIS_PADDING_FACTOR),
-        max: Math.ceil(dataXMax + (dataXMax - dataXMin) * AXIS_PADDING_FACTOR),
-      };
-    }
-  }, [data.value, vizConfig.independentAxisRange, rawDataMinMaxValues]);
-
-  const dependentAxisRange = useMemo(() => {
-    if (!data.value) return undefined;
-    if (vizConfig.dependentAxisRange) {
-      return vizConfig.dependentAxisRange;
-    } else {
-      const {
-        y: { min: dataYMin, max: dataYMax },
-      } = rawDataMinMaxValues;
-      // Standard volcano plots have -log10(raw p value) as the y axis
-      const yAxisMin = -Math.log10(dataYMax);
-      const yAxisMax = -Math.log10(dataYMin);
-
-      // Add a little padding to prevent clipping the glyph representing the extreme points
-      return {
-        min: Math.floor(yAxisMin - (yAxisMax - yAxisMin) * AXIS_PADDING_FACTOR),
-        max: Math.ceil(yAxisMax + (yAxisMax - yAxisMin) * AXIS_PADDING_FACTOR),
-      };
-    }
-  }, [data.value, vizConfig.dependentAxisRange, rawDataMinMaxValues]);
-
-  const significanceThreshold =
-    vizConfig.significanceThreshold ?? DEFAULT_SIG_THRESHOLD;
-  const log2FoldChangeThreshold =
-    vizConfig.log2FoldChangeThreshold ?? DEFAULT_FC_THRESHOLD;
-
-  /**
-   * This version of the data will get passed to the VolcanoPlot component
-   */
-  const finalData = useMemo(() => {
-    if (data.value && independentAxisRange && dependentAxisRange) {
-      const cleanedData = data.value
-        // Only return data if the points fall within the specified range! Otherwise they'll show up on the plot.
-        .filter((d) => {
-          const log2foldChange = Number(d?.log2foldChange);
-          const transformedPValue = -Math.log10(Number(d?.pValue));
-          return (
-            log2foldChange <= independentAxisRange.max &&
-            log2foldChange >= independentAxisRange.min &&
-            transformedPValue <= dependentAxisRange.max &&
-            transformedPValue >= dependentAxisRange.min
-          );
-        })
-        /**
-         * Okay, this map function is doing a number of things.
-         *  1.  We're going to remove the pointID property and replace it with a pointIDs property that is an array of strings.
-         *      Some data share coordinates but correspond to a different pointID. By converting pointID to pointIDs, we can
-         *      later aggregate data that share coordinates and then render one tooltip that lists all pointIDs corresponding
-         *      to the point on the plot
-         *  2.  We also add a significanceColor property that is assigned a value that gets used in VolcanoPlot when rendering
-         *      the data point and the data point's tooltip. The property is also used in the countsData logic.
-         */
-        .map((d) => {
-          const { pointID, ...remainingProperties } = d;
-          // Try to find a user-friendly label for the point. Note that pointIDs are in entityID.variableID format.
-          const displayLabel =
-            pointID &&
-            fixVarIdLabel(
-              pointID.split('.')[1],
-              pointID.split('.')[0],
-              entities
-            );
-          return {
-            ...remainingProperties,
-            pointIDs: pointID ? [pointID] : undefined,
-            displayLabels: displayLabel ? [displayLabel] : undefined,
-            significanceColor: assignSignificanceColor(
-              Number(d.log2foldChange),
-              Number(d.pValue),
-              significanceThreshold,
-              log2FoldChangeThreshold,
-              significanceColors
-            ),
-          };
-        })
-        // Sort data in ascending order for tooltips to work most effectively
-        .sort((a, b) => Number(a.log2foldChange) - Number(b.log2foldChange));
-
-      // Here we're going to loop through the cleanedData to aggregate any data with shared coordinates.
-      // For each entry, we'll check if our aggregatedData includes an item with the same coordinates:
-      //  Yes? => update the matched aggregatedData element's pointID array to include the pointID of the matching entry
-      //  No? => just push the entry onto the aggregatedData array since no match was found
-      const aggregatedData: VolcanoPlotData = [];
-      for (const entry of cleanedData) {
-        const foundIndex = aggregatedData.findIndex(
-          (d: VolcanoPlotDataPoint) =>
-            d.log2foldChange === entry.log2foldChange &&
-            d.pValue === entry.pValue
-        );
-        if (foundIndex === -1) {
-          aggregatedData.push(entry);
-        } else {
-          const { pointIDs, displayLabels } = aggregatedData[foundIndex];
-          if (pointIDs) {
-            aggregatedData[foundIndex] = {
-              ...aggregatedData[foundIndex],
-              pointIDs: [
-                ...pointIDs,
-                ...(entry.pointIDs ? entry.pointIDs : []),
-              ],
-              displayLabels: displayLabels && [
-                ...displayLabels,
-                ...(entry.displayLabels ? entry.displayLabels : []),
-              ],
-            };
-          } else {
-            aggregatedData[foundIndex] = {
-              ...aggregatedData[foundIndex],
-              pointIDs: entry.pointIDs,
-              displayLabels: entry.displayLabels,
-            };
-          }
-        }
-      }
-      return aggregatedData;
-    }
-  }, [
-    data.value,
-    independentAxisRange,
-    dependentAxisRange,
-    significanceThreshold,
-    log2FoldChangeThreshold,
-    entities,
-  ]);
-
-  // For the legend, we need the counts of the data
-  const countsData = useMemo(() => {
-    if (!finalData) return;
-    const counts = {
-      [significanceColors['inconclusive']]: 0,
-      [significanceColors['high']]: 0,
-      [significanceColors['low']]: 0,
-    };
-    for (const entry of finalData) {
-      if (entry.significanceColor) {
-        // Recall that finalData combines data with shared coords into one point in order to display a
-        // single tooltip that lists all the pointIDs for that shared point. This means we need to use
-        // the length of the pointID array to accurately reflect the counts of unique data (not unique coords).
-        const addend = entry.pointIDs?.length ?? 1;
-        counts[entry.significanceColor] =
-          addend + counts[entry.significanceColor];
-      }
-    }
-    return counts;
-  }, [finalData]);
-
-  const plotRef = useUpdateThumbnailEffect(
-    updateThumbnail,
-    plotContainerStyles,
-    [
-      finalData,
-      // vizConfig.checkedLegendItems, TODO
-      vizConfig.independentAxisRange,
-      vizConfig.dependentAxisRange,
-      vizConfig.markerBodyOpacity,
-    ]
-  );
-
-  // Add labels to the extremes of the x axis. These may change in the future based on the type
-  // of data. For example, for genes we may want to say Up regulated in...
-  const comparisonLabels =
-    computationConfiguration &&
-    computationConfiguration.comparator?.groupA &&
-    computationConfiguration.comparator?.groupB
-      ? [
-          'Up in ' +
-            computationConfiguration.comparator.groupA
-              .map((entry) => entry.label)
-              .join(','),
-          'Up in ' +
-            computationConfiguration.comparator.groupB
-              .map((entry) => entry.label)
-              .join(','),
-        ]
-      : [];
-
-  const volcanoPlotProps: VolcanoPlotProps = {
+  const bipartiteNetworkProps: BipartiteNetworkProps = {
     /**
      * VolcanoPlot defines an EmptyVolcanoPlotData variable that will be assigned when data is undefined.
      * In order to display an empty viz, EmptyVolcanoPlotData is defined as:
      *    const EmptyVolcanoPlotData: VolcanoPlotData = [{log2foldChange: '0', pValue: '1'}];
      */
-    data: finalData ? Object.values(finalData) : undefined,
-    significanceThreshold,
-    log2FoldChangeThreshold,
-    /**
-     * Since we are rendering a single point in order to display an empty viz, let's hide the data point
-     * by setting the marker opacity to 0 when data.value doesn't exist
-     */
-    markerBodyOpacity: data.value
-      ? vizConfig.markerBodyOpacity ?? DEFAULT_MARKER_OPACITY
-      : 0,
-    containerStyles: plotContainerStyles,
-    /**
-     * Let's not display comparisonLabels before we have data for the viz. This prevents what may be
-     * confusing behavior where selecting group values displays on the empty viz placeholder.
-     */
-    comparisonLabels: data.value ? comparisonLabels : [],
-    showSpinner: data.pending,
-    truncationBarFill: yellow[300],
-    independentAxisRange,
-    dependentAxisRange,
-    rawDataMinMaxValues,
-    /**
-     * As sophisticated aesthetes, let's specify axis ranges for the empty viz placeholder
-     */
-    ...(data.value ? {} : EMPTY_VIZ_AXIS_RANGES),
+    data: data,
   };
 
   // @ts-ignore
-  const plotNode = <VolcanoPlot {...volcanoPlotProps} ref={plotRef} />;
+  const plotNode = <BipartiteNetwork {...bipartiteNetworkProps} />;
 
-  const controlsNode = (
-    <div style={{ margin: '1em 1em 2em 1em' }}>
-      <LabelledGroup
-        label="Plot controls"
-        containerStyles={{
-          paddingLeft: 0,
-        }}
-      >
-        <SliderWidget
-          minimum={0}
-          maximum={1}
-          step={0.1}
-          value={vizConfig.markerBodyOpacity ?? DEFAULT_MARKER_OPACITY}
-          debounceRateMs={250}
-          onChange={(newValue: number) => {
-            updateVizConfig({ markerBodyOpacity: newValue });
-          }}
-          containerStyles={{ width: '20em', marginTop: '0.5em' }}
-          showLimits={true}
-          label={'Marker opacity'}
-          colorSpec={plotsSliderOpacityGradientColorSpec}
-        />
-      </LabelledGroup>
-      <div
-        style={{
-          display: 'flex',
-          gap: 20,
-        }}
-      >
-        <div>
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-            }}
-          >
-            <LabelledGroup
-              label="X-axis range"
-              children={<></>}
-              containerStyles={{
-                marginRight: 0,
-                paddingLeft: 0,
-              }}
-            />
-            <ResetButtonCoreUI
-              size={'medium'}
-              text={''}
-              themeRole={'primary'}
-              tooltip={'Reset to defaults'}
-              disabled={!vizConfig.independentAxisRange}
-              onPress={() =>
-                updateVizConfig({ independentAxisRange: undefined })
-              }
-            />
-          </div>
-          <AxisRangeControl
-            containerStyles={{ maxWidth: '350px' }}
-            valueType="number"
-            range={independentAxisRange}
-            onRangeChange={(newRange?: NumberOrDateRange) => {
-              const typeCheckedNewRange =
-                typeof newRange?.min === 'number' &&
-                typeof newRange?.max === 'number'
-                  ? {
-                      min: newRange.min,
-                      max: newRange.max,
-                    }
-                  : undefined;
-              updateVizConfig({
-                independentAxisRange: typeCheckedNewRange,
-              });
-            }}
-            step={0.01}
-          />
-        </div>
-        {/** vertical line to separate x from y range controls */}
-        <div style={{ borderRight: '2px solid lightgray' }}></div>
-        <div>
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-            }}
-          >
-            <LabelledGroup
-              label="Y-axis range"
-              children={<></>}
-              containerStyles={{
-                marginRight: 0,
-                paddingLeft: 0,
-              }}
-            />
-            <ResetButtonCoreUI
-              size={'medium'}
-              text={''}
-              themeRole={'primary'}
-              tooltip={'Reset to defaults'}
-              disabled={!vizConfig.dependentAxisRange}
-              onPress={() => updateVizConfig({ dependentAxisRange: undefined })}
-            />
-          </div>
-          <AxisRangeControl
-            containerStyles={{ maxWidth: '350px' }}
-            valueType="number"
-            range={dependentAxisRange}
-            onRangeChange={(newRange?: NumberOrDateRange) => {
-              const typeCheckedNewRange =
-                typeof newRange?.min === 'number' &&
-                typeof newRange?.max === 'number'
-                  ? {
-                      min: newRange.min,
-                      max: newRange.max,
-                    }
-                  : undefined;
-              updateVizConfig({
-                dependentAxisRange: typeCheckedNewRange,
-              });
-            }}
-            step={0.01}
-          />
-        </div>
-      </div>
-    </div>
-  );
-
-  const legendNode = finalData && countsData && (
-    <PlotLegend
-      type="list"
-      legendTitle="Legend"
-      legendItems={[
-        {
-          label: `Inconclusive (${
-            countsData[significanceColors['inconclusive']]
-          })`,
-          marker: 'circle',
-          hasData: true,
-          markerColor: significanceColors['inconclusive'],
-        },
-        {
-          label: `Up regulated in ${computationConfiguration.comparator.groupB
-            ?.map((entry) => entry.label)
-            .join(',')} (${countsData[significanceColors['high']]})`,
-          marker: 'circle',
-          hasData: true,
-          markerColor: significanceColors['high'],
-        },
-        {
-          label: `Up regulated in ${computationConfiguration.comparator.groupA
-            ?.map((entry) => entry.label)
-            .join(',')} (${countsData[significanceColors['low']]})`,
-          marker: 'circle',
-          hasData: true,
-          markerColor: significanceColors['low'],
-        },
-      ]}
-      showCheckbox={false}
-    />
-  );
-
-  // TODO
+  const controlsNode = <> </>;
+  const legendNode = <> </>;
   const tableGroupNode = <> </>;
 
   const LayoutComponent = options?.layoutComponent ?? PlotLayout;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <LabelledGroup label="Threshold lines" alignChildrenHorizontally={true}>
-        <NumberInput
-          onValueChange={(newValue?: NumberOrDate) =>
-            updateVizConfig({ log2FoldChangeThreshold: Number(newValue) })
-          }
-          label="log2(Fold Change)"
-          minValue={0}
-          value={vizConfig.log2FoldChangeThreshold ?? DEFAULT_FC_THRESHOLD}
-          containerStyles={{ marginRight: 10 }}
-        />
-
-        <NumberInput
-          label="P-Value"
-          onValueChange={(newValue?: NumberOrDate) =>
-            updateVizConfig({ significanceThreshold: Number(newValue) })
-          }
-          minValue={0}
-          value={vizConfig.significanceThreshold ?? DEFAULT_SIG_THRESHOLD}
-          containerStyles={{ marginLeft: 10 }}
-          step={0.001}
-        />
-      </LabelledGroup>
-
-      {/* This should be populated with info from the colections var. So like "Showing 1000 taxa blah". Waiting on collections annotations. */}
-      {/* <OutputEntityTitle
-        entity={outputEntity}
-        outputSize={outputSize}
-        subtitle={plotSubtitle}
-      /> */}
       <LayoutComponent
         isFaceted={false}
         legendNode={legendNode}
@@ -635,4 +159,50 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
       />
     </div>
   );
+}
+
+// Gerenate a bipartite network with a given number of nodes and random edges
+function genBipartiteNetwork(
+  column1nNodes: number,
+  column2nNodes: number
+): BipartiteNetworkData {
+  // Create the first column of nodes
+  const column1Nodes: NodeData[] = [...Array(column1nNodes).keys()].map((i) => {
+    return {
+      id: String(i),
+      label: 'Node ' + String(i),
+    };
+  });
+
+  // Create the second column of nodes
+  const column2Nodes: NodeData[] = [...Array(column2nNodes).keys()].map((i) => {
+    return {
+      id: String(i + column1nNodes),
+      label: 'Node ' + String(i + column1nNodes),
+    };
+  });
+
+  // Create links
+  // Not worried about exactly how many edges we're adding just yet since this is
+  // used for stories only. Adding color here to mimic what the visualization
+  // will do.
+  const links: LinkData[] = [...Array(column1nNodes * 2).keys()].map(() => {
+    return {
+      source: column1Nodes[Math.floor(Math.random() * column1nNodes)],
+      target: column2Nodes[Math.floor(Math.random() * column2nNodes)],
+      strokeWidth: Math.random() * 2,
+      color: Math.random() > 0.5 ? twoColorPalette[0] : twoColorPalette[1],
+    };
+  });
+
+  const nodes = column1Nodes.concat(column2Nodes);
+  const column1NodeIDs = column1Nodes.map((node) => node.id);
+  const column2NodeIDs = column2Nodes.map((node) => node.id);
+
+  return {
+    nodes,
+    links,
+    column1NodeIDs,
+    column2NodeIDs,
+  };
 }

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
@@ -1,9 +1,3 @@
-// load scatter plot component
-import VolcanoPlot, {
-  VolcanoPlotProps,
-  assignSignificanceColor,
-  RawDataMinMaxValues,
-} from '@veupathdb/components/lib/plots/VolcanoPlot';
 import {
   BipartiteNetwork,
   BipartiteNetworkProps,
@@ -33,8 +27,7 @@ import { RequestOptions } from '../options/types';
 // Bipartite network imports
 import VolcanoSVG from './selectorIcons/VolcanoSVG';
 import { DifferentialAbundanceConfig } from '../../computations/plugins/differentialabundance';
-import { NumberRange } from '../../../types/general';
-import { VolcanoPlotRequestParams } from '../../../api/DataClient/types';
+import { BipartiteNetworkRequestParams } from '../../../api/DataClient/types';
 import {
   BipartiteNetworkData,
   LinkData,
@@ -45,7 +38,8 @@ import { twoColorPalette } from '@veupathdb/components/lib/types/plots/addOns';
 // end imports
 
 // Defaults
-const DEFAULT_EDGE_THRESHOLD = 0.9;
+const DEFAULT_CORRELATION_COEF_THRESHOLD = 0.9;
+const DEFAULT_SIGNIFICANCE_THRESHOLD = 0.05;
 
 const plotContainerStyles = {
   width: 750,
@@ -63,24 +57,25 @@ export const bipartiteNetworkVisualization = createVisualizationPlugin({
 
 function createDefaultConfig(): BipartiteNetworkConfig {
   return {
-    edgeThreshold: DEFAULT_EDGE_THRESHOLD,
+    correlationCoefThreshold: DEFAULT_CORRELATION_COEF_THRESHOLD,
+    significanceThreshold: DEFAULT_SIGNIFICANCE_THRESHOLD,
   };
 }
 
 export type BipartiteNetworkConfig = t.TypeOf<typeof BipartiteNetworkConfig>;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const BipartiteNetworkConfig = t.partial({
-  edgeThreshold: t.number,
+  correlationCoefThreshold: t.number,
+  significanceThreshold: t.number,
 });
 
 interface Options
   extends LayoutOptions,
-    RequestOptions<BipartiteNetworkConfig, {}, VolcanoPlotRequestParams> {}
+    RequestOptions<BipartiteNetworkConfig, {}, BipartiteNetworkRequestParams> {}
 
-// Volcano Plot Visualization
-// The volcano plot visualization takes no input variables. The received data populates all parts of the plot.
-// The user can control the threshold lines, which affect the marker colors. Additional controls
-// include axis ranges and marker opacity slider.
+// Bipartite Network Visualization
+// The bipartite network takes no input variables, because the received data will complete the plot.
+// Eventually the user will be able to control the significance and correlation coefficient values.
 function BipartiteNetworkViz(props: VisualizationProps<Options>) {
   const {
     options,

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
@@ -1,0 +1,638 @@
+// load scatter plot component
+import VolcanoPlot, {
+  VolcanoPlotProps,
+  assignSignificanceColor,
+  RawDataMinMaxValues,
+} from '@veupathdb/components/lib/plots/VolcanoPlot';
+
+import * as t from 'io-ts';
+import { useCallback, useMemo } from 'react';
+
+import { usePromise } from '../../../hooks/promise';
+import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
+import {
+  useDataClient,
+  useStudyEntities,
+  useStudyMetadata,
+} from '../../../hooks/workspace';
+import { PlotLayout } from '../../layouts/PlotLayout';
+
+import { VisualizationProps } from '../VisualizationTypes';
+
+// concerning axis range control
+import { useVizConfig } from '../../../hooks/visualizations';
+import { createVisualizationPlugin } from '../VisualizationPlugin';
+import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
+import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
+
+import { LayoutOptions } from '../../layouts/types';
+import { RequestOptions } from '../options/types';
+
+// Volcano plot imports
+import DataClient, {
+  VolcanoPlotRequestParams,
+  VolcanoPlotResponse,
+} from '../../../api/DataClient';
+import {
+  VolcanoPlotData,
+  VolcanoPlotDataPoint,
+} from '@veupathdb/components/lib/types/plots/volcanoplot';
+import VolcanoSVG from './selectorIcons/VolcanoSVG';
+import { NumberOrDate } from '@veupathdb/components/lib/types/general';
+import { DifferentialAbundanceConfig } from '../../computations/plugins/differentialabundance';
+import { yellow } from '@material-ui/core/colors';
+import PlotLegend from '@veupathdb/components/lib/components/plotControls/PlotLegend';
+import { significanceColors } from '@veupathdb/components/lib/types/plots';
+import { NumberOrDateRange, NumberRange } from '../../../types/general';
+import { max, min } from 'lodash';
+
+// plot controls
+import SliderWidget, {
+  plotsSliderOpacityGradientColorSpec,
+} from '@veupathdb/components/lib/components/widgets/Slider';
+import { ResetButtonCoreUI } from '../../ResetButton';
+import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
+import { fixVarIdLabel } from '../../../utils/visualization';
+// end imports
+
+const DEFAULT_SIG_THRESHOLD = 0.05;
+const DEFAULT_FC_THRESHOLD = 2;
+const DEFAULT_MARKER_OPACITY = 0.8;
+/**
+ * The padding ensures we don't clip off part of the glyphs that represent the most extreme points.
+ * We could have also used d3.scale.nice but then we dont have precise control of where the extremes
+ * are, which is important for user-defined ranges and truncation bars.
+ */
+const AXIS_PADDING_FACTOR = 0.05;
+const EMPTY_VIZ_AXIS_RANGES = {
+  independentAxisRange: { min: -9, max: 9 },
+  dependentAxisRange: { min: -1, max: 9 },
+};
+
+const plotContainerStyles = {
+  width: 750,
+  height: 450,
+  marginLeft: '0.75rem',
+  border: '1px solid #dedede',
+  boxShadow: '1px 1px 4px #00000066',
+};
+
+export const bipartiteNetworkVisualization = createVisualizationPlugin({
+  selectorIcon: VolcanoSVG,
+  fullscreenComponent: VolcanoPlotViz,
+  createDefaultConfig: createDefaultConfig,
+});
+
+function createDefaultConfig(): VolcanoPlotConfig {
+  return {
+    log2FoldChangeThreshold: DEFAULT_FC_THRESHOLD,
+    significanceThreshold: DEFAULT_SIG_THRESHOLD,
+    markerBodyOpacity: DEFAULT_MARKER_OPACITY,
+    independentAxisRange: undefined,
+    dependentAxisRange: undefined,
+  };
+}
+
+export type VolcanoPlotConfig = t.TypeOf<typeof VolcanoPlotConfig>;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const VolcanoPlotConfig = t.partial({
+  log2FoldChangeThreshold: t.number,
+  significanceThreshold: t.number,
+  markerBodyOpacity: t.number,
+  independentAxisRange: NumberRange,
+  dependentAxisRange: NumberRange,
+});
+
+interface Options
+  extends LayoutOptions,
+    RequestOptions<VolcanoPlotConfig, {}, VolcanoPlotRequestParams> {}
+
+// Volcano Plot Visualization
+// The volcano plot visualization takes no input variables. The received data populates all parts of the plot.
+// The user can control the threshold lines, which affect the marker colors. Additional controls
+// include axis ranges and marker opacity slider.
+function VolcanoPlotViz(props: VisualizationProps<Options>) {
+  const {
+    options,
+    computation,
+    visualization,
+    updateConfiguration,
+    updateThumbnail,
+    filters,
+    dataElementConstraints,
+    dataElementDependencyOrder,
+    filteredCounts,
+    computeJobStatus,
+  } = props;
+
+  const studyMetadata = useStudyMetadata();
+  const { id: studyId } = studyMetadata;
+  const entities = useStudyEntities(filters);
+  const dataClient: DataClient = useDataClient();
+  const computationConfiguration: DifferentialAbundanceConfig = computation
+    .descriptor.configuration as DifferentialAbundanceConfig;
+
+  const [vizConfig, updateVizConfig] = useVizConfig(
+    visualization.descriptor.configuration,
+    VolcanoPlotConfig,
+    createDefaultConfig,
+    updateConfiguration
+  );
+
+  // Get the volcano plot data!
+  const data = usePromise(
+    useCallback(async (): Promise<VolcanoPlotResponse | undefined> => {
+      // Only need to check compute job status and filter status, since there are no
+      // viz input variables.
+      if (computeJobStatus !== 'complete') return undefined;
+      if (filteredCounts.pending || filteredCounts.value == null)
+        return undefined;
+
+      // There are _no_ viz request params for the volcano plot (config: {}).
+      // The data service streams the volcano data directly from the compute service.
+      const params = {
+        studyId,
+        filters,
+        config: {},
+        computeConfig: computationConfiguration,
+      };
+      const response = await dataClient.getVisualizationData(
+        computation.descriptor.type,
+        visualization.descriptor.type,
+        params,
+        VolcanoPlotResponse
+      );
+
+      return response;
+    }, [
+      computeJobStatus,
+      filteredCounts.pending,
+      filteredCounts.value,
+      filters,
+      studyId,
+      computationConfiguration,
+      computation.descriptor.type,
+      dataClient,
+      visualization.descriptor.type,
+    ])
+  );
+
+  /**
+   * Find mins and maxes of the data and for the plot.
+   * The standard x axis is the log2 fold change. The standard
+   * y axis is -log10 raw p value.
+   */
+
+  // Find maxes and mins of the data itself
+  const rawDataMinMaxValues: RawDataMinMaxValues = useMemo(() => {
+    if (!data.value)
+      return {
+        x: { min: 0, max: 0 },
+        y: { min: 1, max: 1 },
+      };
+    const dataXMin = min(data.value.map((d) => Number(d.log2foldChange))) ?? 0;
+    const dataXMax = max(data.value.map((d) => Number(d.log2foldChange))) ?? 0;
+    const dataYMin = min(data.value.map((d) => Number(d.pValue))) ?? 0;
+    const dataYMax = max(data.value.map((d) => Number(d.pValue))) ?? 0;
+    return {
+      x: { min: dataXMin, max: dataXMax },
+      y: { min: dataYMin, max: dataYMax },
+    };
+  }, [data.value]);
+
+  // Determine mins, maxes of axes in the plot. These are different than the data mins/maxes because
+  // of the log transform and the little bit of padding, or because axis ranges are supplied.
+  const independentAxisRange = useMemo(() => {
+    if (!data.value) return undefined;
+    if (vizConfig.independentAxisRange) {
+      return vizConfig.independentAxisRange;
+    } else {
+      const {
+        x: { min: dataXMin, max: dataXMax },
+      } = rawDataMinMaxValues;
+      // We can use the dataMin and dataMax here because we don't have a further transform
+      // Add a little padding to prevent clipping the glyph representing the extreme points
+      return {
+        min: Math.floor(dataXMin - (dataXMax - dataXMin) * AXIS_PADDING_FACTOR),
+        max: Math.ceil(dataXMax + (dataXMax - dataXMin) * AXIS_PADDING_FACTOR),
+      };
+    }
+  }, [data.value, vizConfig.independentAxisRange, rawDataMinMaxValues]);
+
+  const dependentAxisRange = useMemo(() => {
+    if (!data.value) return undefined;
+    if (vizConfig.dependentAxisRange) {
+      return vizConfig.dependentAxisRange;
+    } else {
+      const {
+        y: { min: dataYMin, max: dataYMax },
+      } = rawDataMinMaxValues;
+      // Standard volcano plots have -log10(raw p value) as the y axis
+      const yAxisMin = -Math.log10(dataYMax);
+      const yAxisMax = -Math.log10(dataYMin);
+
+      // Add a little padding to prevent clipping the glyph representing the extreme points
+      return {
+        min: Math.floor(yAxisMin - (yAxisMax - yAxisMin) * AXIS_PADDING_FACTOR),
+        max: Math.ceil(yAxisMax + (yAxisMax - yAxisMin) * AXIS_PADDING_FACTOR),
+      };
+    }
+  }, [data.value, vizConfig.dependentAxisRange, rawDataMinMaxValues]);
+
+  const significanceThreshold =
+    vizConfig.significanceThreshold ?? DEFAULT_SIG_THRESHOLD;
+  const log2FoldChangeThreshold =
+    vizConfig.log2FoldChangeThreshold ?? DEFAULT_FC_THRESHOLD;
+
+  /**
+   * This version of the data will get passed to the VolcanoPlot component
+   */
+  const finalData = useMemo(() => {
+    if (data.value && independentAxisRange && dependentAxisRange) {
+      const cleanedData = data.value
+        // Only return data if the points fall within the specified range! Otherwise they'll show up on the plot.
+        .filter((d) => {
+          const log2foldChange = Number(d?.log2foldChange);
+          const transformedPValue = -Math.log10(Number(d?.pValue));
+          return (
+            log2foldChange <= independentAxisRange.max &&
+            log2foldChange >= independentAxisRange.min &&
+            transformedPValue <= dependentAxisRange.max &&
+            transformedPValue >= dependentAxisRange.min
+          );
+        })
+        /**
+         * Okay, this map function is doing a number of things.
+         *  1.  We're going to remove the pointID property and replace it with a pointIDs property that is an array of strings.
+         *      Some data share coordinates but correspond to a different pointID. By converting pointID to pointIDs, we can
+         *      later aggregate data that share coordinates and then render one tooltip that lists all pointIDs corresponding
+         *      to the point on the plot
+         *  2.  We also add a significanceColor property that is assigned a value that gets used in VolcanoPlot when rendering
+         *      the data point and the data point's tooltip. The property is also used in the countsData logic.
+         */
+        .map((d) => {
+          const { pointID, ...remainingProperties } = d;
+          // Try to find a user-friendly label for the point. Note that pointIDs are in entityID.variableID format.
+          const displayLabel =
+            pointID &&
+            fixVarIdLabel(
+              pointID.split('.')[1],
+              pointID.split('.')[0],
+              entities
+            );
+          return {
+            ...remainingProperties,
+            pointIDs: pointID ? [pointID] : undefined,
+            displayLabels: displayLabel ? [displayLabel] : undefined,
+            significanceColor: assignSignificanceColor(
+              Number(d.log2foldChange),
+              Number(d.pValue),
+              significanceThreshold,
+              log2FoldChangeThreshold,
+              significanceColors
+            ),
+          };
+        })
+        // Sort data in ascending order for tooltips to work most effectively
+        .sort((a, b) => Number(a.log2foldChange) - Number(b.log2foldChange));
+
+      // Here we're going to loop through the cleanedData to aggregate any data with shared coordinates.
+      // For each entry, we'll check if our aggregatedData includes an item with the same coordinates:
+      //  Yes? => update the matched aggregatedData element's pointID array to include the pointID of the matching entry
+      //  No? => just push the entry onto the aggregatedData array since no match was found
+      const aggregatedData: VolcanoPlotData = [];
+      for (const entry of cleanedData) {
+        const foundIndex = aggregatedData.findIndex(
+          (d: VolcanoPlotDataPoint) =>
+            d.log2foldChange === entry.log2foldChange &&
+            d.pValue === entry.pValue
+        );
+        if (foundIndex === -1) {
+          aggregatedData.push(entry);
+        } else {
+          const { pointIDs, displayLabels } = aggregatedData[foundIndex];
+          if (pointIDs) {
+            aggregatedData[foundIndex] = {
+              ...aggregatedData[foundIndex],
+              pointIDs: [
+                ...pointIDs,
+                ...(entry.pointIDs ? entry.pointIDs : []),
+              ],
+              displayLabels: displayLabels && [
+                ...displayLabels,
+                ...(entry.displayLabels ? entry.displayLabels : []),
+              ],
+            };
+          } else {
+            aggregatedData[foundIndex] = {
+              ...aggregatedData[foundIndex],
+              pointIDs: entry.pointIDs,
+              displayLabels: entry.displayLabels,
+            };
+          }
+        }
+      }
+      return aggregatedData;
+    }
+  }, [
+    data.value,
+    independentAxisRange,
+    dependentAxisRange,
+    significanceThreshold,
+    log2FoldChangeThreshold,
+    entities,
+  ]);
+
+  // For the legend, we need the counts of the data
+  const countsData = useMemo(() => {
+    if (!finalData) return;
+    const counts = {
+      [significanceColors['inconclusive']]: 0,
+      [significanceColors['high']]: 0,
+      [significanceColors['low']]: 0,
+    };
+    for (const entry of finalData) {
+      if (entry.significanceColor) {
+        // Recall that finalData combines data with shared coords into one point in order to display a
+        // single tooltip that lists all the pointIDs for that shared point. This means we need to use
+        // the length of the pointID array to accurately reflect the counts of unique data (not unique coords).
+        const addend = entry.pointIDs?.length ?? 1;
+        counts[entry.significanceColor] =
+          addend + counts[entry.significanceColor];
+      }
+    }
+    return counts;
+  }, [finalData]);
+
+  const plotRef = useUpdateThumbnailEffect(
+    updateThumbnail,
+    plotContainerStyles,
+    [
+      finalData,
+      // vizConfig.checkedLegendItems, TODO
+      vizConfig.independentAxisRange,
+      vizConfig.dependentAxisRange,
+      vizConfig.markerBodyOpacity,
+    ]
+  );
+
+  // Add labels to the extremes of the x axis. These may change in the future based on the type
+  // of data. For example, for genes we may want to say Up regulated in...
+  const comparisonLabels =
+    computationConfiguration &&
+    computationConfiguration.comparator?.groupA &&
+    computationConfiguration.comparator?.groupB
+      ? [
+          'Up in ' +
+            computationConfiguration.comparator.groupA
+              .map((entry) => entry.label)
+              .join(','),
+          'Up in ' +
+            computationConfiguration.comparator.groupB
+              .map((entry) => entry.label)
+              .join(','),
+        ]
+      : [];
+
+  const volcanoPlotProps: VolcanoPlotProps = {
+    /**
+     * VolcanoPlot defines an EmptyVolcanoPlotData variable that will be assigned when data is undefined.
+     * In order to display an empty viz, EmptyVolcanoPlotData is defined as:
+     *    const EmptyVolcanoPlotData: VolcanoPlotData = [{log2foldChange: '0', pValue: '1'}];
+     */
+    data: finalData ? Object.values(finalData) : undefined,
+    significanceThreshold,
+    log2FoldChangeThreshold,
+    /**
+     * Since we are rendering a single point in order to display an empty viz, let's hide the data point
+     * by setting the marker opacity to 0 when data.value doesn't exist
+     */
+    markerBodyOpacity: data.value
+      ? vizConfig.markerBodyOpacity ?? DEFAULT_MARKER_OPACITY
+      : 0,
+    containerStyles: plotContainerStyles,
+    /**
+     * Let's not display comparisonLabels before we have data for the viz. This prevents what may be
+     * confusing behavior where selecting group values displays on the empty viz placeholder.
+     */
+    comparisonLabels: data.value ? comparisonLabels : [],
+    showSpinner: data.pending,
+    truncationBarFill: yellow[300],
+    independentAxisRange,
+    dependentAxisRange,
+    rawDataMinMaxValues,
+    /**
+     * As sophisticated aesthetes, let's specify axis ranges for the empty viz placeholder
+     */
+    ...(data.value ? {} : EMPTY_VIZ_AXIS_RANGES),
+  };
+
+  // @ts-ignore
+  const plotNode = <VolcanoPlot {...volcanoPlotProps} ref={plotRef} />;
+
+  const controlsNode = (
+    <div style={{ margin: '1em 1em 2em 1em' }}>
+      <LabelledGroup
+        label="Plot controls"
+        containerStyles={{
+          paddingLeft: 0,
+        }}
+      >
+        <SliderWidget
+          minimum={0}
+          maximum={1}
+          step={0.1}
+          value={vizConfig.markerBodyOpacity ?? DEFAULT_MARKER_OPACITY}
+          debounceRateMs={250}
+          onChange={(newValue: number) => {
+            updateVizConfig({ markerBodyOpacity: newValue });
+          }}
+          containerStyles={{ width: '20em', marginTop: '0.5em' }}
+          showLimits={true}
+          label={'Marker opacity'}
+          colorSpec={plotsSliderOpacityGradientColorSpec}
+        />
+      </LabelledGroup>
+      <div
+        style={{
+          display: 'flex',
+          gap: 20,
+        }}
+      >
+        <div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <LabelledGroup
+              label="X-axis range"
+              children={<></>}
+              containerStyles={{
+                marginRight: 0,
+                paddingLeft: 0,
+              }}
+            />
+            <ResetButtonCoreUI
+              size={'medium'}
+              text={''}
+              themeRole={'primary'}
+              tooltip={'Reset to defaults'}
+              disabled={!vizConfig.independentAxisRange}
+              onPress={() =>
+                updateVizConfig({ independentAxisRange: undefined })
+              }
+            />
+          </div>
+          <AxisRangeControl
+            containerStyles={{ maxWidth: '350px' }}
+            valueType="number"
+            range={independentAxisRange}
+            onRangeChange={(newRange?: NumberOrDateRange) => {
+              const typeCheckedNewRange =
+                typeof newRange?.min === 'number' &&
+                typeof newRange?.max === 'number'
+                  ? {
+                      min: newRange.min,
+                      max: newRange.max,
+                    }
+                  : undefined;
+              updateVizConfig({
+                independentAxisRange: typeCheckedNewRange,
+              });
+            }}
+            step={0.01}
+          />
+        </div>
+        {/** vertical line to separate x from y range controls */}
+        <div style={{ borderRight: '2px solid lightgray' }}></div>
+        <div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <LabelledGroup
+              label="Y-axis range"
+              children={<></>}
+              containerStyles={{
+                marginRight: 0,
+                paddingLeft: 0,
+              }}
+            />
+            <ResetButtonCoreUI
+              size={'medium'}
+              text={''}
+              themeRole={'primary'}
+              tooltip={'Reset to defaults'}
+              disabled={!vizConfig.dependentAxisRange}
+              onPress={() => updateVizConfig({ dependentAxisRange: undefined })}
+            />
+          </div>
+          <AxisRangeControl
+            containerStyles={{ maxWidth: '350px' }}
+            valueType="number"
+            range={dependentAxisRange}
+            onRangeChange={(newRange?: NumberOrDateRange) => {
+              const typeCheckedNewRange =
+                typeof newRange?.min === 'number' &&
+                typeof newRange?.max === 'number'
+                  ? {
+                      min: newRange.min,
+                      max: newRange.max,
+                    }
+                  : undefined;
+              updateVizConfig({
+                dependentAxisRange: typeCheckedNewRange,
+              });
+            }}
+            step={0.01}
+          />
+        </div>
+      </div>
+    </div>
+  );
+
+  const legendNode = finalData && countsData && (
+    <PlotLegend
+      type="list"
+      legendTitle="Legend"
+      legendItems={[
+        {
+          label: `Inconclusive (${
+            countsData[significanceColors['inconclusive']]
+          })`,
+          marker: 'circle',
+          hasData: true,
+          markerColor: significanceColors['inconclusive'],
+        },
+        {
+          label: `Up regulated in ${computationConfiguration.comparator.groupB
+            ?.map((entry) => entry.label)
+            .join(',')} (${countsData[significanceColors['high']]})`,
+          marker: 'circle',
+          hasData: true,
+          markerColor: significanceColors['high'],
+        },
+        {
+          label: `Up regulated in ${computationConfiguration.comparator.groupA
+            ?.map((entry) => entry.label)
+            .join(',')} (${countsData[significanceColors['low']]})`,
+          marker: 'circle',
+          hasData: true,
+          markerColor: significanceColors['low'],
+        },
+      ]}
+      showCheckbox={false}
+    />
+  );
+
+  // TODO
+  const tableGroupNode = <> </>;
+
+  const LayoutComponent = options?.layoutComponent ?? PlotLayout;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <LabelledGroup label="Threshold lines" alignChildrenHorizontally={true}>
+        <NumberInput
+          onValueChange={(newValue?: NumberOrDate) =>
+            updateVizConfig({ log2FoldChangeThreshold: Number(newValue) })
+          }
+          label="log2(Fold Change)"
+          minValue={0}
+          value={vizConfig.log2FoldChangeThreshold ?? DEFAULT_FC_THRESHOLD}
+          containerStyles={{ marginRight: 10 }}
+        />
+
+        <NumberInput
+          label="P-Value"
+          onValueChange={(newValue?: NumberOrDate) =>
+            updateVizConfig({ significanceThreshold: Number(newValue) })
+          }
+          minValue={0}
+          value={vizConfig.significanceThreshold ?? DEFAULT_SIG_THRESHOLD}
+          containerStyles={{ marginLeft: 10 }}
+          step={0.001}
+        />
+      </LabelledGroup>
+
+      {/* This should be populated with info from the colections var. So like "Showing 1000 taxa blah". Waiting on collections annotations. */}
+      {/* <OutputEntityTitle
+        entity={outputEntity}
+        outputSize={outputSize}
+        subtitle={plotSubtitle}
+      /> */}
+      <LayoutComponent
+        isFaceted={false}
+        legendNode={legendNode}
+        plotNode={plotNode}
+        controlsNode={controlsNode}
+        tableGroupNode={tableGroupNode}
+        showRequiredInputsPrompt={false}
+      />
+    </div>
+  );
+}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
@@ -101,8 +101,8 @@ function BipartiteNetworkViz(props: VisualizationProps<Options>) {
     data: cleanedData,
   };
 
-  //@ts-ignore
   const plotNode = (
+    //@ts-ignore
     <BipartiteNetwork {...bipartiteNetworkProps} ref={plotRef} />
   );
 


### PR DESCRIPTION
Resolves tasks in #512 

This PR:

- [x]  adds the Correlation compute plugin
- [x]  adds the bipartite network viz
- [x]  uses fake data to generate a bipartite network when the viz is visited
- [x]  adds a working thumbnail


Using the `add-correlation` of the data service and the rest of the services on their QA images, we can get the following: 


https://github.com/VEuPathDB/web-monorepo/assets/11710234/9a31e7b7-de01-49f1-ac27-122864e6dd9e


Turns out that though it's not so hard to generate fake data, it is a little more involved to sub in the requests and compute job status and such so that we can make the app appear and think that the Step 3 should be enabled. So I did a bit on the backend to help us at least just see the app (see `add-correlation` branch in the data service) but stopped there since we can still see the network enough to verify that it works!

If you do test with the local backend, do not try actually selecting the data in Step 1. The app will try to make a request to the backend but that part of the backend isn't set up yet. In the video, i demo that one _can_ use the drop down, but i don't actually select anything.