### PR TITLE
User datasets:  Add  link to standalone map for ISA user datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ dist
 # VSCode config files
 .vscode
 
+# IntelliJ config files
+.idea
+
 .editorconfig
 
 .pnp.*

--- a/packages/libs/eda/src/lib/core/types/study.ts
+++ b/packages/libs/eda/src/lib/core/types/study.ts
@@ -273,9 +273,14 @@ export const StudyEntity: t.Type<StudyEntity> = t.recursion('StudyEntity', () =>
 // -------------
 
 export type StudyOverview = t.TypeOf<typeof StudyOverview>;
-export const StudyOverview = t.type({
-  id: t.string,
-});
+export const StudyOverview = t.intersection([
+  t.type({
+    id: t.string,
+  }),
+  t.partial({
+    hasMap: t.boolean,
+  }),
+]);
 
 export type StudyMetadata = t.TypeOf<typeof StudyMetadata>;
 export const StudyMetadata = t.intersection([

--- a/packages/libs/user-datasets/src/lib/Components/Detail/IsaDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/IsaDatasetDetail.jsx
@@ -13,16 +13,32 @@ class IsaDatasetDetail extends UserDatasetDetail {
       config: { displayName },
       userDataset: { isInstalled },
       edaWorkspaceUrl,
+      edaMapUrl,
     } = this.props;
 
-    return !isInstalled || !edaWorkspaceUrl ? null : (
-      <section id="eda-linkout">
-        <h2>
-          <Link to={edaWorkspaceUrl}>
-            <i className="ebrc-icon-edaIcon"></i> Explore in {displayName}
-          </Link>
-        </h2>
-      </section>
+    if (!isInstalled) return null;
+
+    return (
+      <>
+        {!edaWorkspaceUrl ? null : (
+          <section id="eda-linkout">
+            <h2>
+              <Link to={edaWorkspaceUrl}>
+                <i className="ebrc-icon-edaIcon"></i> Explore in {displayName}
+              </Link>
+            </h2>
+          </section>
+        )}
+        {!edaMapUrl ? null : (
+          <section id="eda-linkout">
+            <h2>
+              <Link to={edaMapUrl}>
+                <i className="ebrc-icon-edaIcon"></i> Explore in MapVEu
+              </Link>
+            </h2>
+          </section>
+        )}
+      </>
     );
   }
 

--- a/packages/libs/web-common/src/controllers/UserDatasetRouter.ts
+++ b/packages/libs/web-common/src/controllers/UserDatasetRouter.ts
@@ -1,0 +1,1 @@
+export { UserDatasetRouter as default } from '@veupathdb/user-datasets/lib/Controllers/UserDatasetRouter';

--- a/packages/libs/web-common/src/routes.jsx
+++ b/packages/libs/web-common/src/routes.jsx
@@ -30,6 +30,10 @@ export function makeEdaRoute(studyId) {
   return '/workspace/analyses' + (studyId ? `/${studyId}` : '');
 }
 
+export function makeMapRoute(studyId) {
+  return '/workspace/maps' + (studyId ? `/${studyId}` : '');
+}
+
 const EdaWorkspace = React.lazy(() => import('@veupathdb/eda/lib/workspace'));
 
 /**
@@ -70,13 +74,13 @@ export const wrapRoutes = (wdkRoutes) => [
   },
 
   {
-    path: '/workspace/maps',
+    path: makeMapRoute(),
     exact: true,
     component: EdaMapController,
   },
 
   {
-    path: '/workspace/maps',
+    path: makeMapRoute(),
     exact: false,
     isFullscreen: true,
     rootClassNameModifier: 'MapVEu',
@@ -88,7 +92,7 @@ export const wrapRoutes = (wdkRoutes) => [
     exact: false,
     isFullscreen: true,
     rootClassNameModifier: 'MapVEu',
-    component: () => <Redirect to="/workspace/maps" />,
+    component: () => <Redirect to={makeMapRoute()} />,
   },
 
   {

--- a/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
+++ b/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
@@ -5,16 +5,23 @@ import { useLocation } from 'react-router-dom';
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { RouteEntry } from '@veupathdb/wdk-client/lib/Core/RouteEntry';
 
-import { makeEdaRoute } from '@veupathdb/web-common/lib/routes';
+import { makeEdaRoute, makeMapRoute } from '@veupathdb/web-common/lib/routes';
 import { diyUserDatasetIdToWdkRecordId } from '@veupathdb/wdk-client/lib/Utils/diyDatasets';
 
 import { UserDatasetDetailProps } from '@veupathdb/user-datasets/lib/Controllers/UserDatasetDetailController';
 
 import { uploadTypeConfig } from '@veupathdb/user-datasets/lib/Utils/upload-config';
 
-import { communitySite, projectId } from '@veupathdb/web-common/lib/config';
+import {
+  communitySite,
+  edaServiceUrl,
+  projectId,
+} from '@veupathdb/web-common/lib/config';
 
 import ExternalContentController from '@veupathdb/web-common/lib/controllers/ExternalContentController';
+
+import { useConfiguredSubsettingClient } from '@veupathdb/eda/lib/core/hooks/client';
+import { useStudyMetadata } from '@veupathdb/eda/lib/core/hooks/study';
 
 const IsaDatasetDetail = React.lazy(
   () =>
@@ -53,11 +60,16 @@ export const userDatasetRoutes: RouteEntry[] = [
             const wdkDatasetId = diyUserDatasetIdToWdkRecordId(
               props.userDataset.id
             );
-
+            const edaStudyMetadata = useEdaStudyMetadata(wdkDatasetId);
             return (
               <IsaDatasetDetail
                 {...props}
                 edaWorkspaceUrl={`${makeEdaRoute(wdkDatasetId)}/new`}
+                edaMapUrl={
+                  edaStudyMetadata?.hasMap
+                    ? `${makeMapRoute(wdkDatasetId)}/new`
+                    : undefined
+                }
               />
             );
           },
@@ -84,3 +96,8 @@ export const userDatasetRoutes: RouteEntry[] = [
     },
   },
 ];
+
+function useEdaStudyMetadata(wdkDatasetId: string) {
+  const subsettingClient = useConfiguredSubsettingClient(edaServiceUrl);
+  return useStudyMetadata(wdkDatasetId, subsettingClient);
+}


### PR DESCRIPTION
closes #550 

This PR add a link to the standalone map for user datasets that have map data. It is using the relatively new `hasMap` property of the eda study record.

@jernestmyers I assigned you, so you are aware of these changes. Do you see any conflicts with your VDI work?


![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/932e10bd-a552-4235-a2a1-2ef278e60c84)
