### PR TITLE
Draft: handle incompatible numerator/denominator selections without snackbar effects

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -138,6 +138,10 @@ import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 import { FloatingLineplotExtraProps } from '../../../../map/analysis/hooks/plugins/lineplot';
 
 import * as DateMath from 'date-arithmetic';
+import {
+  invalidProportionText,
+  validateProportionValues,
+} from '../../../../map/analysis/utils/defaultOverlayConfig';
 
 const plotContainerStyles = {
   width: 750,
@@ -712,17 +716,17 @@ function LineplotViz(props: VisualizationProps<Options>) {
 
       if (categoricalMode && !valuesAreSpecified) return undefined;
 
-      if (categoricalMode && valuesAreSpecified) {
-        if (
-          dataRequestConfig.numeratorValues != null &&
-          !dataRequestConfig.numeratorValues.every((value) =>
-            dataRequestConfig.denominatorValues?.includes(value)
-          )
+      if (
+        categoricalMode &&
+        dataRequestConfig.numeratorValues &&
+        dataRequestConfig.denominatorValues &&
+        !validateProportionValues(
+          dataRequestConfig.numeratorValues,
+          dataRequestConfig.denominatorValues,
+          yAxisVariable?.vocabulary
         )
-          throw new Error(
-            'To calculate a proportion, all selected numerator values must also be present in the denominator'
-          );
-      }
+      )
+        throw new Error(invalidProportionText);
 
       // no data request if banner should be shown
       if (showIndependentAxisBanner || showDependentAxisBanner)

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -2814,7 +2814,7 @@ export function AggregationInputs<F extends string, P extends Array<string>>(
           >
             <ValuePicker
               allowedValues={props.options}
-              disallowedValues={props.numeratorValues.filter(
+              disallowedValues={props.denominatorValues.filter(
                 (value) => !props.options.includes(value)
               )}
               selectedValues={props.denominatorValues}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -2797,9 +2797,6 @@ export function AggregationInputs<F extends string, P extends Array<string>>(
           >
             <ValuePicker
               allowedValues={props.options}
-              disallowedValues={props.numeratorValues.filter(
-                (value) => !props.options.includes(value)
-              )}
               selectedValues={props.numeratorValues}
               onSelectedValuesChange={props.onNumeratorChange}
             />
@@ -2813,9 +2810,6 @@ export function AggregationInputs<F extends string, P extends Array<string>>(
           >
             <ValuePicker
               allowedValues={props.options}
-              disallowedValues={props.denominatorValues.filter(
-                (value) => !props.options.includes(value)
-              )}
               selectedValues={props.denominatorValues}
               onSelectedValuesChange={props.onDenominatorChange}
             />

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -2797,6 +2797,9 @@ export function AggregationInputs<F extends string, P extends Array<string>>(
           >
             <ValuePicker
               allowedValues={props.options}
+              disallowedValues={props.numeratorValues.filter(
+                (value) => !props.options.includes(value)
+              )}
               selectedValues={props.numeratorValues}
               onSelectedValuesChange={props.onNumeratorChange}
             />
@@ -2810,6 +2813,9 @@ export function AggregationInputs<F extends string, P extends Array<string>>(
           >
             <ValuePicker
               allowedValues={props.options}
+              disallowedValues={props.denominatorValues.filter(
+                (value) => !props.options.includes(value)
+              )}
               selectedValues={props.denominatorValues}
               onSelectedValuesChange={props.onDenominatorChange}
             />

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -2738,6 +2738,7 @@ type AggregationConfig<F extends string, P extends Array<string>> =
       options: P;
     };
 
+// TO DO: move outside of this source file
 export function AggregationInputs<F extends string, P extends Array<string>>(
   props: AggregationConfig<F, P>
 ) {
@@ -2797,6 +2798,9 @@ export function AggregationInputs<F extends string, P extends Array<string>>(
           >
             <ValuePicker
               allowedValues={props.options}
+              disallowedValues={props.numeratorValues.filter(
+                (value) => !props.options.includes(value)
+              )}
               selectedValues={props.numeratorValues}
               onSelectedValuesChange={props.onNumeratorChange}
             />
@@ -2810,6 +2814,9 @@ export function AggregationInputs<F extends string, P extends Array<string>>(
           >
             <ValuePicker
               allowedValues={props.options}
+              disallowedValues={props.numeratorValues.filter(
+                (value) => !props.options.includes(value)
+              )}
               selectedValues={props.denominatorValues}
               onSelectedValuesChange={props.onDenominatorChange}
             />

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ValuePicker.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ValuePicker.tsx
@@ -6,6 +6,8 @@ export type ValuePickerProps = {
   allowedValues?: string[];
   selectedValues?: string[];
   disabledValues?: string[];
+  /** values that are currently selected but should be deselected; displayed with strike-through */
+  disallowedValues?: string[];
   /** Change communicated when [Save] button is clicked. */
   onSelectedValuesChange: (newValues: string[]) => void;
   disabledCheckboxTooltipContent?: ReactNode;
@@ -18,34 +20,61 @@ export type ValuePickerProps = {
 const EMPTY_ALLOWED_VALUES_ARRAY: string[] = [];
 const EMPTY_SELECTED_VALUES_ARRAY: string[] = [];
 const EMPTY_DISABLED_VALUES_ARRAY: string[] = [];
+const EMPTY_DISALLOWED_VALUES_ARRAY: string[] = [];
 
 export function ValuePicker({
   allowedValues = EMPTY_ALLOWED_VALUES_ARRAY,
   selectedValues = EMPTY_SELECTED_VALUES_ARRAY,
   disabledValues = EMPTY_DISABLED_VALUES_ARRAY,
+  disallowedValues = EMPTY_DISALLOWED_VALUES_ARRAY,
   onSelectedValuesChange,
   disabledCheckboxTooltipContent,
   disableInput = false,
   showClearSelectionButton = true,
   isLoading = false,
 }: ValuePickerProps) {
-  const items = allowedValues.map((value) => ({
-    display: <span>{value}</span>,
-    value,
-    disabled: disabledValues.includes(value),
-  }));
+  const items = allowedValues
+    .map((value) => ({
+      display: <span>{value}</span>,
+      value,
+      disabled: disabledValues.includes(value),
+    }))
+    .concat(
+      disallowedValues.map((value) => ({
+        display: (
+          <span>
+            <s>{value}</s>
+          </span>
+        ),
+        value,
+        disabled: false,
+      }))
+    );
 
+  // 'manual' container div styling was a short-cut
+  // because it seems that SelectList's styleOverrides isn't implemented?
   return (
     <>
-      <SelectList
-        defaultButtonDisplayContent={'Select value(s)'}
-        items={items}
-        onChange={onSelectedValuesChange}
-        value={selectedValues}
-        disabledCheckboxTooltipContent={disabledCheckboxTooltipContent}
-        isDisabled={disableInput}
-        isLoading={isLoading}
-      />
+      <div
+        style={
+          disallowedValues.length
+            ? {
+                border: '2px solid red',
+                borderRadius: '5px',
+              }
+            : {}
+        }
+      >
+        <SelectList
+          defaultButtonDisplayContent={'Select value(s)'}
+          items={items}
+          onChange={onSelectedValuesChange}
+          value={selectedValues}
+          disabledCheckboxTooltipContent={disabledCheckboxTooltipContent}
+          isDisabled={disableInput}
+          isLoading={isLoading}
+        />
+      </div>
       {showClearSelectionButton && (
         <ClearSelectionButton
           onClick={() => onSelectedValuesChange([])}

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../core/components/visualizations/implementations/LineplotVisualization';
 import { DataElementConstraint } from '../../../core/types/visualization'; // TO DO for dates: remove
 import { SharedMarkerConfigurations } from '../mapTypes/shared';
+import { invalidProportionText } from '../utils/defaultOverlayConfig';
 
 type AggregatorOption = typeof aggregatorOptions[number];
 const aggregatorOptions = ['mean', 'median'] as const;
@@ -123,7 +124,7 @@ export function BubbleMarkerConfigurationMenu({
       {overlayConfiguration == null && (
         <div style={{ position: 'relative' }}>
           <div style={{ position: 'absolute', width: '100%' }}>
-            <PluginError error="To calculate a proportion, all selected numerator values must also be present in the denominator and any values that have been filtered out must be deselected (indicated by red outline and strike-through)." />
+            <PluginError error={invalidProportionText} />
           </div>
         </div>
       )}

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
@@ -77,14 +77,8 @@ export function BubbleMarkerConfigurationMenu({
   const categoricalMode = isSuitableCategoricalVariable(selectedVariable);
 
   const aggregationConfig = overlayConfiguration?.aggregationConfig;
-  const numeratorValues =
-    aggregationConfig && 'numeratorValues' in aggregationConfig
-      ? aggregationConfig.numeratorValues
-      : undefined;
-  const denominatorValues =
-    aggregationConfig && 'denominatorValues' in aggregationConfig
-      ? aggregationConfig.denominatorValues
-      : undefined;
+  const numeratorValues = configuration.numeratorValues;
+  const denominatorValues = configuration.denominatorValues;
   const aggregator =
     aggregationConfig && 'aggregator' in aggregationConfig
       ? aggregationConfig.aggregator
@@ -93,11 +87,6 @@ export function BubbleMarkerConfigurationMenu({
     selectedVariable && 'vocabulary' in selectedVariable
       ? selectedVariable.vocabulary
       : undefined;
-
-  const proportionIsValid = validateProportionValues(
-    numeratorValues,
-    denominatorValues
-  );
 
   const aggregationInputs = (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -131,10 +120,10 @@ export function BubbleMarkerConfigurationMenu({
                 }),
             })}
       />
-      {!proportionIsValid && (
+      {overlayConfiguration == null && (
         <div style={{ position: 'relative' }}>
           <div style={{ position: 'absolute', width: '100%' }}>
-            <PluginError error="To calculate a proportion, all selected numerator values must also be present in the denominator" />
+            <PluginError error="To calculate a proportion, all selected numerator values must also be present in the denominator and any values that have been filtered out must be deselected (indicated by red outline and strike-through)." />
           </div>
         </div>
       )}
@@ -224,14 +213,3 @@ function isSuitableCategoricalVariable(variable?: VariableTreeNode): boolean {
     variable.distinctValuesCount != null
   );
 }
-
-// We currently call this function twice per value change.
-// If the number of values becomes vary large, we may want to optimize this?
-// Maybe O(n^2) isn't that bad though.
-export const validateProportionValues = (
-  numeratorValues: string[] | undefined,
-  denominatorValues: string[] | undefined
-) =>
-  numeratorValues === undefined ||
-  denominatorValues === undefined ||
-  numeratorValues.every((value) => denominatorValues.includes(value));

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
@@ -78,8 +78,14 @@ export function BubbleMarkerConfigurationMenu({
   const categoricalMode = isSuitableCategoricalVariable(selectedVariable);
 
   const aggregationConfig = overlayConfiguration?.aggregationConfig;
-  const numeratorValues = configuration.numeratorValues;
-  const denominatorValues = configuration.denominatorValues;
+  const numeratorValues =
+    aggregationConfig && 'numeratorValues' in aggregationConfig
+      ? aggregationConfig.numeratorValues
+      : undefined;
+  const denominatorValues =
+    aggregationConfig && 'denominatorValues' in aggregationConfig
+      ? aggregationConfig.denominatorValues
+      : undefined;
   const aggregator =
     aggregationConfig && 'aggregator' in aggregationConfig
       ? aggregationConfig.aggregator

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneMapMarkers.tsx
@@ -37,8 +37,8 @@ import {
   BaseMarkerData,
 } from '@veupathdb/components/lib/map/ChartMarker';
 import { BubbleMarkerProps } from '@veupathdb/components/lib/map/BubbleMarker';
-import { validateProportionValues } from '../MarkerConfiguration/BubbleMarkerConfigurationMenu';
 import _ from 'lodash';
+import { validateProportionValues } from '../utils/defaultOverlayConfig';
 
 /**
  * We can use this viewport to request all available data
@@ -133,9 +133,8 @@ interface MapMarkers {
 }
 
 // TO DO: no longer used - we should remove this, right?
-export function useStandaloneMapMarkers(
-  props: StandaloneMapMarkersProps
-): MapMarkers {
+// starting by "unexporting" it
+function useStandaloneMapMarkers(props: StandaloneMapMarkersProps): MapMarkers {
   const {
     boundsZoomLevel,
     geoConfig,
@@ -262,8 +261,8 @@ export function useStandaloneMapMarkers(
         if (
           !aggregationConfig ||
           numeratorValues?.length === 0 ||
-          denominatorValues?.length === 0 ||
-          !validateProportionValues(numeratorValues, denominatorValues)
+          denominatorValues?.length === 0
+          //          !validateProportionValues(numeratorValues, denominatorValues)
         ) {
           return undefined;
         }

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -154,5 +154,5 @@ export function useStandaloneVizPlugins({
         },
       },
     };
-  }, [selectedOverlayConfig]);
+  }, [selectedOverlayConfig, overlayHelp]);
 }

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -249,7 +249,7 @@ function BubbleLegends(props: MapTypeMapLayerProps) {
             </div>
           ) : (
             <MapLegend
-              isLoading={legendData.data == null}
+              isLoading={legendData.isFetching}
               plotLegendProps={{
                 type: 'bubble',
                 legendMax: legendData.data?.bubbleLegendData?.maxSizeValue ?? 0,
@@ -267,7 +267,7 @@ function BubbleLegends(props: MapTypeMapLayerProps) {
       >
         <div style={{ padding: '5px 10px' }}>
           <MapLegend
-            isLoading={legendData.data == null}
+            isLoading={legendData.isFetching}
             plotLegendProps={{
               type: 'colorscale',
               legendMin: legendData.data?.bubbleLegendData?.minColorValue ?? 0,

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -588,9 +588,7 @@ function useMarkerData(props: DataProps) {
   const { boundsZoomLevel, configuration, geoConfigs, studyId, filters } =
     props;
 
-  const { numeratorValues, denominatorValues } = configuration;
-
-  const studyEntities = useStudyEntities();
+  const studyEntities = useStudyEntities(); // no need for filter-sensitivity (for geo-variables)
   const dataClient = useDataClient();
 
   const {

--- a/packages/libs/eda/src/lib/map/analysis/utils/defaultOverlayConfig.ts
+++ b/packages/libs/eda/src/lib/map/analysis/utils/defaultOverlayConfig.ts
@@ -228,3 +228,6 @@ export const validateProportionValues = (
   denominatorValues.every(
     (value) => vocabulary == null || vocabulary.includes(value)
   );
+
+export const invalidProportionText =
+  'To calculate a proportion, all selected numerator values must also be present in the denominator and any values that have been filtered out must be deselected (indicated by red outline and strike-through).';


### PR DESCRIPTION
Branched from #609 

The main thing here is that `useOverlayConfig` returns undefined if the numerator/denominators are incorrect in two ways
1. the existing condition that numerators must be present in denominator
2. all numerators and denominators must be in the variable's vocabulary (which can change now, due to filters)

When the overlay config is "bad" then the bubbles and bubble legend data requests are disabled and the user is directed to make amends.

How to test
1. at the moment, it's best to use the tick data from qa.vectorbase back end
2. for me that's https://localhost:3000/maps/DS_e18287e335/new
3. get bubble markers on `biological sex` with `female / female+unknown`
4. then add a filter on `biological sex = male, unknown`
5. go back to bubble config to see what's going on

Some rough edges still need to be worked out
- [ ] ideally we need to stop showing the markers when the config is bad, and the legend(s) need to show something helpful, rather than the previous legend data (I'm thinking that all map legends should have a :gear: icon in the bottom right corner which simply opens up the maptype configuration panel)
- [ ] how can we get the `useQuery`s to emphatically return "no data" so that we don't keep showing the previousData? I tried a `return undefined` in a queryFn and it didn't like that.
- [ ] basically we want the map to look the same after changing filters so that bubble proportion configs are invalid
       - directly after invalidation
       - after switching map types and back to bubble again (or refreshing the browser)
- [x] must test lineplot proportions and check not broken! - see how filter sensitivity works there
- [ ] check how many back end requests are made - are any causing back end errors?