### PR TITLE
Add min-width to prevent confusing overflow UX

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
@@ -17,6 +17,7 @@
     .wdk-QuestionFormParameterList {
       width: 60vw;
       margin: auto;
+      min-width: 800px;
     }
 
     .wdk-QuestionFormParameterHeading h2 {


### PR DESCRIPTION
Resolves #552 

Leverages a `min-width` property to prevent table's horizontal scroll behavior.
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/384448a4-5fb3-43a6-9092-15654a28ba28)
