### PR TITLE
Fix broken footer CSS

### DIFF
--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
@@ -31,7 +31,7 @@ body.vpdb-Body .vpdb-RootContainer.vpdb-RootContainer__home-page {
   }
 
   .vpdb-SearchPane {
-    min-height: 100vh;
+    padding-bottom: 12em;
   }
 
   .vpdb-MainContent {
@@ -78,6 +78,7 @@ body.vpdb-Body .vpdb-RootContainer.vpdb-RootContainer__home-page {
       position: fixed;
       bottom: 0;
       width: 100%;
+      z-index: 1;
     }
   }
 


### PR DESCRIPTION
Resolves #631 

I also noticed that the search pane was rendering at `100vh` with very small viewport widths, which looks very silly given the size of the Ortho search pane. I padded the bottom of the container instead, similar to what we do in genomics sites.

![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/e0214e16-491a-4d4b-966b-06ecd7d632ee)
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/4b60bf3e-e460-4409-8600-e64d8ad3c580)
