### PR TITLE
Tweak UI for new SRT

### DIFF
--- a/packages/libs/web-common/src/components/reporters/BedAndSequenceGenomicSequenceReporterForms.jsx
+++ b/packages/libs/web-common/src/components/reporters/BedAndSequenceGenomicSequenceReporterForms.jsx
@@ -41,7 +41,7 @@ let SequenceRegionRange = (props) => {
         end={10000}
         step={1}
         onChange={getUpdateHandler(offset)}
-        size="6"
+        size={6}
       />
       nucleotides
     </React.Fragment>

--- a/packages/libs/web-common/src/components/reporters/BedGeneReporterForm.jsx
+++ b/packages/libs/web-common/src/components/reporters/BedGeneReporterForm.jsx
@@ -17,38 +17,52 @@ import createSequenceForm from './SequenceFormFactory';
  * Adapted from SequenceGeneReporterForm
  * (no protein options)
  */
-let util = Object.assign({}, ComponentUtils, ReporterUtils);
+const util = Object.assign({}, ComponentUtils, ReporterUtils);
 
-let splicedGenomicOptions = [
+const splicedGenomicOptions = [
   { value: 'cds', display: 'Coding Sequence' },
   { value: 'transcript', display: 'Transcript' },
 ];
 
-let dnaComponentOptions = [
+const dnaComponentOptions = [
   { value: 'exon', display: 'Exon' },
   { value: 'intron', display: 'Intron' },
 ];
 
-let transcriptComponentOptions = [
+const transcriptComponentOptions = [
   { value: 'five_prime_utr', display: "5' UTR" },
   { value: 'cds', display: 'CDS' },
   { value: 'three_prime_utr', display: "3' UTR" },
 ];
 
-let genomicAnchorValues = [
+const genomicAnchorValues = [
   { value: 'Start', display: 'Transcription Start***' },
   { value: 'CodeStart', display: 'Translation Start (ATG)' },
   { value: 'CodeEnd', display: 'Translation Stop Codon' },
   { value: 'End', display: 'Transcription Stop***' },
 ];
 
-let signs = [
+const signs = [
   { value: 'plus', display: '+' },
   { value: 'minus', display: '-' },
 ];
 
-let SequenceRegionRange = (props) => {
-  let { label, anchor, sign, offset, formState, getUpdateHandler } = props;
+const formSequenceTypeOptions = [
+  { value: 'genomic', display: 'Unspliced Genomic Region' },
+  {
+    value: 'spliced_genomic',
+    display: (
+      <>
+        Spliced Genomic Region (<i>i.e. transcribed sequences</i>)
+      </>
+    ),
+  },
+  { value: 'dna_component', display: 'DNA Component' },
+  { value: 'transcript_component', display: 'Transcript Component' },
+];
+
+const SequenceRegionRange = (props) => {
+  const { label, anchor, sign, offset, formState, getUpdateHandler } = props;
   return (
     <React.Fragment>
       <span>{label}</span>
@@ -78,8 +92,8 @@ let SequenceRegionRange = (props) => {
   );
 };
 
-let GenomicSequenceRegionInputs = (props) => {
-  let { formState, getUpdateHandler } = props;
+const GenomicSequenceRegionInputs = (props) => {
+  const { formState, getUpdateHandler } = props;
   return (
     <div>
       <div
@@ -114,14 +128,14 @@ let GenomicSequenceRegionInputs = (props) => {
 };
 
 /** @type import('./Types').ReporterFormComponent */
-let formBeforeCommonOptions = (props) => {
-  let { formState, updateFormState, onSubmit, includeSubmit } = props;
-  let getUpdateHandler = (fieldName) =>
+const formBeforeCommonOptions = (props) => {
+  const { formState, updateFormState, onSubmit, includeSubmit } = props;
+  const getUpdateHandler = (fieldName) =>
     util.getChangeHandler(fieldName, updateFormState, formState);
-  let typeUpdateHandler = function (newTypeValue) {
+  const typeUpdateHandler = function (newTypeValue) {
     updateFormState(Object.assign({}, formState, { type: newTypeValue }));
   };
-  let getTypeSpecificParams = () => {
+  const getTypeSpecificParams = () => {
     switch (formState.type) {
       case 'genomic':
         return (
@@ -161,26 +175,29 @@ let formBeforeCommonOptions = (props) => {
   };
   return (
     <React.Fragment>
-      <h3>Choose the type of result:</h3>
+      <h3>Choose the type of sequence:</h3>
       <div style={{ marginLeft: '2em' }}>
         <RadioList
           name="type"
           value={formState.type}
           onChange={typeUpdateHandler}
-          items={[
-            { value: 'genomic', display: 'Unspliced Genomic Region' },
-            { value: 'spliced_genomic', display: 'Spliced Genomic Region' },
-            { value: 'dna_component', display: 'DNA Component' },
-            { value: 'transcript_component', display: 'Transcript Component' },
-          ]}
+          items={formSequenceTypeOptions}
         />
-        <h4>Configure details:</h4>
+        <h4>
+          Configure details for{' '}
+          {
+            formSequenceTypeOptions.find(
+              (item) => item.value === formState.type
+            ).display
+          }
+          :
+        </h4>
         {getTypeSpecificParams()}
       </div>
     </React.Fragment>
   );
 };
-let formAfterSubmitButton = (props) => {
+const formAfterSubmitButton = (props) => {
   return (
     <React.Fragment>
       <div>
@@ -197,7 +214,7 @@ let formAfterSubmitButton = (props) => {
     </React.Fragment>
   );
 };
-let getFormInitialState = () => ({
+const getFormInitialState = () => ({
   type: 'genomic',
 
   reverseAndComplement: false,

--- a/packages/libs/web-common/src/components/reporters/BedGeneReporterForm.jsx
+++ b/packages/libs/web-common/src/components/reporters/BedGeneReporterForm.jsx
@@ -82,7 +82,7 @@ const SequenceRegionRange = (props) => {
         end={10000}
         step={1}
         onChange={getUpdateHandler(offset)}
-        size="6"
+        size={6}
       />
       nucleotides
     </React.Fragment>

--- a/packages/libs/web-common/src/components/reporters/BedGeneReporterForm.jsx
+++ b/packages/libs/web-common/src/components/reporters/BedGeneReporterForm.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import {
   RadioList,
-  CheckboxList,
   SingleSelect,
-  TextBox,
-  Checkbox,
   NumberSelector,
 } from '@veupathdb/wdk-client/lib/Components';
 import { FeaturesList } from './SequenceFormElements';

--- a/packages/libs/web-common/src/components/reporters/ReporterForms.scss
+++ b/packages/libs/web-common/src/components/reporters/ReporterForms.scss
@@ -1,0 +1,5 @@
+.ebrc-FixedWidth-detail {
+  .wdk-NumberSelector {
+    margin: 0 0.25em;
+  }
+}

--- a/packages/libs/web-common/src/components/reporters/SequenceFormElements.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceFormElements.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { RadioList, CheckboxList } from '@veupathdb/wdk-client/lib/Components';
+import { RadioList } from '@veupathdb/wdk-client/lib/Components';
+import CheckboxList from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxList';
 
 let FeaturesList = (props) => {
   let { features, field, formState, getUpdateHandler } = props;
@@ -37,6 +38,7 @@ let ComponentsList = (props) => {
           onChange={getUpdateHandler(field)}
           items={features}
           linksPosition={null}
+          disabledCheckboxTooltipContent="Required field"
         />
       </div>
     </div>

--- a/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
@@ -59,20 +59,18 @@ const sequenceOptions = (props) => {
             { value: 'single_line', display: 'Single Line' },
           ]}
         />
-        {formState.sequenceFormat === 'fixed_width' && (
-          <div className="ebrc-FixedWidth-detail">
-            <NumberSelector
-              name={'basesPerLine'}
-              start={0}
-              end={10000}
-              value={formState['basesPerLine']}
-              step={1}
-              onChange={getUpdateHandler('basesPerLine')}
-              size={6}
-            />
-            <span>bases per line</span>
-          </div>
-        )}
+        <div className="ebrc-FixedWidth-detail">
+          <NumberSelector
+            name={'basesPerLine'}
+            start={0}
+            end={10000}
+            value={formState['basesPerLine']}
+            step={1}
+            onChange={getUpdateHandler('basesPerLine')}
+            size={6}
+          />
+          <span>bases per line</span>
+        </div>
       </div>
     </React.Fragment>
   );

--- a/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
@@ -62,7 +62,7 @@ const sequenceOptions = (props) => {
               value={formState['basesPerLine']}
               step={1}
               onChange={getUpdateHandler('basesPerLine')}
-              size="6"
+              size={6}
             />
             <span>bases per line</span>
           </div>
@@ -85,7 +85,7 @@ const createSequenceForm = (
     return (
       <div>
         {formBeforeCommonOptions(props)}
-        <h3>Download Type:</h3>
+        <h3>Download type:</h3>
         <div style={{ marginLeft: '2em' }}>
           <RadioList
             name="attachmentType"

--- a/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import {
   RadioList,
-  CheckboxList,
-  SingleSelect,
-  TextBox,
-  Checkbox,
   NumberSelector,
 } from '@veupathdb/wdk-client/lib/Components';
-import { FeaturesList, ComponentsList } from './SequenceFormElements';
+import { ComponentsList } from './SequenceFormElements';
 import * as ComponentUtils from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import * as ReporterUtils from '@veupathdb/wdk-client/lib/Views/ReporterForm/reporterUtils';
 import './ReporterForms.scss';
@@ -15,6 +11,7 @@ import './ReporterForms.scss';
 const util = Object.assign({}, ComponentUtils, ReporterUtils);
 
 const deflineFieldOptions = [
+  { value: 'gene_id', display: 'Gene ID', disabled: true },
   { value: 'organism', display: 'Organism' },
   { value: 'description', display: 'Description' },
   { value: 'position', display: 'Location' },
@@ -23,23 +20,14 @@ const deflineFieldOptions = [
 ];
 
 const sequenceOptions = (props) => {
-  const { formState, updateFormState, onSubmit, includeSubmit } = props;
+  const { formState, updateFormState } = props;
   const getUpdateHandler = (fieldName) =>
     util.getChangeHandler(fieldName, updateFormState, formState);
   return (
     <React.Fragment>
       <h3>Fasta defline:</h3>
-      <div style={{ marginLeft: '2em' }}>
-        <RadioList
-          name="deflineType"
-          value={formState.deflineType}
-          onChange={getUpdateHandler('deflineType')}
-          items={[
-            { value: 'short', display: 'ID Only' },
-            { value: 'full', display: 'Full Fasta Header' },
-          ]}
-        />
-        {formState.deflineType === 'short' ? null : (
+      <div>
+        {formState.deflineType === 'full' && (
           <ComponentsList
             field="deflineFields"
             features={deflineFieldOptions}
@@ -122,8 +110,9 @@ const createSequenceForm = (
   Form.getInitialState = () => ({
     formState: {
       attachmentType: 'plain',
-      deflineType: 'short',
-      deflineFields: deflineFieldOptions.map((x) => x.value),
+      deflineType: 'full',
+      // QUESTION: should I remove this from formState when form is submitted or should backend expect this field?
+      deflineFields: ['gene_id'],
       sequenceFormat: 'fixed_width',
       basesPerLine: 60,
       ...getFormInitialState(),

--- a/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
@@ -2,11 +2,17 @@ import React from 'react';
 import {
   RadioList,
   NumberSelector,
+  Checkbox,
 } from '@veupathdb/wdk-client/lib/Components';
 import { ComponentsList } from './SequenceFormElements';
 import * as ComponentUtils from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import * as ReporterUtils from '@veupathdb/wdk-client/lib/Views/ReporterForm/reporterUtils';
 import './ReporterForms.scss';
+
+const SINGLE_TRANSCRIPT_VIEW_FILTER_VALUE = {
+  name: 'representativeTranscriptOnly',
+  value: {},
+};
 
 const util = Object.assign({}, ComponentUtils, ReporterUtils);
 
@@ -79,9 +85,27 @@ const createSequenceForm = (
   reportType
 ) => {
   const Form = (props) => {
-    const { formState, updateFormState, onSubmit, includeSubmit } = props;
+    const {
+      formState,
+      updateFormState,
+      onSubmit,
+      includeSubmit,
+      viewFilters,
+      updateViewFilters,
+    } = props;
     const getUpdateHandler = (fieldName) =>
       util.getChangeHandler(fieldName, updateFormState, formState);
+    const transcriptPerGeneChangeHandler = (isChecked) => {
+      const nextViewFilters =
+        viewFilters?.filter(
+          (filterValue) =>
+            filterValue.name !== SINGLE_TRANSCRIPT_VIEW_FILTER_VALUE.name
+        ) ?? [];
+      if (isChecked) {
+        nextViewFilters.push(SINGLE_TRANSCRIPT_VIEW_FILTER_VALUE);
+      }
+      updateViewFilters(nextViewFilters);
+    };
     return (
       <div>
         {formBeforeCommonOptions(props)}
@@ -95,6 +119,22 @@ const createSequenceForm = (
           />
         </div>
         {reportType === 'Sequences' && sequenceOptions(props)}
+        <h3>Additional options:</h3>
+        <div style={{ marginLeft: '1.5em' }}>
+          <label>
+            <Checkbox
+              value={
+                viewFilters?.some(
+                  (f) => f.name === SINGLE_TRANSCRIPT_VIEW_FILTER_VALUE.name
+                ) ?? false
+              }
+              onChange={transcriptPerGeneChangeHandler}
+            />
+            <span style={{ marginLeft: '0.5em' }}>
+              Include only one transcript per gene (the longest)
+            </span>
+          </label>
+        </div>
         {includeSubmit && (
           <div style={{ margin: '0.8em' }}>
             <button className="btn" type="submit" onClick={onSubmit}>
@@ -107,18 +147,20 @@ const createSequenceForm = (
     );
   };
 
-  Form.getInitialState = () => ({
-    formState: {
-      attachmentType: 'plain',
-      deflineType: 'full',
-      // QUESTION: should I remove this from formState when form is submitted or should backend expect this field?
-      deflineFields: ['gene_id'],
-      sequenceFormat: 'fixed_width',
-      basesPerLine: 60,
-      ...getFormInitialState(),
-    },
-    formUiState: {},
-  });
+  Form.getInitialState = () => {
+    return {
+      formState: {
+        attachmentType: 'plain',
+        deflineType: 'full',
+        // QUESTION: should I remove this from formState when form is submitted or should backend expect this field?
+        deflineFields: ['gene_id'],
+        sequenceFormat: 'fixed_width',
+        basesPerLine: 60,
+        ...getFormInitialState(),
+      },
+      formUiState: {},
+    };
+  };
   return Form;
 };
 export default createSequenceForm;

--- a/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
@@ -10,10 +10,11 @@ import {
 import { FeaturesList, ComponentsList } from './SequenceFormElements';
 import * as ComponentUtils from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import * as ReporterUtils from '@veupathdb/wdk-client/lib/Views/ReporterForm/reporterUtils';
+import './ReporterForms.scss';
 
-let util = Object.assign({}, ComponentUtils, ReporterUtils);
+const util = Object.assign({}, ComponentUtils, ReporterUtils);
 
-let deflineFieldOptions = [
+const deflineFieldOptions = [
   { value: 'organism', display: 'Organism' },
   { value: 'description', display: 'Description' },
   { value: 'position', display: 'Location' },
@@ -21,9 +22,9 @@ let deflineFieldOptions = [
   { value: 'segment_length', display: 'Segment Length' },
 ];
 
-let sequenceOptions = (props) => {
-  let { formState, updateFormState, onSubmit, includeSubmit } = props;
-  let getUpdateHandler = (fieldName) =>
+const sequenceOptions = (props) => {
+  const { formState, updateFormState, onSubmit, includeSubmit } = props;
+  const getUpdateHandler = (fieldName) =>
     util.getChangeHandler(fieldName, updateFormState, formState);
   return (
     <React.Fragment>
@@ -48,19 +49,24 @@ let sequenceOptions = (props) => {
         )}
       </div>
       <h3>Sequence format:</h3>
-      <div style={{ marginLeft: '2em' }}>
+      <div
+        style={{
+          marginLeft: '2em',
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr',
+        }}
+      >
         <RadioList
           name="sequenceFormat"
           value={formState.sequenceFormat}
           onChange={getUpdateHandler('sequenceFormat')}
           items={[
+            { value: 'fixed_width', display: 'Fixed Width with' },
             { value: 'single_line', display: 'Single Line' },
-            { value: 'fixed_width', display: 'Fixed Width' },
           ]}
         />
-        {formState.sequenceFormat === 'single_line' ? null : (
-          <React.Fragment>
-            <span>Bases Per Line: </span>
+        {formState.sequenceFormat === 'fixed_width' && (
+          <div className="ebrc-FixedWidth-detail">
             <NumberSelector
               name={'basesPerLine'}
               start={0}
@@ -70,22 +76,23 @@ let sequenceOptions = (props) => {
               onChange={getUpdateHandler('basesPerLine')}
               size="6"
             />
-          </React.Fragment>
+            <span>bases per line</span>
+          </div>
         )}
       </div>
     </React.Fragment>
   );
 };
 
-let createSequenceForm = (
+const createSequenceForm = (
   formBeforeCommonOptions,
   formAfterSubmitButton,
   getFormInitialState,
   reportType
 ) => {
-  let Form = (props) => {
-    let { formState, updateFormState, onSubmit, includeSubmit } = props;
-    let getUpdateHandler = (fieldName) =>
+  const Form = (props) => {
+    const { formState, updateFormState, onSubmit, includeSubmit } = props;
+    const getUpdateHandler = (fieldName) =>
       util.getChangeHandler(fieldName, updateFormState, formState);
     return (
       <div>

--- a/packages/libs/web-common/src/components/reporters/SequenceGeneReporterForm.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceGeneReporterForm.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import {
   RadioList,
-  CheckboxList,
   SingleSelect,
-  TextBox,
   Checkbox,
   NumberSelector,
 } from '@veupathdb/wdk-client/lib/Components';
@@ -72,7 +70,14 @@ const formSequenceTypeOptions = [
   { value: 'dna_component', display: 'DNA Component' },
   { value: 'transcript_component', display: 'Transcript Component' },
   { value: 'protein', display: 'Protein Sequence' },
-  { value: 'protein_features', display: 'Protein Features' },
+  {
+    value: 'protein_features',
+    display: (
+      <>
+        Protein Features (<i>one per line</i>)
+      </>
+    ),
+  },
 ];
 
 const SequenceRegionRange = (props) => {

--- a/packages/libs/web-common/src/components/reporters/SequenceGeneReporterForm.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceGeneReporterForm.jsx
@@ -104,7 +104,7 @@ const SequenceRegionRange = (props) => {
         end={10000}
         step={1}
         onChange={getUpdateHandler(offset)}
-        size="6"
+        size={6}
       />
       nucleotides
     </React.Fragment>
@@ -129,7 +129,7 @@ const ProteinRegionRange = (props) => {
         end={10000}
         step={1}
         onChange={getUpdateHandler(offset)}
-        size="6"
+        size={6}
       />
       amino acids
     </React.Fragment>
@@ -213,7 +213,7 @@ const ProteinSequenceRegionInputs = (props) => {
 
 /** @type import('./Types').ReporterFormComponent */
 const formBeforeCommonOptions = (props) => {
-  const { formState, updateFormState, onSubmit, includeSubmit } = props;
+  const { formState, updateFormState, viewFilters } = props;
   const getUpdateHandler = (fieldName) =>
     util.getChangeHandler(fieldName, updateFormState, formState);
   const typeUpdateHandler = function (newTypeValue) {

--- a/packages/libs/web-common/src/components/reporters/SequenceGeneReporterForm.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceGeneReporterForm.jsx
@@ -17,50 +17,66 @@ import createSequenceForm from './SequenceFormFactory';
  * Similar to SequenceGeneReporterForm
  * (but with protein options)
  */
-let util = Object.assign({}, ComponentUtils, ReporterUtils);
+const util = Object.assign({}, ComponentUtils, ReporterUtils);
 
-let splicedGenomicOptions = [
+const splicedGenomicOptions = [
   { value: 'cds', display: 'Coding Sequence' },
   { value: 'transcript', display: 'Transcript' },
 ];
 
-let proteinFeatureOptions = [
+const proteinFeatureOptions = [
   { value: 'interpro', display: 'InterPro' },
   { value: 'signalp', display: 'SignalP' },
   { value: 'tmhmm', display: 'Transmembrane Domains' },
   { value: 'low_complexity', display: 'Low Complexity Regions' },
 ];
 
-let dnaComponentOptions = [
+const dnaComponentOptions = [
   { value: 'exon', display: 'Exon' },
   { value: 'intron', display: 'Intron' },
 ];
 
-let transcriptComponentOptions = [
+const transcriptComponentOptions = [
   { value: 'five_prime_utr', display: "5' UTR" },
   { value: 'cds', display: 'CDS' },
   { value: 'three_prime_utr', display: "3' UTR" },
 ];
 
-let genomicAnchorValues = [
+const genomicAnchorValues = [
   { value: 'Start', display: 'Transcription Start***' },
   { value: 'CodeStart', display: 'Translation Start (ATG)' },
   { value: 'CodeEnd', display: 'Translation Stop Codon' },
   { value: 'End', display: 'Transcription Stop***' },
 ];
 
-let proteinAnchorValues = [
+const proteinAnchorValues = [
   { value: 'DownstreamFromStart', display: 'Downstream from Start' },
   { value: 'UpstreamFromEnd', display: 'Upstream from End' },
 ];
 
-let signs = [
+const signs = [
   { value: 'plus', display: '+' },
   { value: 'minus', display: '-' },
 ];
 
-let SequenceRegionRange = (props) => {
-  let { label, anchor, sign, offset, formState, getUpdateHandler } = props;
+const formSequenceTypeOptions = [
+  { value: 'genomic', display: 'Unspliced Genomic Sequence' },
+  {
+    value: 'spliced_genomic',
+    display: (
+      <>
+        Spliced Genomic Region (<i>i.e. transcribed sequences</i>)
+      </>
+    ),
+  },
+  { value: 'dna_component', display: 'DNA Component' },
+  { value: 'transcript_component', display: 'Transcript Component' },
+  { value: 'protein', display: 'Protein Sequence' },
+  { value: 'protein_features', display: 'Protein Features' },
+];
+
+const SequenceRegionRange = (props) => {
+  const { label, anchor, sign, offset, formState, getUpdateHandler } = props;
   return (
     <React.Fragment>
       <span>{label}</span>
@@ -90,8 +106,8 @@ let SequenceRegionRange = (props) => {
   );
 };
 
-let ProteinRegionRange = (props) => {
-  let { label, anchor, offset, formState, getUpdateHandler } = props;
+const ProteinRegionRange = (props) => {
+  const { label, anchor, offset, formState, getUpdateHandler } = props;
   return (
     <React.Fragment>
       <span>{label}</span>
@@ -115,8 +131,8 @@ let ProteinRegionRange = (props) => {
   );
 };
 
-let GenomicSequenceRegionInputs = (props) => {
-  let { formState, getUpdateHandler } = props;
+const GenomicSequenceRegionInputs = (props) => {
+  const { formState, getUpdateHandler } = props;
   return (
     <div>
       <div style={{ marginLeft: '0.75em' }}>
@@ -157,8 +173,8 @@ let GenomicSequenceRegionInputs = (props) => {
     </div>
   );
 };
-let ProteinSequenceRegionInputs = (props) => {
-  let { formState, getUpdateHandler } = props;
+const ProteinSequenceRegionInputs = (props) => {
+  const { formState, getUpdateHandler } = props;
   return (
     <div>
       <div
@@ -191,14 +207,14 @@ let ProteinSequenceRegionInputs = (props) => {
 };
 
 /** @type import('./Types').ReporterFormComponent */
-let formBeforeCommonOptions = (props) => {
-  let { formState, updateFormState, onSubmit, includeSubmit } = props;
-  let getUpdateHandler = (fieldName) =>
+const formBeforeCommonOptions = (props) => {
+  const { formState, updateFormState, onSubmit, includeSubmit } = props;
+  const getUpdateHandler = (fieldName) =>
     util.getChangeHandler(fieldName, updateFormState, formState);
-  let typeUpdateHandler = function (newTypeValue) {
+  const typeUpdateHandler = function (newTypeValue) {
     updateFormState(Object.assign({}, formState, { type: newTypeValue }));
   };
-  let getTypeSpecificParams = () => {
+  const getTypeSpecificParams = () => {
     switch (formState.type) {
       case 'genomic':
         return (
@@ -254,28 +270,29 @@ let formBeforeCommonOptions = (props) => {
   };
   return (
     <React.Fragment>
-      <h3>Choose the type of result:</h3>
+      <h3>Choose the type of sequence:</h3>
       <div style={{ marginLeft: '2em' }}>
         <RadioList
           name="type"
           value={formState.type}
           onChange={typeUpdateHandler}
-          items={[
-            { value: 'genomic', display: 'Unspliced Genomic Sequence' },
-            { value: 'spliced_genomic', display: 'Spliced Genomic Sequence' },
-            { value: 'dna_component', display: 'DNA Component' },
-            { value: 'transcript_component', display: 'Transcript Component' },
-            { value: 'protein', display: 'Protein Sequence' },
-            { value: 'protein_features', display: 'Protein Features' },
-          ]}
+          items={formSequenceTypeOptions}
         />
-        <h4>Configure details:</h4>
+        <h4>
+          Configure details for{' '}
+          {
+            formSequenceTypeOptions.find(
+              (item) => item.value === formState.type
+            ).display
+          }
+          :
+        </h4>
         {getTypeSpecificParams()}
       </div>
     </React.Fragment>
   );
 };
-let formAfterSubmitButton = (props) => {
+const formAfterSubmitButton = (props) => {
   return (
     <React.Fragment>
       <div>
@@ -297,7 +314,7 @@ let formAfterSubmitButton = (props) => {
     </React.Fragment>
   );
 };
-let getFormInitialState = () => ({
+const getFormInitialState = () => ({
   type: 'genomic',
 
   // sequence region inputs for 'genomic'

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/TranscriptRecordClasses.TranscriptRecordClass.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/TranscriptRecordClasses.TranscriptRecordClass.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { useWdkServiceWithRefresh } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 
 import {
-  isTranscripFilterEnabled,
+  isTranscriptFilterEnabled,
   requestTranscriptFilterUpdate,
   isInBasketFilterEnabled,
 } from '../../util/transcriptFilters';
@@ -137,7 +137,7 @@ function TranscriptViewFilter({
 
 const ConnectedTranscriptViewFilter = connect(
   (state, props) => ({
-    isEnabled: isTranscripFilterEnabled(state, { viewId: props.viewId }),
+    isEnabled: isTranscriptFilterEnabled(state, { viewId: props.viewId }),
     inBasketFilterEnabled: isInBasketFilterEnabled(state, {
       viewId: props.viewId,
     }),

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/util/transcriptFilters.js
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/util/transcriptFilters.js
@@ -9,7 +9,7 @@ const isFilter = (filter) =>
 const isNotFilter = negate(isFilter);
 
 // selector to determine if filter is enabled
-export function isTranscripFilterEnabled(state, props) {
+export function isTranscriptFilterEnabled(state, props) {
   const viewFilters = get(
     [
       'resultTableSummaryView',


### PR DESCRIPTION
Addresses the following points [from this issue](https://github.com/VEuPathDB/EbrcWebsiteCommon/issues/193):
> 1. Mockup updated after UX meeting Jan 18 2023 https://docs.google.com/presentation/d/1m43IHO6BnkXHpusYR2cnJgWdgazm8jCy1euqBiNyKRA/edit#slide=id.p
> 2. Add a checkbox as in the tabular reporter to select one transcript per gene to all report forms where this is now supported. See
https://github.com/VEuPathDB/ApiCommonWebsite/issues/117

Below is a screenshot of the UI changes [modeled off of this mockup](https://docs.google.com/presentation/d/1m43IHO6BnkXHpusYR2cnJgWdgazm8jCy1euqBiNyKRA/edit#slide=id.p).

Note that there's a comment in the code that wonders if the flattening of the defline options, which requires adding `gene_id` to the `deflineFields` array, would cause trouble with the backend. It does not appear to break anything. I tested my branch with a local dev server pointed at @ryanrdoherty's dev site and the same reports succeed and fail when using this branch versus `main`.

![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/679477f5-c425-4d7b-9dbd-d74f1a237e06)