### PR TITLE
Update visible help styling

### DIFF
--- a/packages/libs/wdk-client/src/Core/Style/wdk-Common.scss
+++ b/packages/libs/wdk-client/src/Core/Style/wdk-Common.scss
@@ -96,6 +96,28 @@ td {
   vertical-align: baseline;
 }
 
+// =begin <dl>
+// Definition list styling
+
+dl {
+  display: grid;
+  grid-template-columns: max-content auto;
+  row-gap: 0.3em;
+  column-gap: 1em;
+}
+
+dt {
+  grid-column-start: 1;
+  justify-self: end;
+  font-weight: bold;
+}
+
+dd {
+  grid-column-start: 2;
+  margin: 0;
+}
+// =end <dl>
+
 img[data-assets-src] {
   visibility: hidden;
 }

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
@@ -30,6 +30,8 @@ import StepValidationInfo from '../../Views/Question/StepValidationInfo';
 import { Tabs } from '../../Components';
 
 import '../../Views/Question/DefaultQuestionForm.scss';
+import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
+import { type } from 'os';
 
 type TextboxChangeHandler = (
   event: React.ChangeEvent<HTMLInputElement>
@@ -408,9 +410,12 @@ export function ParameterList(props: ParameterListProps) {
               }
             />
             {parameter.visibleHelp !== undefined && (
-              <div className={cx('VisibleHelp')}>
-                {safeHtml(parameter.visibleHelp)}
-              </div>
+              <Banner
+                banner={{
+                  type: 'info',
+                  message: safeHtml(parameter.visibleHelp, null, 'div'),
+                }}
+              />
             )}
             <div className={cx('ParameterControl')}>
               {parameterElements[parameter.name]}


### PR DESCRIPTION
This PR includes the following changes:
1. Puts visible help in an info box
2. Add global style rules for `<dl>` blocks: `<dt>` and `<dd>` are on the same line, and `<dt>` is in bold.

![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/1e9158cf-5190-4dc5-b288-cb3d75e2dd03)
