### PR TITLE
temporarily turn off correlation

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/index.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/index.ts
@@ -7,13 +7,11 @@ import { plugin as countsandproportions } from './countsAndProportions';
 import { plugin as abundance } from './abundance';
 import { plugin as differentialabundance } from './differentialabundance';
 import { plugin as xyrelationships } from './xyRelationships';
-import { plugin as correlationassaymetadata } from './correlationAssayMetadata';
 export const plugins: Record<string, ComputationPlugin> = {
   abundance,
   alphadiv,
   betadiv,
   differentialabundance,
-  correlationassaymetadata,
   countsandproportions,
   distributions,
   pass,


### PR DESCRIPTION
Resolves #619 

Turns off the correlation app so that it will not get released with b66.

Can be reverted after the release!

From PR (Correlation should show up between diff abund and Distributions, but it's not there!)
<img width="906" alt="Screen Shot 2023-11-21 at 6 04 03 AM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/c5395336-7bbe-4a13-86ac-69f21c6f9f84">
