### PR TITLE
Eda:  better handle single app mode

### DIFF
--- a/packages/libs/eda/src/lib/core/hooks/analysis.ts
+++ b/packages/libs/eda/src/lib/core/hooks/analysis.ts
@@ -47,18 +47,25 @@ export type AnalysisState = {
   analysis?: Analysis | NewAnalysis;
   /** Error object related to loading an analysis */
   error?: unknown;
-  /** Set the display name of the analysis. See @Setter */
+  /** Set the display name of the analysis. See {@link Setter}. */
   setName: Setter<Analysis['displayName']>;
-  /** Set the description of the analysis. */
+  /** Set the description of the analysis. See {@link Setter}. */
   setDescription: Setter<Analysis['description']>;
+  /** Set the notes of an analysis. See {@link Setter}. */
   setNotes: Setter<Analysis['notes']>;
+  /** Set the isPublic flag of an anlysis. See {@link Setter}. */
   setIsPublic: Setter<Analysis['isPublic']>;
+  /** Set the filters of an analysis. See {@link Setter}. */
   setFilters: Setter<Analysis['descriptor']['subset']['descriptor']>;
-  /** Set the list of configured computations of the analysis. See {@link Setter} */
+  /** Set the list of configured computations of the analysis. See {@link Setter}. */
   setComputations: Setter<Analysis['descriptor']['computations']>;
+  /** Set the list of derived variables of an analysis. See {@link Setter}. */
   setDerivedVariables: Setter<Analysis['descriptor']['derivedVariables']>;
+  /** Set the list of starred variables of an analysis. See {@link Setter}. */
   setStarredVariables: Setter<Analysis['descriptor']['starredVariables']>;
+  /** Set the UI state of variables in an analysis. See {@link Setter}. */
   setVariableUISettings: Setter<Analysis['descriptor']['subset']['uiSettings']>;
+  /** Set the datatable config of an analysis. See {@link Setter}. */
   setDataTableConfig: Setter<Analysis['descriptor']['dataTableConfig']>;
 
   /** Convenience methods for manipulating visualizations nested inside computations.

--- a/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
+++ b/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
@@ -129,6 +129,7 @@ export function MapVeuContainer(mapVeuContainerProps: Props) {
               className="MapVEu"
             >
               <MapAnalysis
+                singleAppMode={singleAppMode}
                 analysisId={routeProps.match.params.analysisId}
                 siteInformationProps={siteInformationProps}
                 studyId={routeProps.match.params.studyId}

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -105,12 +105,17 @@ const mapStyle: React.CSSProperties = {
 interface Props {
   analysisId?: string;
   sharingUrl: string;
+  singleAppMode?: string;
   studyId: string;
   siteInformationProps: SiteInformationProps;
 }
 
 export function MapAnalysis(props: Props) {
-  const appStateAndSetters = useAppState('@@mapApp@@', props.analysisId);
+  const appStateAndSetters = useAppState(
+    '@@mapApp@@',
+    props.analysisId,
+    props.singleAppMode
+  );
   const geoConfigs = useGeoConfig(useStudyEntities());
 
   if (geoConfigs == null || geoConfigs.length === 0)

--- a/packages/libs/eda/src/lib/map/analysis/appState.ts
+++ b/packages/libs/eda/src/lib/map/analysis/appState.ts
@@ -116,8 +116,12 @@ export const AppState = t.intersection([
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type AppState = t.TypeOf<typeof AppState>;
 
-export function useAppState(uiStateKey: string, analysisId?: string) {
-  const analysisState = useAnalysis(analysisId);
+export function useAppState(
+  uiStateKey: string,
+  analysisId?: string,
+  singleAppMode?: string
+) {
+  const analysisState = useAnalysis(analysisId, singleAppMode);
 
   // make some backwards compatability updates to the appstate retrieved from the back end
   const [appStateChecked, setAppStateChecked] = useState(false);

--- a/packages/libs/eda/src/lib/map/analysis/appState.ts
+++ b/packages/libs/eda/src/lib/map/analysis/appState.ts
@@ -229,7 +229,10 @@ export function useAppState(uiStateKey: string, analysisId?: string) {
     appStateChecked,
   ]);
 
-  function useSetter<T extends keyof AppState>(key: T) {
+  function useSetter<T extends keyof AppState>(
+    key: T,
+    createIfUnsaved = false
+  ) {
     return useCallback(
       function setter(value: AppState[T]) {
         setVariableUISettings((prev) => {
@@ -244,9 +247,9 @@ export function useAppState(uiStateKey: string, analysisId?: string) {
             };
           }
           return prev;
-        });
+        }, createIfUnsaved);
       },
-      [key]
+      [key, createIfUnsaved]
     );
   }
 
@@ -254,13 +257,14 @@ export function useAppState(uiStateKey: string, analysisId?: string) {
     appState,
     analysisState,
     setActiveMarkerConfigurationType: useSetter(
-      'activeMarkerConfigurationType'
+      'activeMarkerConfigurationType',
+      true
     ),
-    setMarkerConfigurations: useSetter('markerConfigurations'),
+    setMarkerConfigurations: useSetter('markerConfigurations', true),
     setBoundsZoomLevel: useSetter('boundsZoomLevel'),
     setIsSidePanelExpanded: useSetter('isSidePanelExpanded'),
     setSubsetVariableAndEntity: useSetter('subsetVariableAndEntity'),
     setViewport: useSetter('viewport'),
-    setTimeSliderConfig: useSetter('timeSliderConfig'),
+    setTimeSliderConfig: useSetter('timeSliderConfig', true),
   };
 }

--- a/packages/libs/eda/src/lib/workspace/ComputationRoute.tsx
+++ b/packages/libs/eda/src/lib/workspace/ComputationRoute.tsx
@@ -15,6 +15,8 @@ import { FilledButton } from '@veupathdb/coreui/lib/components/buttons';
 import AddIcon from '@material-ui/icons/Add';
 import { Computation } from '../core/types/visualization';
 import Path from 'path';
+import { createComputation } from '../core/components/computations/Utils';
+import { Loading } from '@veupathdb/wdk-client/lib/Components';
 
 export interface Props {
   analysisState: AnalysisState;
@@ -94,17 +96,31 @@ export function ComputationRoute(props: Props) {
         if (singleAppMode) {
           if (analysisState.analysis == null) return;
 
-          const computationType =
-            analysisState.analysis.descriptor.computations[0].descriptor.type;
+          // Find an existing computation whose type is the value of `singleAppMode`
+          const singleAppComputation =
+            analysisState.analysis.descriptor.computations.find(
+              (c) => c.descriptor.type === singleAppMode
+            );
 
-          // Check to ensure analysisState didn't somehow get the wrong app
-          if (computationType !== singleAppMode) {
-            throw new Error('Incompatible app type supplied.');
+          if (singleAppComputation == null) {
+            analysisState.setComputations(
+              (computations) =>
+                computations.concat(
+                  createComputation(
+                    singleAppMode,
+                    undefined,
+                    computations,
+                    [],
+                    singleAppMode === 'pass' ? 'pass-through' : singleAppMode
+                  )
+                ),
+              false
+            );
+            return <Loading />;
           }
 
           // Note: the pass app's id will be 'pass-through' for backwards compatability
-          const singleAppComputationId =
-            analysisState.analysis.descriptor.computations[0].computationId;
+          const singleAppComputationId = singleAppComputation.computationId;
 
           return (
             <Switch>


### PR DESCRIPTION
This PR updates the logic related to `singleAppMode` in the EDA workspace. Previously, we assumed the first `computation` in the `analysis.descriptor.computations` array would match the `singleAppMode` computation type. The precludes the possibility that the analysis was created in some other context, or that the analysis contains other computations.

Now, we will look for any analysis that matches the `singleAppMode` type. If one is not found, one will be created before rendering the viz tab. Additionally, `singleAppMode` is being passed to `MapAnalysis`, to ensure that the computation is always created when the website is configured to use `singleAppMode`.

This is to enable using both the EDA Workspace view, and the Standalone Map view, for a single analysis object.

ETA this also addresses an issue with the SAM where a new analysis is not saved when the marker config is updated. This was fixed by adding a way to override the `createIfUnsaved` argument for the AnalysisState setters.  