### PR TITLE
replace variableId with collectionId

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -92,7 +92,7 @@ function AbundanceConfigDescriptionComponent({
   const updatedCollectionVariable = collections.find((collectionVar) =>
     isEqual(
       {
-        variableId: collectionVar.id,
+        collectionId: collectionVar.id,
         entityId: collectionVar.entityId,
       },
       collectionVariable

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -75,7 +75,7 @@ function AlphaDivConfigDescriptionComponent({
   const updatedCollectionVariable = collections.find((collectionVar) =>
     isEqual(
       {
-        variableId: collectionVar.id,
+        collectionId: collectionVar.id,
         entityId: collectionVar.entityId,
       },
       collectionVariable

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -77,7 +77,7 @@ function BetaDivConfigDescriptionComponent({
   const updatedCollectionVariable = collections.find((collectionVar) =>
     isEqual(
       {
-        variableId: collectionVar.id,
+        collectionId: collectionVar.id,
         entityId: collectionVar.entityId,
       },
       collectionVariable

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -74,7 +74,7 @@ function CorrelationAssayMetadataConfigDescriptionComponent({
   const updatedCollectionVariable = collections.find((collectionVar) =>
     isEqual(
       {
-        variableId: collectionVar.id,
+        collectionId: collectionVar.id,
         entityId: collectionVar.entityId,
       },
       collectionVariable

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -127,7 +127,7 @@ function DifferentialAbundanceConfigDescriptionComponent({
   const updatedCollectionVariable = collections.find((collectionVar) =>
     isEqual(
       {
-        variableId: collectionVar.id,
+        collectionId: collectionVar.id,
         entityId: collectionVar.entityId,
       },
       collectionVariable


### PR DESCRIPTION
When the api changed last week, it replaced `variableId` with `collectionId` for collection variables. We missed one spot in the description component for each app where we should have also made the swap. This eventually made the component think there was no collection variable selected.

Before (qa):
![image](https://github.com/VEuPathDB/web-monorepo/assets/11710234/bcea5427-d0d5-4fdd-88e8-905e699f5452)

After (this PR):
<img width="518" alt="Screen Shot 2023-10-10 at 2 15 16 PM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/1a12e6a2-ae55-4cad-a36e-edcff32037b6">

