### PR TITLE
Fix unsync'ed "Currently viewing" marker in All Analyses table.

### DIFF
--- a/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
+++ b/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
@@ -643,6 +643,7 @@ export function AllAnalyses(props: Props) {
       exampleAnalysesAuthor,
       user,
       studyId,
+      activeAnalysisId,
     ]
   );
 


### PR DESCRIPTION
Fixes #515 

Added the missing dependency.

However, a related issue is that editing the active analysis' name in either the table or the header does not cause the other one to update.  I looked into it briefly but didn't find an obvious answer.  Should we try to fix that too?