### PR TITLE
ellipsis of legend title and tooltip for SAM and minWidth

### DIFF
--- a/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
+++ b/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
@@ -7,6 +7,7 @@ import { screenReaderOnly } from '../../../styleDefinitions/typography';
 import { useUITheme } from '../../theming';
 import DismissButton from '../../notifications/DismissButton';
 import { H6 } from '../../typography';
+import { truncateWithEllipsis } from '@veupathdb/components/lib/utils/axis-tick-label-ellipsis';
 
 export type DraggablePanelCoordinatePair = {
   x: number;
@@ -121,6 +122,9 @@ export default function DraggablePanel({
     ? constrainPositionOnScreen(panelPosition, width, height, window)
     : panelPosition;
 
+  // set maximum text length for the panel title
+  const maxPanelTitleTextLength = 25;
+
   return (
     <Draggable
       bounds={confineToParentContainer ? 'parent' : false}
@@ -184,8 +188,12 @@ export default function DraggablePanel({
               padding: '0 10px',
             }}
           >
-            <span css={showPanelTitle ? null : screenReaderOnly}>
-              {panelTitle}
+            {/* ellipsis and tooltip for panel title */}
+            <span
+              css={showPanelTitle ? null : screenReaderOnly}
+              title={panelTitle}
+            >
+              {truncateWithEllipsis(panelTitle, maxPanelTitleTextLength)}
             </span>
           </H6>
           {onPanelDismiss && (

--- a/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
+++ b/packages/libs/coreui/src/components/containers/DraggablePanel/index.tsx
@@ -7,7 +7,6 @@ import { screenReaderOnly } from '../../../styleDefinitions/typography';
 import { useUITheme } from '../../theming';
 import DismissButton from '../../notifications/DismissButton';
 import { H6 } from '../../typography';
-import { truncateWithEllipsis } from '@veupathdb/components/lib/utils/axis-tick-label-ellipsis';
 
 export type DraggablePanelCoordinatePair = {
   x: number;
@@ -283,3 +282,10 @@ function constrainPositionOnScreen(
     y: isYOffScreen ? bottomMostY : position.y,
   };
 }
+
+// function for ellipsis
+export const truncateWithEllipsis = (label: string, maxLabelLength: number) => {
+  return (label || '').length > maxLabelLength
+    ? (label || '').substring(0, maxLabelLength - 2) + '...'
+    : label;
+};

--- a/packages/libs/eda/src/lib/map/analysis/DraggableLegendPanel.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/DraggableLegendPanel.tsx
@@ -16,6 +16,8 @@ export const DraggableLegendPanel = (props: {
     defaultPosition={props.defaultPosition ?? { x: window.innerWidth, y: 225 }}
     styleOverrides={{
       zIndex: props.zIndex,
+      // set minWidth for draggable panel
+      minWidth: '120px',
     }}
   >
     {props.children}


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/624

Similar to EDA legend, the panel title at Draggable panel now has ellipsis (25 characters like EDA) and mouseover tooltip (screenshot). Also, minWidth is set to the Draggable panel so that it cannot be too narrow for bubble marker: set to be 120px based on Country variable and considering the width of scale bar.

![SAM legend title ellipsis01](https://github.com/VEuPathDB/web-monorepo/assets/12802305/16d5fcf7-3556-440a-9b73-cafdd8d38ba4)
