### PR TITLE
test expandable computation step container

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/ComputationStepContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/ComputationStepContainer.tsx
@@ -4,6 +4,7 @@ import {
   NumberedHeader,
   NumberedHeaderProps,
 } from '../../../workspace/Subsetting/SubsetDownloadModal';
+import { ExpandablePanel } from '@veupathdb/coreui';
 
 type ComputationStepContainer = {
   children: React.ReactChild;
@@ -21,18 +22,18 @@ const disabledStyles: CSSProperties = {
 };
 
 export function ComputationStepContainer(props: ComputationStepContainer) {
-  const theme = useUITheme();
-  const primaryColor =
-    theme?.palette.primary.hue[theme.palette.primary.level] ?? 'black';
   const { children, computationStepInfo, isStepDisabled } = props;
   return (
     <div style={isStepDisabled ? disabledStyles : undefined}>
-      <NumberedHeader
-        number={computationStepInfo.stepNumber}
-        text={computationStepInfo.stepTitle}
-        color={isStepDisabled ? 'darkgrey' : primaryColor}
-      />
-      {children}
+      <ExpandablePanel
+        title={computationStepInfo.stepTitle}
+        subTitle={''}
+        state={'open'}
+        stylePreset="floating"
+        themeRole="primary"
+      >
+        {children}
+      </ExpandablePanel>
     </div>
   );
 }


### PR DESCRIPTION
In previous UX meetings (long ago now), there was concern about both the number of steps in the mbio apps and also how many parameters we might have filling up too much page space. We're encountering this issue with the diff abund app because of its data-method dependencies and also how the grouping variables work. All works right now but we could improve the flow clarity by offering more steps. But, of course, that takes up more page space. 

Rambling aside, this PR tests what it would be like swapping the step container for expandable panel. I do _not_ suggest we keep the blue background, and there are probably more styling things we should consider. But this is much faster than figma-ing a bunch of expandable panels, thanks to some clever developers who made swapping components really nice 🔥 

Thoughts welcome!




https://github.com/VEuPathDB/web-monorepo/assets/11710234/09c1092b-1495-4ea1-9d66-038aa4e95f0a


