### PR TITLE
Deal with react-query errors and retry settings

### DIFF
--- a/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
+++ b/packages/libs/eda/src/lib/map/MapVeuContainer.tsx
@@ -67,6 +67,10 @@ export function MapVeuContainer(mapVeuContainerProps: Props) {
         keepPreviousData: true,
         // We presume data will not go stale during the lifecycle of an application.
         staleTime: Infinity,
+        // Do not attempt to retry if an error is encountered
+        retry: false,
+        // Do not referch when the browser tab is focused again
+        refetchOnWindowFocus: false,
       },
     },
   });

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -419,7 +419,7 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
       >
         <div style={{ padding: '5px 10px' }}>
           <MapLegend
-            isLoading={legendItems === null}
+            isLoading={markerData.isFetching}
             plotLegendProps={{ type: 'list', legendItems: legendItems ?? [] }}
             showCheckbox={false}
           />

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -252,7 +252,7 @@ function BubbleLegends(props: MapTypeMapLayerProps) {
             </div>
           ) : (
             <MapLegend
-              isLoading={legendData.data == null}
+              isLoading={legendData.isFetching}
               plotLegendProps={{
                 type: 'bubble',
                 legendMax: legendData.data?.bubbleLegendData?.maxSizeValue ?? 0,

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -379,7 +379,7 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
       >
         <div style={{ padding: '5px 10px' }}>
           <MapLegend
-            isLoading={data.legendItems == null}
+            isLoading={data.isFetching}
             plotLegendProps={{
               type: 'list',
               legendItems: data.legendItems ?? [],


### PR DESCRIPTION
Fixes #637 

This PR prevents useQuery from retrying queries when they fail. It also prevents useQuery from refetching queries when the browser window is refocused. Finally, the `isLoading` props for legend uses the `isFetching` property of a useQuery result.