### PR TITLE
Use correct mapType for supporting plots

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -292,7 +292,7 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
           activeVisualizationId={configuration.activeVisualizationId}
           plugins={plugins}
           geoConfigs={geoConfigs}
-          mapType="bubble"
+          mapType="barplot"
           setHideVizInputsAndControls={props.setHideVizInputsAndControls}
         />
       ),

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -264,7 +264,7 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
           activeVisualizationId={configuration.activeVisualizationId}
           plugins={plugins}
           geoConfigs={geoConfigs}
-          mapType="bubble"
+          mapType="pie"
           setHideVizInputsAndControls={props.setHideVizInputsAndControls}
         />
       ),


### PR DESCRIPTION
This PR fixes an issue where a supporting plot will appear for all map types, regardless of where it was created.