### PR TITLE
Fix annoying react key errors in EDA site homepage

### DIFF
--- a/packages/libs/web-common/src/App/NewsSidebar/News.jsx
+++ b/packages/libs/web-common/src/App/NewsSidebar/News.jsx
@@ -44,7 +44,10 @@ const News = ({ twitterUrls, news, error }) => {
               )}
               {Seq.from(news ? news.records : Seq.empty())
                 .map(({ attributes }) => (
-                  <div className="NewsEntry" key={attributes.id}>
+                  <div
+                    className="NewsEntry"
+                    key={attributes.date + '__' + attributes.tag}
+                  >
                     <h4 className="NewsHeadline">
                       <Link to={`${newsUrl}#${attributes.tag}`}>
                         {attributes.headline}

--- a/packages/libs/web-common/src/App/Showcase/Showcase.jsx
+++ b/packages/libs/web-common/src/App/Showcase/Showcase.jsx
@@ -95,7 +95,7 @@ export default function Showcase(props) {
               card={card}
               attemptAction={attemptAction}
               prefix={prefix}
-              key={card.name}
+              key={Card.name === 'AnalysisCard' ? card.displayName : card.name}
               permissions={permissions}
             />
           )}


### PR DESCRIPTION
While working on https://github.com/VEuPathDB/web-monorepo/issues/642 I noticed that I introduced a key error with my `CollapsibleDetailsSection` work. I am addressing that particular key error and the rest of that ticket on a separate branch, but I went ahead and resolved the other two annoying key errors re: `News` and `CardList`.