### PR TITLE
Bring back old FlyTo behaviour for now

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -34,6 +34,7 @@ import SemanticMarkers from '@veupathdb/components/lib/map/SemanticMarkers';
 import {
   DistributionMarkerDataProps,
   defaultAnimation,
+  isApproxSameViewport,
   useCategoricalValues,
   useDistributionMarkerData,
   useDistributionOverlayConfig,
@@ -356,7 +357,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
           animation={defaultAnimation}
           flyToMarkers={
             !markerData.isFetching &&
-            markerData.boundsZoomLevel?.zoomLevel === defaultViewport.zoom
+            isApproxSameViewport(props.appState.viewport, defaultViewport)
           }
           flyToMarkersDelay={500}
         />

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -38,7 +38,11 @@ import {
 import { BubbleMarkerIcon } from '../../MarkerConfiguration/icons';
 import { useStandaloneVizPlugins } from '../../hooks/standaloneVizPlugins';
 import { getDefaultBubbleOverlayConfig } from '../../utils/defaultOverlayConfig';
-import { defaultAnimation, useCommonData } from '../shared';
+import {
+  defaultAnimation,
+  isApproxSameViewport,
+  useCommonData,
+} from '../shared';
 import {
   MapTypeConfigPanelProps,
   MapTypeMapLayerProps,
@@ -198,8 +202,7 @@ function BubbleMapLayer(props: MapTypeMapLayerProps) {
           animation={defaultAnimation}
           flyToMarkers={
             !markersData.isFetching &&
-            markersData.data?.boundsZoomLevel?.zoomLevel ===
-              defaultViewport.zoom
+            isApproxSameViewport(props.appState.viewport, defaultViewport)
           }
           flyToMarkersDelay={500}
         />

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -34,6 +34,7 @@ import {
 import {
   DistributionMarkerDataProps,
   defaultAnimation,
+  isApproxSameViewport,
   useCategoricalValues,
   useDistributionMarkerData,
   useDistributionOverlayConfig,
@@ -315,8 +316,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
           animation={defaultAnimation}
           flyToMarkers={
             !markerDataResponse.isFetching &&
-            markerDataResponse.boundsZoomLevel?.zoomLevel ===
-              defaultViewport.zoom
+            isApproxSameViewport(props.appState.viewport, defaultViewport)
           }
           flyToMarkersDelay={500}
         />

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.ts
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.ts
@@ -30,6 +30,7 @@ import {
   gradientSequentialColorscaleMap,
 } from '@veupathdb/components/lib/types/plots';
 import { getCategoricalValues } from '../utils/categoricalValues';
+import { Viewport } from '@veupathdb/components/lib/map/MapVEuMap';
 
 export const defaultAnimation = {
   method: 'geohash',
@@ -341,4 +342,13 @@ export function useCategoricalValues(props: CategoricalValuesProps) {
     },
     enabled: props.enabled ?? true,
   });
+}
+
+export function isApproxSameViewport(v1: Viewport, v2: Viewport) {
+  const epsilon = 2.0;
+  return (
+    v1.zoom === v2.zoom &&
+    Math.abs(v1.center[0] - v2.center[0]) < epsilon &&
+    Math.abs(v1.center[1] - v2.center[1]) < epsilon
+  );
 }


### PR DESCRIPTION
I wasn't too keen on the map automatically zooming to data whenever the user zoomed out to zoom level 1.  This brings back the old behaviour without too much bother.