### PR TITLE
Increase row count font size in beta Downloads table

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
@@ -81,6 +81,9 @@
     }
 
     .TableToolbar {
+      .TableToolbar-Info {
+        font-size: 100%;
+      }
       order: -3;
     }
 


### PR DESCRIPTION
I chose to make it 100% font size instead of the previously-set 80%.

![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/250a0495-0b17-43c6-bce6-a2a0651f1a0c)