### PR TITLE
allow adjustedPValueFloor to also be null

### DIFF
--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -373,7 +373,7 @@ export const VolcanoPlotResponse = intersection([
   }),
   partial({
     pValueFloor: string,
-    adjustedPValueFloor: string,
+    adjustedPValueFloor: union([string, nullType]),
   }),
 ]);
 


### PR DESCRIPTION
Resolves #578 

The backend sometimes sends an adjustedPValueFloor = null. This PR adds that option to the api.

