### PR TITLE
fix initial bubble marker bug

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -595,11 +595,6 @@ function useMarkerData(props: DataProps) {
 
   const { numeratorValues, denominatorValues } = configuration;
 
-  const disabled =
-    numeratorValues?.length === 0 ||
-    denominatorValues?.length === 0 ||
-    !validateProportionValues(numeratorValues, denominatorValues);
-
   const studyEntities = useStudyEntities();
   const dataClient = useDataClient();
 
@@ -638,6 +633,13 @@ function useMarkerData(props: DataProps) {
     },
   };
   const { data: legendData } = useLegendData(props);
+
+  // add to check legendData is undefined for refetch
+  const disabled =
+    numeratorValues?.length === 0 ||
+    denominatorValues?.length === 0 ||
+    !validateProportionValues(numeratorValues, denominatorValues) ||
+    legendData == null;
 
   // FIXME Don't make dependent on legend data
   return useQuery({


### PR DESCRIPTION
Hi @dmfalke (and @bobular):

As commented at https://github.com/VEuPathDB/web-monorepo/issues/597#issuecomment-1795524714 about a bug concerning the bubble marker, I tried to find the reason and fix the bug. After delving into the issue, I realized that it was because marker data is prefetched via useQuery while the legendData via useLegendData hook is still being undefined. This leads the bubble markers to be not shown: more specifically all the marker data have 0 diameters & no colors due to undefined bubbleValueToColorMapper & bubbleValueToDiameterMapper functions at legendData. After sleeping on this, I finally found two possible solutions as follows:

a) Based on the pre-existing comment by Dave, "FIXME Don't make dependent on legend data", I tried to move legendData and the relevant parts to use legendData, i.e., finalMarkerData, out of useMarkerData, i.e. move them to the parent where useMarkerData is called, and then adjusted the parent accordingly. Based on my tests, this worked fine.

b) That being said, an idea came to my mind as an alternative solution after a while. So, basically this can also be considered as an issue of not calling useQuery again (refetch) when legendData is ready (not undefined), thus I changed the conditions of "enabled" option used in the useQuery by additionally checking if legendData is undefined. Certainly, this is much simpler solution than a) and I confirmed that this also worked out.

Due to simplicity, I made PR for b). What do you think @dmfalke?