### PR TITLE
Genomics add beta icon to searches

### DIFF
--- a/packages/libs/wdk-client/src/Components.ts
+++ b/packages/libs/wdk-client/src/Components.ts
@@ -71,6 +71,9 @@ import RecordNavigationSection from './Views/Records/RecordNavigation/RecordNavi
 import { SearchInputSelector } from './Views/Strategy/SearchInputSelector';
 import CollapsibleDetailsSection from './Components/Display/CollapsibleDetailsSection';
 
+export { NewIcon } from './Core/Style/Icons/NewIcon';
+export { BetaIcon } from './Core/Style/Icons/BetaIcon';
+
 export {
   AccordionButton,
   AnswerTableCell,

--- a/packages/libs/wdk-client/src/Core/Style/Icons/BetaIcon.tsx
+++ b/packages/libs/wdk-client/src/Core/Style/Icons/BetaIcon.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import betaImage from '../images/beta2-30.png';
+
+export function BetaIcon() {
+  return <img src={betaImage} />;
+}

--- a/packages/libs/wdk-client/src/Core/Style/Icons/NewIcon.tsx
+++ b/packages/libs/wdk-client/src/Core/Style/Icons/NewIcon.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import newImage from '../images/new-feature.png';
+
+export function NewIcon() {
+  return <img src={newImage} />;
+}

--- a/packages/libs/wdk-client/src/Utils/WdkModel.ts
+++ b/packages/libs/wdk-client/src/Utils/WdkModel.ts
@@ -270,6 +270,7 @@ export interface Question extends UrlModelEntity {
   paramNames: string[];
   queryName?: string;
   isCacheable: boolean;
+  isBeta?: boolean;
 }
 
 export interface QuestionWithParameters extends Question {

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
@@ -32,6 +32,7 @@ import { Tabs } from '../../Components';
 import '../../Views/Question/DefaultQuestionForm.scss';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 import { type } from 'os';
+import { BetaIcon } from '../../Core/Style/Icons/BetaIcon';
 
 type TextboxChangeHandler = (
   event: React.ChangeEvent<HTMLInputElement>
@@ -241,6 +242,7 @@ export default function DefaultQuestionForm(props: Props) {
           submissionMetadata.type === 'edit-step'
         }
         headerText={`Identify ${recordClass.displayNamePlural} based on ${question.displayName}`}
+        isBeta={question.isBeta}
       />
       <Tabs
         activeTab={selectedTab}
@@ -265,12 +267,15 @@ export default function DefaultQuestionForm(props: Props) {
 type QuestionHeaderProps = {
   headerText: string;
   showHeader: boolean;
+  isBeta?: boolean;
 };
 
 export function QuestionHeader(props: QuestionHeaderProps) {
   return props.showHeader ? (
     <div className={cx('QuestionHeader')}>
-      <h1>{props.headerText}</h1>
+      <h1>
+        {props.headerText} {props.isBeta && <BetaIcon />}
+      </h1>
     </div>
   ) : (
     <></>

--- a/packages/libs/web-common/src/components/homepage/SearchPane.tsx
+++ b/packages/libs/web-common/src/components/homepage/SearchPane.tsx
@@ -10,6 +10,7 @@ import {
   Link,
   Loading,
   IconAlt,
+  BetaIcon,
 } from '@veupathdb/wdk-client/lib/Components';
 import {
   LinksPosition,
@@ -245,15 +246,15 @@ function SearchPaneNode({
       : { isSearch: false };
 
   const baseUrlSegment = nodeMetadata.isSearch ? nodeMetadata.searchName : null;
+  const question = questionsByUrlSegment[baseUrlSegment];
 
   // autoRun searches whose questions (1) require no parameters and (2) are not internal dataset questions
   // (N.B.: internal dataset questions are currently being detected by the presence of
   // "datasetCategory" and "datasetSubtype" properties)
   const urlSegment =
-    questionsByUrlSegment[baseUrlSegment]?.paramNames.length === 0 &&
-    questionsByUrlSegment[baseUrlSegment]?.properties?.datasetCategory ==
-      null &&
-    questionsByUrlSegment[baseUrlSegment]?.properties?.datasetSubtype == null
+    question?.paramNames.length === 0 &&
+    question?.properties?.datasetCategory == null &&
+    question?.properties?.datasetSubtype == null
       ? `${baseUrlSegment}?autoRun`
       : baseUrlSegment;
 
@@ -268,6 +269,7 @@ function SearchPaneNode({
       <div
         style={{
           display: 'flex',
+          alignItems: 'baseline',
         }}
       >
         <div
@@ -282,7 +284,9 @@ function SearchPaneNode({
             <IconAlt fa="search" />
           </span>
         </div>
-        <span style={{ color: '#069' }}>{displayName}</span>
+        <span style={{ color: '#069' }}>
+          {displayName} {question.isBeta && <BetaIcon />}
+        </span>
       </div>
     </Link>
   ) : (

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -271,6 +271,7 @@ function InternalGeneDatasetContent(props: Props) {
           submissionMetadata.type === 'edit-step'
         }
         headerText={`Identify ${outputRecordClass.displayNamePlural} based on ${internalQuestion.displayName}`}
+        isBeta={internalQuestion.isBeta}
       />
       <div className={cx('Legend')}>
         <span style={{ fontWeight: 'bold', fontSize: '13px' }}>Legend:</span>

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/wrapWdkService.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/wrapWdkService.tsx
@@ -77,6 +77,18 @@ export const wrapWdkService = flowRight(
       })
     : identity,
   addMultiBlastService,
+  (wdkService: WdkService): WdkService => ({
+    ...wdkService,
+    // Hardcode isBeta. This method is used by search pages
+    // and the search tree in the site header menu.
+    getQuestions: memoize(async () => {
+      const questions = await wdkService.getQuestions();
+      return questions.map((q) => ({
+        ...q,
+        isBeta: q.urlSegment.endsWith('ByLongReadEvidence'),
+      }));
+    }),
+  }),
   function addGenomicsServices(wdkService: WdkService): GenomicsService {
     return {
       ...wdkService,


### PR DESCRIPTION
This PR adds support for an `isBeta` property on wdk questions. This can be used to display a beta icon when rendering the display name of the question.

This PR also hard codes `isBeta` for long read searches.

_Note, I will be merging this PR without a review so it can be included in the next release._