### PR TITLE
Use Maaslin only and report method in plot

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -206,11 +206,13 @@ export function DifferentialAbundanceConfiguration(
     );
 
   const collectionVarItems = useMemo(() => {
+    // Show all collections except for absolute abundance. Eventually this will be performed by
+    // the backend, similar to how we do visualization input var constraints.
     return collections
       .filter((collectionVar) => {
         return collectionVar.normalizationMethod
-          ? collectionVar.normalizationMethod !== 'NULL' &&
-              !collectionVar.displayName?.includes('pathway')
+          ? collectionVar.normalizationMethod !== 'NULL' ||
+              collectionVar.displayName?.includes('pathway')
           : true; // DIY may not have the normalizationMethod annotations, but we still want those datasets to pass.
       })
       .map((collectionVar) => ({

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -35,7 +35,6 @@ import {
   GetBinRangesProps,
   getBinRanges,
 } from '../../../../map/analysis/utils/defaultOverlayConfig';
-import { config } from 'process';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
@@ -91,7 +90,13 @@ export const plugin: ComputationPlugin = {
   createDefaultConfiguration: () => undefined,
   isConfigurationValid: isCompleteDifferentialAbundanceConfig,
   visualizationPlugins: {
-    volcanoplot: volcanoPlotVisualization, // Must match name in data service and in visualization.tsx
+    volcanoplot: volcanoPlotVisualization.withOptions({
+      getPlotSubtitle(config) {
+        if (DifferentialAbundanceConfig.is(config)) {
+          return `Differential abundance computed using ${config.differentialAbundanceMethod} with default parameters.`;
+        }
+      },
+    }), // Must match name in data service and in visualization.tsx
   },
 };
 

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -25,7 +25,7 @@ import { createVisualizationPlugin } from '../VisualizationPlugin';
 import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
 import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
 
-import { LayoutOptions } from '../../layouts/types';
+import { LayoutOptions, TitleOptions } from '../../layouts/types';
 import { RequestOptions } from '../options/types';
 
 // Volcano plot imports
@@ -54,6 +54,7 @@ import SliderWidget, {
 import { ResetButtonCoreUI } from '../../ResetButton';
 import AxisRangeControl from '@veupathdb/components/lib/components/plotControls/AxisRangeControl';
 import { fixVarIdLabel } from '../../../utils/visualization';
+import { OutputEntityTitle } from '../OutputEntityTitle';
 // end imports
 
 const DEFAULT_SIG_THRESHOLD = 0.05;
@@ -106,6 +107,7 @@ export const VolcanoPlotConfig = t.partial({
 
 interface Options
   extends LayoutOptions,
+    TitleOptions,
     RequestOptions<VolcanoPlotConfig, {}, VolcanoPlotRequestParams> {}
 
 // Volcano Plot Visualization
@@ -384,6 +386,11 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
     ]
   );
 
+  // plot subtitle
+  const plotSubtitle = options?.getPlotSubtitle?.(
+    computation.descriptor.configuration
+  );
+
   // Add labels to the extremes of the x axis. These may change in the future based on the type
   // of data. For example, for genes we may want to say Up regulated in...
   const comparisonLabels =
@@ -627,12 +634,7 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
         />
       </LabelledGroup>
 
-      {/* This should be populated with info from the colections var. So like "Showing 1000 taxa blah". Waiting on collections annotations. */}
-      {/* <OutputEntityTitle
-        entity={outputEntity}
-        outputSize={outputSize}
-        subtitle={plotSubtitle}
-      /> */}
+      <OutputEntityTitle subtitle={plotSubtitle} />
       <LayoutComponent
         isFaceted={false}
         legendNode={legendNode}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -121,8 +121,6 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
     updateConfiguration,
     updateThumbnail,
     filters,
-    dataElementConstraints,
-    dataElementDependencyOrder,
     filteredCounts,
     computeJobStatus,
   } = props;

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -34,7 +34,6 @@ import DataClient, {
   VolcanoPlotResponse,
 } from '../../../api/DataClient';
 import {
-  VolcanoPlotData,
   VolcanoPlotDataPoint,
   VolcanoPlotStats,
 } from '@veupathdb/components/lib/types/plots/volcanoplot';


### PR DESCRIPTION
Resolves #541 

Discussed in the mbio meeting, @dpbisme raised concerns about the method selection becoming too complicated for users. Instead he suggested choosing the method based on the data, so that the user doesn't have to choose. 
UPDATE: New decision is to only use the 'Maaslin' method for this first roll out. Code has been updated so as to only use Maaslin as the differential abundance method.


This PR 
1. Removes the Method input selector
2. Sets the `differentialAbundanceMethod` to always be `Maaslin`
3. Reports the method used in the volcano plot subtitle.

