### PR TITLE
Better handling for `undefined` compute configs

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/ComputationInstance.tsx
@@ -3,12 +3,13 @@ import { useRouteMatch } from 'react-router-dom';
 import { useToggleStarredVariable } from '../../hooks/starredVariables';
 import { Computation } from '../../types/visualization';
 import { VisualizationsContainer } from '../visualizations/VisualizationsContainer';
-import { ComputationProps } from './Types';
+import { ComputationPlugin, ComputationProps } from './Types';
 import { plugins } from './plugins';
 import { VisualizationPlugin } from '../visualizations/VisualizationPlugin';
 import { AnalysisState } from '../../hooks/analysis';
 import { useComputeJobStatus } from './ComputeJobStatusHook';
 import { Filter } from '../../types/filter';
+import { useStudyMetadata } from '../../hooks/workspace';
 
 export interface Props extends ComputationProps {
   computationId: string;
@@ -31,12 +32,29 @@ export function ComputationInstance(props: Props) {
   } = props;
 
   const { analysis } = analysisState;
+  const { rootEntity } = useStudyMetadata();
 
-  const computation = useComputation(analysis, computationId);
+  const _computation = useComputation(analysis, computationId);
 
   if (analysis == null) throw new Error('Cannot find analysis.');
 
-  if (computation == null) throw new Error('Cannot find computation.');
+  if (_computation == null) throw new Error('Cannot find computation.');
+
+  const plugin = plugins[_computation.descriptor.type];
+
+  if (plugin == null) throw new Error('Cannot find plugin for computation.');
+
+  // handle undefined computation configurations
+  const computation =
+    _computation.descriptor.configuration == null
+      ? {
+          ..._computation,
+          descriptor: {
+            ..._computation.descriptor,
+            configuration: plugin.createDefaultConfiguration(rootEntity),
+          },
+        }
+      : _computation;
 
   const toggleStarredVariable = useToggleStarredVariable(props.analysisState);
 
@@ -68,7 +86,11 @@ export function ComputationInstance(props: Props) {
             gap: '1em',
           }}
         >
-          <AppTitle computation={computation} filters={filters} />
+          <AppTitle
+            computation={computation}
+            filters={filters}
+            plugin={plugin}
+          />
         </div>
       )}
       <VisualizationsContainer
@@ -76,6 +98,7 @@ export function ComputationInstance(props: Props) {
         computationAppOverview={computationAppOverview}
         geoConfigs={geoConfigs}
         computation={computation}
+        computationPlugin={plugin}
         visualizationsOverview={computationAppOverview.visualizations}
         visualizationPlugins={visualizationPlugins}
         filters={analysis.descriptor.subset.descriptor}
@@ -96,11 +119,11 @@ export function ComputationInstance(props: Props) {
 interface AppTitleProps {
   computation: Computation;
   filters: Filter[];
+  plugin: ComputationPlugin;
 }
 
 function AppTitle(props: AppTitleProps) {
-  const { computation, filters } = props;
-  const plugin = plugins[computation.descriptor?.type];
+  const { computation, filters, plugin } = props;
   const ConfigDescription = plugin
     ? plugin.configurationDescriptionComponent
     : undefined;

--- a/packages/libs/eda/src/lib/core/components/computations/ComputationInstance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/ComputationInstance.tsx
@@ -31,17 +31,15 @@ export function ComputationInstance(props: Props) {
     isSingleAppMode,
   } = props;
 
-  const { analysis } = analysisState;
   const { rootEntity } = useStudyMetadata();
 
-  const _computation = useComputation(analysis, computationId);
-
+  const { analysis } = analysisState;
   if (analysis == null) throw new Error('Cannot find analysis.');
 
+  const _computation = useComputation(analysis, computationId);
   if (_computation == null) throw new Error('Cannot find computation.');
 
   const plugin = plugins[_computation.descriptor.type];
-
   if (plugin == null) throw new Error('Cannot find plugin for computation.');
 
   // handle undefined computation configurations

--- a/packages/libs/eda/src/lib/core/components/computations/Types.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Types.ts
@@ -46,6 +46,8 @@ export interface ComputationPlugin {
     filters: Filter[];
   }>;
   visualizationPlugins: Partial<Record<string, VisualizationPlugin<any>>>;
-  createDefaultConfiguration: (rootEntity: StudyEntity) => unknown;
+  createDefaultConfiguration: (
+    rootEntity: StudyEntity
+  ) => Record<string, unknown> | null;
   isConfigurationComplete: (configuration: unknown) => boolean;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/Types.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Types.ts
@@ -48,6 +48,6 @@ export interface ComputationPlugin {
   visualizationPlugins: Partial<Record<string, VisualizationPlugin<any>>>;
   createDefaultConfiguration: (
     rootEntity: StudyEntity
-  ) => Record<string, unknown> | null;
+  ) => Record<string, unknown> | undefined;
   isConfigurationComplete: (configuration: unknown) => boolean;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/ZeroConfiguration.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/ZeroConfiguration.tsx
@@ -1,28 +1,8 @@
-import React, { useEffect } from 'react';
-import { ComputationConfigProps } from './Types';
-
-export interface Props extends ComputationConfigProps {
-  autoCreate?: boolean;
-}
+import React from 'react';
 
 /**
  * An App configuration component that can be used when no configuration is needed.
- * This component will create a new instance of the app and immediately redirect to it.
  */
-// alphadiv abundance null as any needs to be be used here if ComputationConfiguration is typed
-function ZeroConfig(props: Props) {
-  const { autoCreate = false, addNewComputation } = props;
-  useEffect(() => {
-    if (autoCreate) addNewComputation('Unnamed computation', undefined);
-  }, [addNewComputation, autoCreate]);
-
+export function ZeroConfiguration() {
   return null;
-}
-
-export function ZeroConfigWithAutoCreate(props: ComputationConfigProps) {
-  return <ZeroConfig {...props} autoCreate />;
-}
-
-export function ZeroConfigWithButton(props: ComputationConfigProps) {
-  return <ZeroConfig {...props} />;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/countsAndProportions.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/countsAndProportions.tsx
@@ -10,8 +10,8 @@ import { ZeroConfigWithButton } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
-  isConfigurationComplete: t.undefined.is,
-  createDefaultConfiguration: () => undefined,
+  isConfigurationComplete: t.nullType.is,
+  createDefaultConfiguration: () => null,
   visualizationPlugins: {
     testVisualization,
     twobytwo: twoByTwoVisualization,

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/countsAndProportions.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/countsAndProportions.tsx
@@ -6,12 +6,12 @@ import {
 } from '../../visualizations/implementations/MosaicVisualization';
 import { testVisualization } from '../../visualizations/implementations/TestVisualization';
 import { ComputationPlugin } from '../Types';
-import { ZeroConfigWithButton } from '../ZeroConfiguration';
+import { ZeroConfiguration } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
-  configurationComponent: ZeroConfigWithButton,
-  isConfigurationComplete: t.nullType.is,
-  createDefaultConfiguration: () => null,
+  configurationComponent: ZeroConfiguration,
+  isConfigurationComplete: t.undefined.is,
+  createDefaultConfiguration: () => undefined,
   visualizationPlugins: {
     testVisualization,
     twobytwo: twoByTwoVisualization,

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/distributions.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/distributions.tsx
@@ -3,12 +3,12 @@ import { boxplotVisualization } from '../../visualizations/implementations/Boxpl
 import { histogramVisualization } from '../../visualizations/implementations/HistogramVisualization';
 import { testVisualization } from '../../visualizations/implementations/TestVisualization';
 import { ComputationPlugin } from '../Types';
-import { ZeroConfigWithButton } from '../ZeroConfiguration';
+import { ZeroConfiguration } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
-  configurationComponent: ZeroConfigWithButton,
-  isConfigurationComplete: t.nullType.is,
-  createDefaultConfiguration: () => null,
+  configurationComponent: ZeroConfiguration,
+  isConfigurationComplete: t.undefined.is,
+  createDefaultConfiguration: () => undefined,
   visualizationPlugins: {
     testVisualization,
     histogram: histogramVisualization,

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/distributions.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/distributions.tsx
@@ -7,8 +7,8 @@ import { ZeroConfigWithButton } from '../ZeroConfiguration';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
-  isConfigurationComplete: t.undefined.is,
-  createDefaultConfiguration: () => undefined,
+  isConfigurationComplete: t.nullType.is,
+  createDefaultConfiguration: () => null,
   visualizationPlugins: {
     testVisualization,
     histogram: histogramVisualization,

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/pass.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/pass.tsx
@@ -10,13 +10,13 @@ import { lineplotVisualization } from '../../visualizations/implementations/Line
 import { mapVisualization } from '../../visualizations/implementations/MapVisualization';
 import { testVisualization } from '../../visualizations/implementations/TestVisualization';
 import { ComputationPlugin } from '../Types';
-import { ZeroConfigWithButton } from '../ZeroConfiguration';
+import { ZeroConfiguration } from '../ZeroConfiguration';
 import * as t from 'io-ts';
 
 export const plugin: ComputationPlugin = {
-  configurationComponent: ZeroConfigWithButton,
-  isConfigurationComplete: t.nullType.is,
-  createDefaultConfiguration: () => null,
+  configurationComponent: ZeroConfiguration,
+  isConfigurationComplete: t.undefined.is,
+  createDefaultConfiguration: () => undefined,
   visualizationPlugins: {
     testVisualization,
     histogram: histogramVisualization,

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/pass.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/pass.tsx
@@ -15,8 +15,8 @@ import * as t from 'io-ts';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
-  isConfigurationComplete: t.undefined.is,
-  createDefaultConfiguration: () => undefined,
+  isConfigurationComplete: t.nullType.is,
+  createDefaultConfiguration: () => null,
   visualizationPlugins: {
     testVisualization,
     histogram: histogramVisualization,

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/xyRelationships.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/xyRelationships.tsx
@@ -7,8 +7,8 @@ import * as t from 'io-ts';
 
 export const plugin: ComputationPlugin = {
   configurationComponent: ZeroConfigWithButton,
-  isConfigurationComplete: t.undefined.is,
-  createDefaultConfiguration: () => undefined,
+  isConfigurationComplete: t.nullType.is,
+  createDefaultConfiguration: () => null,
   visualizationPlugins: {
     testVisualization,
     scatterplot: scatterplotVisualization,

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/xyRelationships.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/xyRelationships.tsx
@@ -2,13 +2,13 @@ import { scatterplotVisualization } from '../../visualizations/implementations/S
 import { lineplotVisualization } from '../../visualizations/implementations/LineplotVisualization';
 import { testVisualization } from '../../visualizations/implementations/TestVisualization';
 import { ComputationPlugin } from '../Types';
-import { ZeroConfigWithButton } from '../ZeroConfiguration';
+import { ZeroConfiguration } from '../ZeroConfiguration';
 import * as t from 'io-ts';
 
 export const plugin: ComputationPlugin = {
-  configurationComponent: ZeroConfigWithButton,
-  isConfigurationComplete: t.nullType.is,
-  createDefaultConfiguration: () => null,
+  configurationComponent: ZeroConfiguration,
+  isConfigurationComplete: t.undefined.is,
+  createDefaultConfiguration: () => undefined,
   visualizationPlugins: {
     testVisualization,
     scatterplot: scatterplotVisualization,

--- a/packages/libs/eda/src/lib/core/components/visualizations/VisualizationTypes.ts
+++ b/packages/libs/eda/src/lib/core/components/visualizations/VisualizationTypes.ts
@@ -6,6 +6,7 @@ import { StudyMetadata } from '../../types/study';
 import { VariableDescriptor } from '../../types/variable';
 import {
   Computation,
+  ComputationAppOverview,
   DataElementConstraint,
   Visualization,
   VisualizationOverview,
@@ -29,6 +30,7 @@ export interface VisualizationProps<Options = undefined> {
   updateConfiguration: (configuration: unknown) => void;
   updateThumbnail?: (source: string) => void;
   computation: Computation;
+  copmutationAppOverview: ComputationAppOverview;
   filters?: Filter[];
   starredVariables: VariableDescriptor[];
   toggleStarredVariable: (targetVariableId: VariableDescriptor) => void;

--- a/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -718,6 +718,7 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
                   dataElementDependencyOrder={dataElementDependencyOrder}
                   visualization={viz}
                   computation={computation}
+                  copmutationAppOverview={computationAppOverview}
                   filters={filters}
                   starredVariables={starredVariables}
                   toggleStarredVariable={toggleStarredVariable}
@@ -742,6 +743,7 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
               dataElementDependencyOrder={dataElementDependencyOrder}
               visualization={viz}
               computation={computation}
+              copmutationAppOverview={computationAppOverview}
               filters={filters}
               starredVariables={starredVariables}
               toggleStarredVariable={toggleStarredVariable}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -185,6 +185,7 @@ export const BoxplotConfig = t.partial({
 function BoxplotViz(props: VisualizationProps<Options>) {
   const {
     computation,
+    copmutationAppOverview,
     options,
     visualization,
     updateConfiguration,
@@ -489,7 +490,9 @@ function BoxplotViz(props: VisualizationProps<Options>) {
             : [],
           showMissingness: vizConfig.showMissingness ? 'TRUE' : 'FALSE',
         },
-        computeConfig: computation.descriptor.configuration,
+        computeConfig: copmutationAppOverview.computeName
+          ? computation.descriptor.configuration
+          : undefined,
       };
 
       // boxplot

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -262,6 +262,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
   const {
     options,
     computation,
+    copmutationAppOverview,
     visualization,
     updateConfiguration,
     updateThumbnail,
@@ -700,7 +701,9 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
             : undefined,
           showMissingness: vizConfig.showMissingness ? 'TRUE' : 'FALSE',
         },
-        computeConfig: computation.descriptor.configuration,
+        computeConfig: copmutationAppOverview.computeName
+          ? computation.descriptor.configuration
+          : undefined,
       };
 
       const response = await dataClient.getVisualizationData(

--- a/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/DraggableVisualization.tsx
@@ -56,9 +56,11 @@ export default function DraggableVisualization({
   const activeVizOverview: VisualizationOverview | undefined =
     app?.visualizations.find((viz) => viz.name === activeViz?.descriptor.type);
 
-  const visualizationPlugins = computationType
-    ? plugins[computationType]?.visualizationPlugins
-    : null;
+  const computationPlugin = computationType
+    ? plugins[computationType]
+    : undefined;
+
+  const visualizationPlugins = computationPlugin?.visualizationPlugins;
 
   const shouldRenderVisualization =
     activeViz &&
@@ -125,6 +127,7 @@ export default function DraggableVisualization({
             <FullScreenVisualization
               analysisState={analysisState}
               computation={activeComputation!}
+              computationPlugin={computationPlugin}
               visualizationPlugins={visualizationPlugins}
               visualizationsOverview={app.visualizations}
               geoConfigs={geoConfigs}

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -1,7 +1,7 @@
 import { ReactNode, useMemo } from 'react';
 import * as t from 'io-ts';
 import { ComputationPlugin } from '../../../core/components/computations/Types';
-import { ZeroConfigWithButton } from '../../../core/components/computations/ZeroConfiguration';
+import { ZeroConfiguration } from '../../../core/components/computations/ZeroConfiguration';
 import { FloatingLayout } from '../../../core/components/layouts/FloatingLayout';
 import { LayoutOptions } from '../../../core/components/layouts/types';
 import {
@@ -100,9 +100,9 @@ export function useStandaloneVizPlugins({
     }
 
     const pluginBasics = {
-      configurationComponent: ZeroConfigWithButton,
-      isConfigurationComplete: t.nullType.is,
-      createDefaultConfiguration: () => null,
+      configurationComponent: ZeroConfiguration,
+      isConfigurationComplete: t.undefined.is,
+      createDefaultConfiguration: () => undefined,
     };
 
     return {

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -101,8 +101,8 @@ export function useStandaloneVizPlugins({
 
     const pluginBasics = {
       configurationComponent: ZeroConfigWithButton,
-      isConfigurationComplete: t.undefined.is,
-      createDefaultConfiguration: () => undefined,
+      isConfigurationComplete: t.nullType.is,
+      createDefaultConfiguration: () => null,
     };
 
     return {


### PR DESCRIPTION
fixed #735 

This PR adds some defensive code to handle `undefined` compute configs. It also introduces more specific types for compute configs (`null | Record<string, unknown>`).

- If a compute config is undefined, stub in the default using the plugin's createDefaultConfiguration function
- Require compute plugins to return either `null` or `Record<string, unknown>`, which better models our expectations.