### PR TITLE
Display useful message to user when analysis fails to load

### DIFF
--- a/packages/libs/eda/src/lib/core/components/AnalysisError.tsx
+++ b/packages/libs/eda/src/lib/core/components/AnalysisError.tsx
@@ -1,0 +1,67 @@
+import { FetchClientError } from '@veupathdb/http-utils';
+import { AnalysisState } from '../hooks/analysis';
+import { Link } from 'react-router-dom';
+import * as Path from 'path';
+
+interface Props {
+  error: AnalysisState['error'];
+  baseAnalysisPath: string;
+}
+
+export function AnalysisError(props: Props) {
+  const { error, baseAnalysisPath } = props;
+  const myAnalysesPath = Path.resolve(baseAnalysisPath, '../..');
+  const newAnalysisPath = Path.resolve(baseAnalysisPath, '../new');
+  return error instanceof FetchClientError && error.statusCode === 404 ? (
+    <>
+      <h1>Analysis Not Found</h1>
+      <div css={{ fontSize: '1.2em' }}>
+        <p>
+          The requested analysis does not exist. You might want to try one of
+          the following options.
+        </p>
+        <ul>
+          <li>
+            <Link to={myAnalysesPath}>See your saved analyses.</Link>
+          </li>
+          <li>
+            <Link to={newAnalysisPath}>Create a new analysis.</Link>
+          </li>
+        </ul>
+      </div>
+    </>
+  ) : error instanceof FetchClientError && error.statusCode === 403 ? (
+    <>
+      <h1>Access Denied</h1>
+      <div css={{ fontSize: '1.2em' }}>
+        <p>
+          The requested analysis belongs to a different user. You might want to
+          try one of the following options.
+        </p>
+        <ul>
+          <li>
+            If this analysis was shared with you, ask the owner to use the{' '}
+            <strong>Share</strong> button to generate a share link.
+          </li>
+          <li>
+            <Link to={myAnalysesPath}>See your saved analyses.</Link>
+          </li>
+          <li>
+            <Link to={newAnalysisPath}>Create a new analysis.</Link>
+          </li>
+        </ul>
+      </div>
+    </>
+  ) : (
+    <>
+      <h1>Analysis Loading Error</h1>
+      <div css={{ fontSize: '1.2em' }}>
+        <p>The analysis could not be loaded.</p>
+        <p>
+          Error message:{' '}
+          <code>{error instanceof Error ? error.message : String(error)}</code>
+        </p>
+      </div>
+    </>
+  );
+}

--- a/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
+++ b/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
@@ -81,13 +81,11 @@ export function MapVeuContainer(mapVeuContainerProps: Props) {
           path={path}
           exact
           render={() => (
-            <Page requireLogin={false}>
-              <AllAnalyses
-                analysisClient={analysisClient}
-                subsettingClient={edaClient}
-                showLoginForm={showLoginForm}
-              />
-            </Page>
+            <AllAnalyses
+              analysisClient={analysisClient}
+              subsettingClient={edaClient}
+              showLoginForm={showLoginForm}
+            />
           )}
         />
         <Route

--- a/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
+++ b/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
@@ -28,6 +28,7 @@ import { SiteInformationProps } from './analysis/Types';
 import { StudyList } from './StudyList';
 import { PublicAnalysesRoute } from '../workspace/PublicAnalysesRoute';
 import { ImportAnalysis } from '../workspace/ImportAnalysis';
+import { Page } from '@veupathdb/wdk-client/lib/Components';
 
 interface Props {
   edaServiceUrl: string;
@@ -80,25 +81,33 @@ export function MapVeuContainer(mapVeuContainerProps: Props) {
           path={path}
           exact
           render={() => (
-            <AllAnalyses
-              analysisClient={analysisClient}
-              subsettingClient={edaClient}
-              showLoginForm={showLoginForm}
-            />
+            <Page requireLogin={false}>
+              <AllAnalyses
+                analysisClient={analysisClient}
+                subsettingClient={edaClient}
+                showLoginForm={showLoginForm}
+              />
+            </Page>
           )}
         />
         <Route
           path={`${path}/studies`}
           exact
-          render={() => <StudyList subsettingClient={edaClient} />}
+          render={() => (
+            <Page requireLogin={false}>
+              <StudyList subsettingClient={edaClient} />
+            </Page>
+          )}
         />
         <Route
           path={`${path}/public`}
           render={() => (
-            <PublicAnalysesRoute
-              analysisClient={analysisClient}
-              subsettingClient={edaClient}
-            />
+            <Page requireLogin={false}>
+              <PublicAnalysesRoute
+                analysisClient={analysisClient}
+                subsettingClient={edaClient}
+              />
+            </Page>
           )}
         />
         <Route
@@ -110,10 +119,12 @@ export function MapVeuContainer(mapVeuContainerProps: Props) {
             }>
           ) => {
             return (
-              <ImportAnalysis
-                {...props.match.params}
-                analysisClient={analysisClient}
-              />
+              <Page requireLogin={false}>
+                <ImportAnalysis
+                  {...props.match.params}
+                  analysisClient={analysisClient}
+                />
+              </Page>
             );
           }}
         />

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -50,7 +50,7 @@ import { useLoginCallbacks } from '../../workspace/sharing/hooks';
 import NameAnalysis from '../../workspace/sharing/NameAnalysis';
 import NotesTab from '../../workspace/NotesTab';
 import ConfirmShareAnalysis from '../../workspace/sharing/ConfirmShareAnalysis';
-import { useHistory, useRouteMatch } from 'react-router';
+import { useHistory, useLocation, useRouteMatch } from 'react-router';
 
 import { uniq } from 'lodash';
 import Path from 'path';
@@ -85,6 +85,7 @@ import AnalysisNameDialog from '../../workspace/AnalysisNameDialog';
 import { FetchClientError } from '@veupathdb/http-utils';
 import { Page } from '@veupathdb/wdk-client/lib/Components';
 import { Link } from 'react-router-dom';
+import { AnalysisError } from '../../core/components/AnalysisError';
 
 enum MapSideNavItemLabels {
   Download = 'Download',
@@ -120,6 +121,7 @@ export function MapAnalysis(props: Props) {
     props.singleAppMode
   );
   const geoConfigs = useGeoConfig(useStudyEntities());
+  const location = useLocation();
 
   if (geoConfigs == null || geoConfigs.length === 0)
     return (
@@ -131,63 +133,14 @@ export function MapAnalysis(props: Props) {
       </Page>
     );
   if (appStateAndSetters.analysisState.error) {
-    const { error } = appStateAndSetters.analysisState;
-    const message =
-      error instanceof FetchClientError && error.statusCode === 404 ? (
-        <>
-          <h1>Analysis Not Found</h1>
-          <div css={{ fontSize: '1.2em' }}>
-            <p>
-              The requested analysis does not exist. You might want to try one
-              of the following options.
-            </p>
-            <ul>
-              <li>
-                <Link to="..">See your saved analyses.</Link>
-              </li>
-              <li>
-                <Link to="new">Create a new analysis.</Link>
-              </li>
-            </ul>
-          </div>
-        </>
-      ) : error instanceof FetchClientError && error.statusCode === 403 ? (
-        <>
-          <h1>Access Denied</h1>
-          <div css={{ fontSize: '1.2em' }}>
-            <p>
-              The requested analysis belongs to a different user. You might want
-              to try one of the following options.
-            </p>
-            <ul>
-              <li>
-                If this analysis was shared with you, ask the owner to use the{' '}
-                <strong>Share</strong> button to generate a share link.
-              </li>
-              <li>
-                <Link to="..">See your saved analyses.</Link>
-              </li>
-              <li>
-                <Link to="new">Create a new analysis.</Link>
-              </li>
-            </ul>
-          </div>
-        </>
-      ) : (
-        <>
-          <h1>Analysis Loading Error</h1>
-          <div css={{ fontSize: '1.2em' }}>
-            <p>The analysis could not be loaded.</p>
-            <p>
-              Error message:{' '}
-              <code>
-                {error instanceof Error ? error.message : String(error)}
-              </code>
-            </p>
-          </div>
-        </>
-      );
-    return <Page requireLogin={false}>{message}</Page>;
+    return (
+      <Page requireLogin={false}>
+        <AnalysisError
+          error={appStateAndSetters.analysisState.error}
+          baseAnalysisPath={location.pathname}
+        />
+      </Page>
+    );
   }
 
   if (appStateAndSetters.appState == null) return null;

--- a/packages/libs/eda/src/lib/workspace/AnalysisPanel.tsx
+++ b/packages/libs/eda/src/lib/workspace/AnalysisPanel.tsx
@@ -51,6 +51,7 @@ import { VariableLinkConfig } from '../core/components/VariableLink';
 import FilterChipList from '../core/components/FilterChipList';
 import { Public } from '@material-ui/icons';
 import { Link } from 'react-router-dom';
+import { AnalysisError } from '../core/components/AnalysisError';
 
 const AnalysisTabErrorBoundary = ({
   children,
@@ -117,6 +118,7 @@ export function AnalysisPanel({
 
   const {
     status,
+    error,
     analysis,
     setName,
     copyAnalysis,
@@ -224,6 +226,10 @@ export function AnalysisPanel({
       return linkBase;
     },
   };
+
+  if (error) {
+    return <AnalysisError error={error} baseAnalysisPath={routeBase} />;
+  }
 
   if (status === Status.Error)
     return (

--- a/packages/libs/http-utils/src/FetchClient.ts
+++ b/packages/libs/http-utils/src/FetchClient.ts
@@ -46,12 +46,8 @@ export interface FetchApiOptions {
 
 export class FetchClientError extends Error {
   name = 'FetchClientError';
-  constructor(
-    message: string,
-    public statusCode: number,
-    options?: ErrorOptions
-  ) {
-    super(message, options);
+  constructor(message: string, public statusCode: number) {
+    super(message);
   }
 }
 

--- a/packages/libs/http-utils/src/FetchClient.ts
+++ b/packages/libs/http-utils/src/FetchClient.ts
@@ -46,6 +46,13 @@ export interface FetchApiOptions {
 
 export class FetchClientError extends Error {
   name = 'FetchClientError';
+  constructor(
+    message: string,
+    public statusCode: number,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+  }
 }
 
 export abstract class FetchClient {
@@ -112,7 +119,8 @@ export abstract class FetchClient {
         `${status} ${statusText}: ${method.toUpperCase()} ${url}`,
         traceid != null ? 'Traceid: ' + traceid + '\n' : '',
         await response.text(),
-      ].join('\n')
+      ].join('\n'),
+      status
     );
 
     this.onNonSuccessResponse?.(fetchError);

--- a/packages/libs/wdk-client/src/Components/Layout/Page.tsx
+++ b/packages/libs/wdk-client/src/Components/Layout/Page.tsx
@@ -14,7 +14,7 @@ import { useWdkService } from '../../Hooks/WdkServiceHook';
 
 export type Props = RouteComponentProps<any> & {
   classNameModifier?: string;
-  children: React.ReactChild;
+  children: React.ReactNode;
   requireLogin: boolean;
   isFullScreen?: boolean;
 };


### PR DESCRIPTION
### Details

Fixes #518 

This PR adds some specific rendering when an error is encountered, while trying to load an analysis.

Additionally, the use of Banner was replaced with a more conservative UI, for studies without geo data.

### Screenshots

![Screenshot 2023-11-15 at 08-22-04 https __localhost 8080](https://github.com/VEuPathDB/web-monorepo/assets/365139/34ff6443-3d9e-4eb1-bc79-dbb91a2867bb)

![Screenshot 2023-11-15 at 11-52-58 https __localhost 8080](https://github.com/VEuPathDB/web-monorepo/assets/365139/f61b3590-6817-4dba-9e31-8c2719ffaf1d)

![Screenshot 2023-11-15 at 10-44-19 https __localhost 8080](https://github.com/VEuPathDB/web-monorepo/assets/365139/27f7c2e8-7c0f-493f-bdfb-18c26694093d)