### PR TITLE
Eda study type error

### DIFF
--- a/packages/libs/eda/src/lib/core/hooks/study.ts
+++ b/packages/libs/eda/src/lib/core/hooks/study.ts
@@ -31,6 +31,7 @@ import { useStudyAccessApi } from '@veupathdb/study-data-access/lib/study-access
 import { getWdkStudyRecords } from '../utils/study-records';
 import { useDeepValue } from './immutability';
 import { usePermissions } from '@veupathdb/study-data-access/lib/data-restriction/permissionsHooks';
+import { FetchClientError } from '@veupathdb/http-utils';
 
 const STUDY_RECORD_CLASS_NAME = 'dataset';
 
@@ -230,11 +231,14 @@ export function useStudyMetadata(datasetId: string, client: SubsettingClient) {
       try {
         return await client.getStudyMetadata(studyId);
       } catch (error) {
-        console.error(error);
-        return {
-          id: studyId,
-          rootEntity: STUB_ENTITY,
-        };
+        if (error instanceof FetchClientError) {
+          console.error(error);
+          return {
+            id: studyId,
+            rootEntity: STUB_ENTITY,
+          };
+        }
+        throw error;
       }
     },
     [datasetId, client, permissionsResponse]

--- a/packages/libs/http-utils/src/FetchClient.ts
+++ b/packages/libs/http-utils/src/FetchClient.ts
@@ -44,7 +44,7 @@ export interface FetchApiOptions {
   onNonSuccessResponse?: (error: Error) => void;
 }
 
-class FetchClientError extends Error {
+export class FetchClientError extends Error {
   name = 'FetchClientError';
 }
 

--- a/packages/libs/wdk-client/src/Views/UnhandledErrors/UnhandledErrors.scss
+++ b/packages/libs/wdk-client/src/Views/UnhandledErrors/UnhandledErrors.scss
@@ -54,12 +54,13 @@
 
   &--Details {
     overflow: auto;
-    max-height: calc(100vh - 35em);
+    max-height: calc(100vh - 46em);
     font-size: 0.9em;
     color: #000000e6;
 
     h3 {
       margin-top: 1em;
+      white-space: pre;
     }
   }
 


### PR DESCRIPTION
This PR will throw errors caught when attempting to load eda study metadata, if it is not a `FetchClientError`. This change will cause io-ts error to get thrown, which is useful to prevent masking that error. The styling of the error modal is also updated.

![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/f5a918e3-ba10-44c4-830d-6dd4110172f8)
