### PR TITLE
Eda categorical collection type

### DIFF
--- a/packages/libs/eda/src/lib/core/types/study.ts
+++ b/packages/libs/eda/src/lib/core/types/study.ts
@@ -209,7 +209,6 @@ export type CollectionVariableTreeNode = t.TypeOf<
 export const CollectionVariableTreeNode = t.intersection([
   t.type({
     dataShape: t.string,
-    distributionDefaults: NumberDistributionDefaults,
     id: t.string,
     memberVariableIds: t.array(t.string),
     type: t.string,
@@ -224,6 +223,7 @@ export const CollectionVariableTreeNode = t.intersection([
     isCompositional: t.boolean,
     isProportion: t.boolean,
     normalizationMethod: t.string,
+    distributionDefaults: NumberDistributionDefaults,
   }),
 ]);
 

--- a/packages/libs/wdk-client/src/Views/UnhandledErrors/UnhandledErrors.scss
+++ b/packages/libs/wdk-client/src/Views/UnhandledErrors/UnhandledErrors.scss
@@ -54,7 +54,7 @@
 
   &--Details {
     overflow: auto;
-    max-height: calc(100vh - 46em);
+    max-height: calc(80vh - 46em);
     font-size: 0.9em;
     color: #000000e6;
 


### PR DESCRIPTION
This PR makes `distributionDefaults` optional, for collection variables, since categorical variables do not have this property.