### PR TITLE
Simple record page

### DIFF
--- a/packages/libs/wdk-client/src/Core/routes.tsx
+++ b/packages/libs/wdk-client/src/Core/routes.tsx
@@ -147,6 +147,26 @@ const routes: RouteEntry[] = [
   },
 
   {
+    path: '/embed-record/:recordClass/:primaryKey+',
+    isFullscreen: true,
+    component: (
+      props: RouteComponentProps<{ recordClass: string; primaryKey: string }>
+    ) => {
+      const { attributes = '', tables = '' } = parseQueryString(props);
+      return (
+        <div style={{ padding: '1rem' }}>
+          <RecordController
+            recordClass={props.match.params.recordClass}
+            primaryKey={props.match.params.primaryKey}
+            attributes={attributes ? attributes.split(',') : undefined}
+            tables={tables ? tables.split(',') : undefined}
+          />
+        </div>
+      );
+    },
+  },
+
+  {
     path: '/step/:stepId(\\d+)/download',
     component: (props: RouteComponentProps<{ stepId: string }>) => {
       const { format, summaryView } = parseQueryString(props);

--- a/packages/libs/wdk-client/src/Views/Records/RecordMain/RecordMainSection.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordMain/RecordMainSection.jsx
@@ -5,7 +5,7 @@ import RecordMainCategorySection from '../../../Views/Records/RecordMain/RecordM
 import { pure, wrappable } from '../../../Utils/ComponentUtils';
 import { getId, getLabel } from '../../../Utils/CategoryUtils';
 
-/** @type {React.StatelessComponent} */
+/** @type {React.FunctionComponent} */
 let RecordMainSection$;
 
 const RecordMainSection = ({

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
@@ -65,11 +65,19 @@ export function RecordController(WdkRecordController) {
         recordClass,
         categoryTree
       );
+
+      // This is a request for a custom page, so use default
+      // request props.
+      if (this.props.attributes || this.props.tables) {
+        return requestOptions;
+      }
+
       if (
         recordClass.urlSegment !== 'gene' &&
         recordClass.urlSegment !== 'dataset'
-      )
+      ) {
         return requestOptions;
+      }
 
       // Dataset records
       if (recordClass.urlSegment === 'dataset') {
@@ -84,34 +92,17 @@ export function RecordController(WdkRecordController) {
       // Gene records
       return [
         {
+          // This includes all attributes
           attributes: requestOptions[0].attributes,
-          tables: requestOptions[0].tables
-            .concat(['MetaTable'])
-            .concat(
-              'TranscriptionSummary' in recordClass.tablesMap
-                ? ['TranscriptionSummary']
-                : []
-            )
-            .concat(
-              'ExpressionGraphs' in recordClass.tablesMap
-                ? ['ExpressionGraphs']
-                : []
-            )
-            .concat(
-              'PhenotypeGraphs' in recordClass.tablesMap
-                ? ['PhenotypeGraphs']
-                : []
-            )
-            .concat(
-              'CrisprPhenotypeGraphs' in recordClass.tablesMap
-                ? ['CrisprPhenotypeGraphs']
-                : []
-            )
-            .concat(
-              'FungiVBOrgLinkoutsTable' in recordClass.tablesMap
-                ? ['FungiVBOrgLinkoutsTable']
-                : []
-            ),
+          // Preload these tables. Others are lazy-loaded.
+          tables: [
+            'MetaTable',
+            'TranscriptionSummary',
+            'ExpressionGraphs',
+            'PhenotypeGraphs',
+            'CrisprPhenotypeGraphs',
+            'FungiVBOrgLinkoutsTable',
+          ].filter((tableName) => tableName in recordClass.tablesMap),
         },
       ];
     }


### PR DESCRIPTION
This PR introduces a simplified version of a record page, that can be embedded in popups. Attributes and tables can be specified via query params.

Route paths for this page look like:
```
/embed-record/long_read_transcript/TALONT000034884_DS_2e2a681fa9?tables=SampleInfo
```

which results in a page that looks like:
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/f675f5b6-fb76-4847-9f82-d45de0210fe9)
