### PR TITLE
Reposition reference filter

### DIFF
--- a/packages/libs/preferred-organisms/src/lib/components/OrganismParam.tsx
+++ b/packages/libs/preferred-organisms/src/lib/components/OrganismParam.tsx
@@ -141,7 +141,7 @@ function TreeBoxOrganismEnumParam(
           ? Array.from(referenceStrains)
           : undefined,
       isAdditionalFilterApplied: showOnlyReferenceOrganisms,
-      additionalActions: [
+      additionalFilters: [
         <Tooltip
           title={
             <span style={{ fontWeight: 'normal' }}>
@@ -162,16 +162,11 @@ function TreeBoxOrganismEnumParam(
         </Tooltip>,
       ],
       styleOverrides: {
-        treeLinks: {
+        searchBox: {
           container: {
-            flexDirection: 'column',
-            alignItems: 'center',
-          } as React.CSSProperties,
-          actionsContainerStyle: {
-            flexGrow: 'auto',
-            marginLeft: '1em',
-            alignSelf: 'flex-start',
-          } as React.CSSProperties,
+            flexGrow: 1,
+            width: 'auto',
+          },
         },
       },
     }),


### PR DESCRIPTION
Moved to the right of the search box, similar to the site search and org prefs implementations.

![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/acdb073e-6231-4618-938d-5d891285eb6b)

