### PR TITLE
Improve UX for bubble marker proportion configuration when filters are active on the variable

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -1756,7 +1756,13 @@ function LineplotViz(props: VisualizationProps<Options>) {
           }
         : {
             aggregationType: 'proportion',
-            options: yAxisVariable?.vocabulary ?? [],
+            options:
+              yAxisVariable?.fullVocabulary ?? yAxisVariable?.vocabulary ?? [],
+            disabledOptions: yAxisVariable?.fullVocabulary
+              ? yAxisVariable?.fullVocabulary.filter(
+                  (value) => !yAxisVariable?.vocabulary?.includes(value)
+                )
+              : [],
             numeratorValues: vizConfig.numeratorValues ?? [],
             denominatorValues: vizConfig.denominatorValues ?? [],
             // onChange handlers now ensure the available options belong to the vocabulary (which can change due to direct filters)
@@ -2749,6 +2755,7 @@ type AggregationConfig<F extends string, P extends Array<string>> =
       denominatorValues: Array<P[number]>;
       onDenominatorChange: (value: Array<P[number]>) => void;
       options: P;
+      disabledOptions: P;
     };
 
 export function AggregationInputs<F extends string, P extends Array<string>>(
@@ -2810,6 +2817,7 @@ export function AggregationInputs<F extends string, P extends Array<string>>(
           >
             <ValuePicker
               allowedValues={props.options}
+              disabledValues={props.disabledOptions}
               selectedValues={props.numeratorValues}
               onSelectedValuesChange={props.onNumeratorChange}
             />
@@ -2823,6 +2831,7 @@ export function AggregationInputs<F extends string, P extends Array<string>>(
           >
             <ValuePicker
               allowedValues={props.options}
+              disabledValues={props.disabledOptions}
               selectedValues={props.denominatorValues}
               onSelectedValuesChange={props.onDenominatorChange}
             />

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -1743,6 +1743,8 @@ function LineplotViz(props: VisualizationProps<Options>) {
     </>
   );
 
+  const { vocabulary, fullVocabulary } = yAxisVariable ?? {};
+
   const aggregationInputs = (
     <AggregationInputs
       {...(vizConfig.valueSpecConfig !== 'Proportion'
@@ -1756,27 +1758,20 @@ function LineplotViz(props: VisualizationProps<Options>) {
           }
         : {
             aggregationType: 'proportion',
-            options:
-              yAxisVariable?.fullVocabulary ?? yAxisVariable?.vocabulary ?? [],
-            disabledOptions: yAxisVariable?.fullVocabulary
-              ? yAxisVariable?.fullVocabulary.filter(
-                  (value) => !yAxisVariable?.vocabulary?.includes(value)
-                )
+            options: fullVocabulary ?? vocabulary ?? [],
+            disabledOptions: fullVocabulary
+              ? fullVocabulary.filter((value) => vocabulary?.includes(value))
               : [],
             numeratorValues: vizConfig.numeratorValues ?? [],
             denominatorValues: vizConfig.denominatorValues ?? [],
             // onChange handlers now ensure the available options belong to the vocabulary (which can change due to direct filters)
             onNumeratorChange: (values) =>
               onNumeratorValuesChange(
-                values.filter((value) =>
-                  yAxisVariable?.vocabulary?.includes(value)
-                )
+                values.filter((value) => vocabulary?.includes(value))
               ),
             onDenominatorChange: (values) =>
               onDenominatorValuesChange(
-                values.filter((value) =>
-                  yAxisVariable?.vocabulary?.includes(value)
-                )
+                values.filter((value) => vocabulary?.includes(value))
               ),
           })}
     />

--- a/packages/libs/eda/src/lib/core/hooks/workspace.ts
+++ b/packages/libs/eda/src/lib/core/hooks/workspace.ts
@@ -149,6 +149,7 @@ export function useStudyEntities(filters?: Filter[]) {
                       // (it's less critical than for dates due to time slider)
                       return {
                         ...variable,
+                        fullVocabulary: variable.vocabulary,
                         vocabulary,
                         distributionDefaults: {
                           ...variable.distributionDefaults,
@@ -186,6 +187,7 @@ export function useStudyEntities(filters?: Filter[]) {
 
                       return {
                         ...variable,
+                        fullVocabulary: variable.vocabulary,
                         vocabulary,
                         distributionDefaults: {
                           ...variable.distributionDefaults,
@@ -206,6 +208,7 @@ export function useStudyEntities(filters?: Filter[]) {
                     } else
                       return {
                         ...variable,
+                        fullVocabulary: variable.vocabulary,
                         vocabulary,
                         distinctValuesCount: vocabulary?.length ?? 0,
                       };

--- a/packages/libs/eda/src/lib/core/types/study.ts
+++ b/packages/libs/eda/src/lib/core/types/study.ts
@@ -121,6 +121,10 @@ const Variable_Base = t.intersection([
   }),
   t.partial({
     vocabulary: t.array(t.string),
+    // filter-sensitive versions of StudyEntity data have modified
+    // vocabularies - this is where we keep a copy of the original
+    // (note that this never comes from the back end)
+    fullVocabulary: t.array(t.string),
   }),
 ]);
 

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
@@ -14,10 +14,7 @@ import {
 } from '../../../core/components/visualizations/implementations/LineplotVisualization';
 import { DataElementConstraint } from '../../../core/types/visualization'; // TO DO for dates: remove
 import { SharedMarkerConfigurations } from '../mapTypes/shared';
-import {
-  invalidProportionText,
-  validateProportionValues,
-} from '../utils/defaultOverlayConfig';
+import { invalidProportionText } from '../utils/defaultOverlayConfig';
 
 type AggregatorOption = typeof aggregatorOptions[number];
 const aggregatorOptions = ['mean', 'median'] as const;
@@ -46,6 +43,7 @@ interface Props
   onChange: (configuration: BubbleMarkerConfiguration) => void;
   configuration: BubbleMarkerConfiguration;
   overlayConfiguration: BubbleOverlayConfig | undefined;
+  isValidProportion: boolean | undefined; // undefined when not categorical mode
 }
 
 export function BubbleMarkerConfigurationMenu({
@@ -56,6 +54,7 @@ export function BubbleMarkerConfigurationMenu({
   starredVariables,
   toggleStarredVariable,
   constraints,
+  isValidProportion,
 }: Props) {
   function handleInputVariablesOnChange(selection: VariablesByInputName) {
     if (!selection.overlayVariable) {
@@ -97,12 +96,12 @@ export function BubbleMarkerConfigurationMenu({
     selectedVariable && 'vocabulary' in selectedVariable
       ? selectedVariable.vocabulary
       : undefined;
-
-  const proportionIsValid = validateProportionValues(
-    numeratorValues,
-    denominatorValues,
-    vocabulary
-  );
+  // if the vocabulary has been altered by filters on this variable
+  // the fullVocabulary will be available here, otherwise it's undefined
+  const fullVocabulary =
+    selectedVariable && 'fullVocabulary' in selectedVariable
+      ? selectedVariable.fullVocabulary
+      : undefined;
 
   const aggregationInputs = (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -121,7 +120,10 @@ export function BubbleMarkerConfigurationMenu({
             }
           : {
               aggregationType: 'proportion',
-              options: vocabulary ?? [],
+              options: fullVocabulary ?? vocabulary ?? [],
+              disabledOptions: fullVocabulary
+                ? fullVocabulary.filter((value) => !vocabulary?.includes(value))
+                : [],
               numeratorValues: numeratorValues ?? [],
               onNumeratorChange: (values) =>
                 onChange({
@@ -140,7 +142,7 @@ export function BubbleMarkerConfigurationMenu({
                 }),
             })}
       />
-      {!proportionIsValid && (
+      {isValidProportion == false && (
         <div style={{ position: 'relative' }}>
           <div style={{ position: 'absolute', width: '100%' }}>
             <PluginError error={invalidProportionText} />

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
@@ -142,7 +142,7 @@ export function BubbleMarkerConfigurationMenu({
                 }),
             })}
       />
-      {isValidProportion == false && (
+      {isValidProportion === false && (
         <div style={{ position: 'relative' }}>
           <div style={{ position: 'absolute', width: '100%' }}>
             <PluginError error={invalidProportionText} />

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -34,10 +34,7 @@ import {
 } from '../../MarkerConfiguration/MapTypeConfigurationMenu';
 import { BubbleMarkerIcon } from '../../MarkerConfiguration/icons';
 import { useStandaloneVizPlugins } from '../../hooks/standaloneVizPlugins';
-import {
-  getDefaultBubbleOverlayConfig,
-  validateProportionValues,
-} from '../../utils/defaultOverlayConfig';
+import { getDefaultBubbleOverlayConfig } from '../../utils/defaultOverlayConfig';
 import {
   defaultAnimation,
   isApproxSameViewport,
@@ -519,8 +516,8 @@ function useLegendData(props: DataProps) {
 
   const { aggregationConfig, ...restOverlayConfig } = overlayConfig;
   const valueType =
-    overlayConfig.aggregationConfig.overlayType === 'continuous'
-      ? overlayConfig.aggregationConfig.valueType
+    aggregationConfig.overlayType === 'continuous'
+      ? aggregationConfig.valueType
       : undefined;
   const legendRequestParams: StandaloneMapBubblesLegendRequestParams = {
     studyId,
@@ -723,7 +720,7 @@ function useMarkerData(props: DataProps) {
 
   const rawMarkersResult = useRawMarkerData(props);
   const legendDataResult = useLegendData(props);
-  const overlayConfig = useOverlayConfig({
+  const { overlayConfig } = useOverlayConfig({
     studyId,
     filters,
     ...configuration,

--- a/packages/libs/eda/src/lib/map/analysis/utils/defaultOverlayConfig.ts
+++ b/packages/libs/eda/src/lib/map/analysis/utils/defaultOverlayConfig.ts
@@ -33,7 +33,7 @@ export interface DefaultBubbleOverlayConfigProps {
 
 export function getDefaultBubbleOverlayConfig(
   props: DefaultBubbleOverlayConfigProps
-): BubbleOverlayConfig {
+): { overlayConfig: BubbleOverlayConfig; isValidProportion?: boolean } {
   const {
     overlayVariable,
     overlayEntity,
@@ -50,20 +50,29 @@ export function getDefaultBubbleOverlayConfig(
   if (CategoricalVariableDataShape.is(overlayVariable.dataShape)) {
     // categorical
     return {
-      overlayVariable: overlayVariableDescriptor,
-      aggregationConfig: {
-        overlayType: 'categorical',
+      overlayConfig: {
+        overlayVariable: overlayVariableDescriptor,
+        aggregationConfig: {
+          overlayType: 'categorical',
+          numeratorValues,
+          denominatorValues,
+        },
+      },
+      isValidProportion: validateProportionValues(
         numeratorValues,
         denominatorValues,
-      },
+        overlayVariable.vocabulary
+      ),
     };
   } else if (ContinuousVariableDataShape.is(overlayVariable.dataShape)) {
     // continuous
     return {
-      overlayVariable: overlayVariableDescriptor,
-      aggregationConfig: {
-        overlayType: 'continuous', // TO DO for dates: might do `overlayVariable.type === 'date' ? 'date' : 'number'`
-        aggregator,
+      overlayConfig: {
+        overlayVariable: overlayVariableDescriptor,
+        aggregationConfig: {
+          overlayType: 'continuous', // TO DO for dates: might do `overlayVariable.type === 'date' ? 'date' : 'number'`
+          aggregator,
+        },
       },
     };
   }


### PR DESCRIPTION
Fixes #670 

- [x] show "filtered away" values as greyed out in num/denom dropdowns
- [x] tidy up validation logic by putting validation check into `useOverlayConfig`
- [x] don't show markers when the proportion is invalid
- [x] show something in the legends when no markers are shown for this reason. Note that I will be adding a ticket to add a :gear: (gear) icon to the legends, which will open up the active marker config.
- [ ] one question remains... is the checked greyed out checkbox a problem? (it cannot be deselected)
      - do we want to modify ValuePicker/SelectList so that disabled items have greyed out labels but active deselectable checkboxes (but not reselectable?)
- [ ] use `ReactNode` for `invalidProportionText` and make it two paragraphs? Oh, but `PluginError` can't handle that at present. I feel this should be a separate ticket?

![Screenshot from 2023-11-23 18-02-39](https://github.com/VEuPathDB/web-monorepo/assets/308639/bb332a0a-522b-4e81-8832-fcd8a005c901)
