### PR TITLE
Disable apps based on study metadata

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
@@ -11,6 +11,7 @@ import { v4 as uuid } from 'uuid';
 import { useStudyMetadata } from '../../';
 import PlaceholderIcon from '../visualizations/PlaceholderIcon';
 import { useVizIconColors } from '../visualizations/implementations/selectorIcons/types';
+import { gray } from '@veupathdb/coreui/lib/definitions/colors';
 
 interface Props {
   analysisState: AnalysisState;
@@ -84,6 +85,11 @@ export function StartPage(props: Props) {
                     <H6
                       text={app.displayName}
                       additionalStyles={{ margin: 0, marginBottom: 5 }}
+                      color={
+                        isAppDisabled
+                          ? (gray[400] as React.CSSProperties['color'])
+                          : undefined
+                      }
                     />
                     <span
                       style={{
@@ -96,6 +102,7 @@ export function StartPage(props: Props) {
                         <span
                           style={{
                             fontWeight: '500',
+                            color: gray[700],
                           }}
                         >
                           <br />
@@ -125,6 +132,7 @@ export function StartPage(props: Props) {
                           key={`vizType${index}`}
                           style={{
                             margin: tightLayout ? '1em 1em' : '0 3em',
+                            opacity: isAppDisabled ? 0.5 : 1,
                           }}
                         >
                           <Tooltip title={<>{viz.description}</>}>

--- a/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
@@ -59,9 +59,9 @@ export function StartPage(props: Props) {
           {apps
             .filter((app) => plugins[app.name] != null)
             .map((app) => {
-              //@ts-ignore
               const isAppDisabled =
                 plugins[app.name]?.isEnabledInPicker &&
+                //@ts-ignore
                 !plugins[app.name]?.isEnabledInPicker({ studyMetadata });
               return (
                 <div
@@ -93,18 +93,17 @@ export function StartPage(props: Props) {
                     >
                       {app.description}
                       {isAppDisabled && (
-                        <>
-                          <br></br>
-                          <br></br>
-                          <br></br>
-                          <span
-                            style={{
-                              fontWeight: '500',
-                            }}
-                          >
-                            Not available for this study because blah blah blah
-                          </span>
-                        </>
+                        <span
+                          style={{
+                            fontWeight: '500',
+                          }}
+                        >
+                          <br />
+                          <br />
+                          <br />
+                          Not available for this study. <br />
+                          {plugins[app.name]?.studyRequirements}
+                        </span>
                       )}
                     </span>
                   </div>

--- a/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
@@ -1,6 +1,6 @@
 import { ComputationAppOverview } from '../../types/visualization';
 import { ComputationPlugin } from './Types';
-import { orderBy, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import { H5, H6 } from '@veupathdb/coreui';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import '../visualizations/Visualizations.scss';
@@ -59,10 +59,10 @@ export function StartPage(props: Props) {
           {apps
             .filter((app) => plugins[app.name] != null)
             .map((app) => {
+              const plugin = plugins[app.name];
               const isAppDisabled =
-                plugins[app.name]?.isEnabledInPicker &&
-                //@ts-ignore
-                !plugins[app.name]?.isEnabledInPicker({ studyMetadata });
+                plugin?.isEnabledInPicker &&
+                !plugin.isEnabledInPicker({ studyMetadata });
               return (
                 <div
                   style={{
@@ -102,7 +102,7 @@ export function StartPage(props: Props) {
                           <br />
                           <br />
                           Not available for this study. <br />
-                          {plugins[app.name]?.studyRequirements}
+                          {plugin.studyRequirements}
                         </span>
                       )}
                     </span>

--- a/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
@@ -58,179 +58,188 @@ export function StartPage(props: Props) {
           {/* orderBy renders available apps ahead of those in development */}
           {apps
             .filter((app) => plugins[app.name] != null)
-            .map((app) => (
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: tightLayout ? 'auto' : 'auto 4fr',
-                  padding: tightLayout ? '0em' : '1em',
-                  margin: '1em 0',
-                }}
-                key={app.name}
-              >
-                <div
-                  style={
-                    tightLayout
-                      ? { width: '100%' }
-                      : { width: '300px', margin: '0 8em' }
-                  }
-                >
-                  <H6
-                    text={app.displayName}
-                    additionalStyles={{ margin: 0, marginBottom: 5 }}
-                  />
-                  <span
-                    style={{
-                      fontWeight: '300',
-                      marginTop: '0.5em',
-                    }}
-                  >
-                    {app.description}
-                  </span>
-                </div>
+            .map((app) => {
+              const appDisabled = true;
+              return (
                 <div
                   style={{
-                    display: 'flex',
-                    flexWrap: 'wrap',
-                    rowGap: '2em',
+                    display: 'grid',
+                    gridTemplateColumns: tightLayout ? 'auto' : 'auto 4fr',
+                    padding: tightLayout ? '0em' : '1em',
+                    margin: '1em 0',
                   }}
+                  className={cx('-AppPicker', appDisabled && 'disabled')}
+                  key={app.name}
                 >
-                  {app.visualizations.map((viz, index) => {
-                    const plugin = plugins[app.name];
-                    const vizPlugin =
-                      plugin && plugin.visualizationPlugins[viz.name];
-                    const disabled =
-                      !plugin || !plugin.visualizationPlugins[viz.name];
-                    return (
-                      <div
-                        className={cx('-PickerEntry', disabled && 'disabled')}
-                        key={`vizType${index}`}
-                        style={{
-                          margin: tightLayout ? '1em 1em' : '0 3em',
-                        }}
-                      >
-                        <Tooltip title={<>{viz.description}</>}>
-                          <button
-                            style={{
-                              cursor: disabled ? 'not-allowed' : 'cursor',
-                            }}
-                            disabled={disabled}
-                            onClick={async () => {
-                              if (
-                                analysisState.analysis == null ||
-                                plugin == null ||
-                                vizPlugin == null
-                              )
-                                return;
-                              const computations =
-                                analysisState.analysis.descriptor.computations;
-                              const defaultComputationConfig =
-                                plugin.createDefaultConfiguration(
-                                  studyMetadata.rootEntity
-                                );
-                              /*
-                                The first instance of a configurable app will be derived by a default configuration.
-                                Here we're checking if a computation with a defaultConfig already exists.
-                              */
-                              const existingComputation = computations.find(
-                                (c) =>
-                                  isEqual(
-                                    c.descriptor.configuration,
-                                    defaultComputationConfig
-                                  ) && app.name === c.descriptor.type
-                              );
-                              const visualizationId = uuid();
-                              const newVisualization = {
-                                visualizationId,
-                                displayName: 'Unnamed visualization',
-                                descriptor: {
-                                  type: viz.name!,
-                                  configuration:
-                                    vizPlugin.createDefaultConfig(),
-                                  ...(applicationContext != null
-                                    ? { applicationContext }
-                                    : {}),
-                                },
-                              };
-                              if (!existingComputation) {
-                                const computation = createComputation(
-                                  app.name,
-                                  defaultComputationConfig,
-                                  computations,
-                                  [newVisualization]
-                                );
-                                analysisState.setComputations([
-                                  computation,
-                                  ...computations,
-                                ]);
-                                onVisualizationCreated(
-                                  visualizationId,
-                                  computation.computationId
-                                );
+                  <div
+                    style={
+                      tightLayout
+                        ? { width: '100%' }
+                        : { width: '300px', margin: '0 8em' }
+                    }
+                  >
+                    <H6
+                      text={app.displayName}
+                      additionalStyles={{ margin: 0, marginBottom: 5 }}
+                    />
+                    <span
+                      style={{
+                        fontWeight: '300',
+                        marginTop: '0.5em',
+                      }}
+                    >
+                      {app.description}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexWrap: 'wrap',
+                      rowGap: '2em',
+                    }}
+                  >
+                    {app.visualizations.map((viz, index) => {
+                      const plugin = plugins[app.name];
+                      const vizPlugin =
+                        plugin && plugin.visualizationPlugins[viz.name];
+                      const disabled =
+                        !plugin ||
+                        !vizPlugin ||
+                        (vizPlugin?.isEnabledInPicker != null &&
+                          //@ts-ignore
+                          vizPlugin?.isEnabledInPicker({}) === false);
+                      return (
+                        <div
+                          className={cx('-PickerEntry', disabled && 'disabled')}
+                          key={`vizType${index}`}
+                          style={{
+                            margin: tightLayout ? '1em 1em' : '0 3em',
+                          }}
+                        >
+                          <Tooltip title={<>{viz.description}</>}>
+                            <button
+                              style={{
+                                cursor: disabled ? 'not-allowed' : 'cursor',
+                              }}
+                              disabled={disabled}
+                              onClick={async () => {
+                                if (
+                                  analysisState.analysis == null ||
+                                  plugin == null ||
+                                  vizPlugin == null
+                                )
+                                  return;
+                                const computations =
+                                  analysisState.analysis.descriptor
+                                    .computations;
+                                const defaultComputationConfig =
+                                  plugin.createDefaultConfiguration(
+                                    studyMetadata.rootEntity
+                                  );
                                 /*
-				   history.push(
-                                  Path.resolve(
-                                    history.location.pathname,
-                                    '..',
-                                    computation.computationId,
-                                    visualizationId
-                                  )
-                                   );
-				   */
-                              } else {
-                                const updatedComputation = {
-                                  ...existingComputation,
-                                  visualizations:
-                                    existingComputation.visualizations.concat(
-                                      newVisualization
-                                    ),
+                                  The first instance of a configurable app will be derived by a default configuration.
+                                  Here we're checking if a computation with a defaultConfig already exists.
+                                */
+                                const existingComputation = computations.find(
+                                  (c) =>
+                                    isEqual(
+                                      c.descriptor.configuration,
+                                      defaultComputationConfig
+                                    ) && app.name === c.descriptor.type
+                                );
+                                const visualizationId = uuid();
+                                const newVisualization = {
+                                  visualizationId,
+                                  displayName: 'Unnamed visualization',
+                                  descriptor: {
+                                    type: viz.name!,
+                                    configuration:
+                                      vizPlugin.createDefaultConfig(),
+                                    ...(applicationContext != null
+                                      ? { applicationContext }
+                                      : {}),
+                                  },
                                 };
-                                analysisState.setComputations([
-                                  updatedComputation,
-                                  ...computations.filter(
-                                    (c) =>
-                                      c.computationId !==
-                                      updatedComputation.computationId
-                                  ),
-                                ]);
-                                onVisualizationCreated(
-                                  visualizationId,
-                                  existingComputation.computationId
-                                );
-                                /*
-				history.push(
-                                  Path.resolve(
-                                    history.location.pathname,
-                                    '..',
-                                    existingComputation.computationId,
-                                    visualizationId
-                                  )
-                                );
-				*/
-                              }
-                            }}
-                          >
-                            {vizPlugin ? (
-                              <vizPlugin.selectorIcon {...colors} />
-                            ) : (
-                              <PlaceholderIcon name={viz.name} />
-                            )}
-                          </button>
-                        </Tooltip>
-                        <div className={cx('-PickerEntryName')}>
-                          <div>
-                            {viz.displayName
-                              ?.split(/(, )/g)
-                              .map((str) => (str === ', ' ? <br /> : str))}
+                                if (!existingComputation) {
+                                  const computation = createComputation(
+                                    app.name,
+                                    defaultComputationConfig,
+                                    computations,
+                                    [newVisualization]
+                                  );
+                                  analysisState.setComputations([
+                                    computation,
+                                    ...computations,
+                                  ]);
+                                  onVisualizationCreated(
+                                    visualizationId,
+                                    computation.computationId
+                                  );
+                                  /*
+            history.push(
+                                    Path.resolve(
+                                      history.location.pathname,
+                                      '..',
+                                      computation.computationId,
+                                      visualizationId
+                                    )
+                                    );
+            */
+                                } else {
+                                  const updatedComputation = {
+                                    ...existingComputation,
+                                    visualizations:
+                                      existingComputation.visualizations.concat(
+                                        newVisualization
+                                      ),
+                                  };
+                                  analysisState.setComputations([
+                                    updatedComputation,
+                                    ...computations.filter(
+                                      (c) =>
+                                        c.computationId !==
+                                        updatedComputation.computationId
+                                    ),
+                                  ]);
+                                  onVisualizationCreated(
+                                    visualizationId,
+                                    existingComputation.computationId
+                                  );
+                                  /*
+          history.push(
+                                    Path.resolve(
+                                      history.location.pathname,
+                                      '..',
+                                      existingComputation.computationId,
+                                      visualizationId
+                                    )
+                                  );
+          */
+                                }
+                              }}
+                            >
+                              {vizPlugin ? (
+                                <vizPlugin.selectorIcon {...colors} />
+                              ) : (
+                                <PlaceholderIcon name={viz.name} />
+                              )}
+                            </button>
+                          </Tooltip>
+                          <div className={cx('-PickerEntryName')}>
+                            <div>
+                              {viz.displayName
+                                ?.split(/(, )/g)
+                                .map((str) => (str === ', ' ? <br /> : str))}
+                            </div>
+                            {disabled && <i>(Coming soon!)</i>}
                           </div>
-                          {disabled && <i>(Coming soon!)</i>}
                         </div>
-                      </div>
-                    );
-                  })}
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
         </div>
       </div>
     )

--- a/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
@@ -118,13 +118,7 @@ export function StartPage(props: Props) {
                       const plugin = plugins[app.name];
                       const vizPlugin =
                         plugin && plugin.visualizationPlugins[viz.name];
-                      const disabled =
-                        !plugin ||
-                        !vizPlugin ||
-                        (vizPlugin?.isEnabledInPicker != null &&
-                          //@ts-ignore
-                          vizPlugin?.isEnabledInPicker({}) === false) ||
-                        isAppDisabled;
+                      const disabled = !plugin || !vizPlugin || isAppDisabled;
                       return (
                         <div
                           className={cx('-PickerEntry', disabled && 'disabled')}

--- a/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/StartPage.tsx
@@ -59,7 +59,10 @@ export function StartPage(props: Props) {
           {apps
             .filter((app) => plugins[app.name] != null)
             .map((app) => {
-              const appDisabled = true;
+              //@ts-ignore
+              const isAppDisabled =
+                plugins[app.name]?.isEnabledInPicker &&
+                !plugins[app.name]?.isEnabledInPicker({ studyMetadata });
               return (
                 <div
                   style={{
@@ -68,7 +71,7 @@ export function StartPage(props: Props) {
                     padding: tightLayout ? '0em' : '1em',
                     margin: '1em 0',
                   }}
-                  className={cx('-AppPicker', appDisabled && 'disabled')}
+                  className={cx('-AppPicker', isAppDisabled && 'disabled')}
                   key={app.name}
                 >
                   <div
@@ -89,6 +92,20 @@ export function StartPage(props: Props) {
                       }}
                     >
                       {app.description}
+                      {isAppDisabled && (
+                        <>
+                          <br></br>
+                          <br></br>
+                          <br></br>
+                          <span
+                            style={{
+                              fontWeight: '500',
+                            }}
+                          >
+                            Not available for this study because blah blah blah
+                          </span>
+                        </>
+                      )}
                     </span>
                   </div>
                   <div
@@ -107,7 +124,8 @@ export function StartPage(props: Props) {
                         !vizPlugin ||
                         (vizPlugin?.isEnabledInPicker != null &&
                           //@ts-ignore
-                          vizPlugin?.isEnabledInPicker({}) === false);
+                          vizPlugin?.isEnabledInPicker({}) === false) ||
+                        isAppDisabled;
                       return (
                         <div
                           className={cx('-PickerEntry', disabled && 'disabled')}
@@ -231,7 +249,6 @@ export function StartPage(props: Props) {
                                 ?.split(/(, )/g)
                                 .map((str) => (str === ', ' ? <br /> : str))}
                             </div>
-                            {disabled && <i>(Coming soon!)</i>}
                           </div>
                         </div>
                       );

--- a/packages/libs/eda/src/lib/core/components/computations/Types.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Types.ts
@@ -6,6 +6,7 @@ import { GeoConfig } from '../../types/geoConfig';
 import { Computation, ComputationAppOverview } from '../../types/visualization';
 import { Filter, StudyEntity } from '../..';
 import { VisualizationPlugin } from '../visualizations/VisualizationPlugin';
+import { IsEnabledInPickerParams } from '../visualizations/VisualizationTypes';
 
 export interface ComputationProps {
   analysisState: AnalysisState;
@@ -48,4 +49,6 @@ export interface ComputationPlugin {
   visualizationPlugins: Partial<Record<string, VisualizationPlugin<any>>>;
   createDefaultConfiguration: (rootEntity: StudyEntity) => unknown;
   isConfigurationComplete: (configuration: unknown) => boolean;
+  /** Function used to determine if visualization is compatible with study */
+  isEnabledInPicker?: (props: IsEnabledInPickerParams) => boolean;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/Types.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Types.ts
@@ -53,6 +53,6 @@ export interface ComputationPlugin {
   isConfigurationComplete: (configuration: unknown) => boolean;
   /** Function used to determine if visualization is compatible with study */
   isEnabledInPicker?: (props: IsEnabledInPickerParams) => boolean;
-  //** Human-readable requirements for this computation */
+  /** Human-readable study requirements for this computation */
   studyRequirements?: string;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/Types.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Types.ts
@@ -51,4 +51,6 @@ export interface ComputationPlugin {
   isConfigurationComplete: (configuration: unknown) => boolean;
   /** Function used to determine if visualization is compatible with study */
   isEnabledInPicker?: (props: IsEnabledInPickerParams) => boolean;
+  //** Human-readable requirements for this computation */
+  studyRequirements?: string;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -18,6 +18,9 @@ import { ComputationStepContainer } from '../ComputationStepContainer';
 import './Plugins.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { VariableCollectionSelectList } from '../../variableSelectors/VariableCollectionSingleSelect';
+import { IsEnabledInPickerParams } from '../../visualizations/VisualizationTypes';
+import { entityTreeToArray } from '../../../utils/study-metadata';
+import { StudyEntity } from '../../../types/study';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
@@ -95,6 +98,9 @@ export const plugin: ComputationPlugin = {
       hideShowMissingnessToggle: true,
     }),
   },
+  isEnabledInPicker: isEnabledInPicker,
+  studyRequirements:
+    'These visualizations are only available for studies with compatible assay data.',
 };
 
 function AbundanceConfigDescriptionComponent({
@@ -194,4 +200,20 @@ export function AbundanceConfiguration(props: ComputationConfigProps) {
       </div>
     </ComputationStepContainer>
   );
+}
+
+// The abundance app's only requirement for the study is that the study
+// contains at least one collection.
+function isEnabledInPicker({
+  studyMetadata,
+}: IsEnabledInPickerParams): boolean {
+  if (!studyMetadata) return false;
+  const entities = entityTreeToArray(studyMetadata.rootEntity);
+  // Ensure there are collections in this study. Otherwise, disable app
+  const studyHasCollections = !!entities.filter(
+    (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
+      !!e.collections?.length
+  ).length;
+  if (!studyHasCollections) return false;
+  return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -208,12 +208,13 @@ function isEnabledInPicker({
   studyMetadata,
 }: IsEnabledInPickerParams): boolean {
   if (!studyMetadata) return false;
+
   const entities = entityTreeToArray(studyMetadata.rootEntity);
   // Ensure there are collections in this study. Otherwise, disable app
   const studyHasCollections = !!entities.filter(
     (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
       !!e.collections?.length
   ).length;
-  if (!studyHasCollections) return false;
+
   return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -211,10 +211,10 @@ function isEnabledInPicker({
 
   const entities = entityTreeToArray(studyMetadata.rootEntity);
   // Ensure there are collections in this study. Otherwise, disable app
-  const studyHasCollections = !!entities.filter(
+  const studyHasCollections = entities.some(
     (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
       !!e.collections?.length
-  ).length;
+  );
 
   return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -20,7 +20,6 @@ import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUt
 import { VariableCollectionSelectList } from '../../variableSelectors/VariableCollectionSingleSelect';
 import { IsEnabledInPickerParams } from '../../visualizations/VisualizationTypes';
 import { entityTreeToArray } from '../../../utils/study-metadata';
-import { StudyEntity } from '../../../types/study';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
@@ -212,8 +211,7 @@ function isEnabledInPicker({
   const entities = entityTreeToArray(studyMetadata.rootEntity);
   // Ensure there are collections in this study. Otherwise, disable app
   const studyHasCollections = entities.some(
-    (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
-      !!e.collections?.length
+    (entity) => !!entity.collections?.length
   );
 
   return studyHasCollections;

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -174,10 +174,10 @@ function isEnabledInPicker({
   const entities = entityTreeToArray(studyMetadata.rootEntity);
 
   // Ensure there are collections in this study. Otherwise, disable app
-  const studyHasCollections = !!entities.filter(
+  const studyHasCollections = entities.some(
     (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
       !!e.collections?.length
-  ).length;
+  );
 
   return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -1,4 +1,4 @@
-import { useFindEntityAndVariableCollection } from '../../..';
+import { StudyEntity, useFindEntityAndVariableCollection } from '../../..';
 import { VariableCollectionDescriptor } from '../../../types/variable';
 import { boxplotVisualization } from '../../visualizations/implementations/BoxplotVisualization';
 import { scatterplotVisualization } from '../../visualizations/implementations/ScatterplotVisualization';
@@ -17,6 +17,8 @@ import { ComputationStepContainer } from '../ComputationStepContainer';
 import './Plugins.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { VariableCollectionSelectList } from '../../variableSelectors/VariableCollectionSingleSelect';
+import { IsEnabledInPickerParams } from '../../visualizations/VisualizationTypes';
+import { entityTreeToArray } from '../../../utils/study-metadata';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
@@ -60,6 +62,9 @@ export const plugin: ComputationPlugin = {
       hideShowMissingnessToggle: true,
     }),
   },
+  isEnabledInPicker: isEnabledInPicker,
+  studyRequirements:
+    'These visualizations are only available for studies with compatible assay data.',
 };
 
 function AlphaDivConfigDescriptionComponent({
@@ -158,4 +163,20 @@ export function AlphaDivConfiguration(props: ComputationConfigProps) {
       </div>
     </ComputationStepContainer>
   );
+}
+
+// Alpha div's only requirement of the study is that
+// the study contains at least one collection.
+function isEnabledInPicker({
+  studyMetadata,
+}: IsEnabledInPickerParams): boolean {
+  if (!studyMetadata) return false;
+  const entities = entityTreeToArray(studyMetadata.rootEntity);
+  // Ensure there are collections in this study. Otherwise, disable app
+  const studyHasCollections = !!entities.filter(
+    (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
+      !!e.collections?.length
+  ).length;
+  if (!studyHasCollections) return false;
+  return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -1,4 +1,4 @@
-import { StudyEntity, useFindEntityAndVariableCollection } from '../../..';
+import { useFindEntityAndVariableCollection } from '../../..';
 import { VariableCollectionDescriptor } from '../../../types/variable';
 import { boxplotVisualization } from '../../visualizations/implementations/BoxplotVisualization';
 import { scatterplotVisualization } from '../../visualizations/implementations/ScatterplotVisualization';
@@ -175,8 +175,7 @@ function isEnabledInPicker({
 
   // Ensure there are collections in this study. Otherwise, disable app
   const studyHasCollections = entities.some(
-    (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
-      !!e.collections?.length
+    (entity) => !!entity.collections?.length
   );
 
   return studyHasCollections;

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -172,11 +172,12 @@ function isEnabledInPicker({
 }: IsEnabledInPickerParams): boolean {
   if (!studyMetadata) return false;
   const entities = entityTreeToArray(studyMetadata.rootEntity);
+
   // Ensure there are collections in this study. Otherwise, disable app
   const studyHasCollections = !!entities.filter(
     (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
       !!e.collections?.length
   ).length;
-  if (!studyHasCollections) return false;
+
   return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -187,10 +187,10 @@ function isEnabledInPicker({
   const entities = entityTreeToArray(studyMetadata.rootEntity);
 
   // Ensure there are collections in this study. Otherwise, disable app
-  const studyHasCollections = !!entities.filter(
+  const studyHasCollections = entities.some(
     (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
       !!e.collections?.length
-  ).length;
+  );
 
   return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -1,4 +1,4 @@
-import { StudyEntity, useFindEntityAndVariableCollection } from '../../..';
+import { useFindEntityAndVariableCollection } from '../../..';
 import { VariableCollectionDescriptor } from '../../../types/variable';
 import { scatterplotVisualization } from '../../visualizations/implementations/ScatterplotVisualization';
 import { ComputationConfigProps, ComputationPlugin } from '../Types';
@@ -188,8 +188,7 @@ function isEnabledInPicker({
 
   // Ensure there are collections in this study. Otherwise, disable app
   const studyHasCollections = entities.some(
-    (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
-      !!e.collections?.length
+    (entity) => !!entity.collections?.length
   );
 
   return studyHasCollections;

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -185,11 +185,12 @@ function isEnabledInPicker({
 }: IsEnabledInPickerParams): boolean {
   if (!studyMetadata) return false;
   const entities = entityTreeToArray(studyMetadata.rootEntity);
+
   // Ensure there are collections in this study. Otherwise, disable app
   const studyHasCollections = !!entities.filter(
     (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
       !!e.collections?.length
   ).length;
-  if (!studyHasCollections) return false;
+
   return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -1,4 +1,4 @@
-import { useFindEntityAndVariableCollection } from '../../..';
+import { StudyEntity, useFindEntityAndVariableCollection } from '../../..';
 import { VariableCollectionDescriptor } from '../../../types/variable';
 import { scatterplotVisualization } from '../../visualizations/implementations/ScatterplotVisualization';
 import { ComputationConfigProps, ComputationPlugin } from '../Types';
@@ -18,6 +18,8 @@ import { ComputationStepContainer } from '../ComputationStepContainer';
 import './Plugins.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { VariableCollectionSelectList } from '../../variableSelectors/VariableCollectionSingleSelect';
+import { IsEnabledInPickerParams } from '../../visualizations/VisualizationTypes';
+import { entityTreeToArray } from '../../../utils/study-metadata';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
@@ -63,6 +65,9 @@ export const plugin: ComputationPlugin = {
       })
       .withSelectorIcon(ScatterBetadivSVG),
   },
+  isEnabledInPicker: isEnabledInPicker,
+  studyRequirements:
+    'These visualizations are only available for studies with compatible assay data.',
 };
 
 function BetaDivConfigDescriptionComponent({
@@ -171,4 +176,20 @@ export function BetaDivConfiguration(props: ComputationConfigProps) {
       </div>
     </ComputationStepContainer>
   );
+}
+
+// Beta div's only requirement of the study is that it contains
+// at least one collection
+function isEnabledInPicker({
+  studyMetadata,
+}: IsEnabledInPickerParams): boolean {
+  if (!studyMetadata) return false;
+  const entities = entityTreeToArray(studyMetadata.rootEntity);
+  // Ensure there are collections in this study. Otherwise, disable app
+  const studyHasCollections = !!entities.filter(
+    (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
+      !!e.collections?.length
+  ).length;
+  if (!studyHasCollections) return false;
+  return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -1,5 +1,4 @@
 import { useFindEntityAndVariableCollection } from '../../..';
-import { useStudyEntities } from '../../../hooks/workspace';
 import { VariableCollectionDescriptor } from '../../../types/variable';
 import { ComputationConfigProps, ComputationPlugin } from '../Types';
 import { partial } from 'lodash';
@@ -213,6 +212,12 @@ function isEnabledInPicker({
   if (!studyMetadata) return false;
 
   const entities = entityTreeToArray(studyMetadata.rootEntity);
+  // Ensure there are collections in this study. Otherwise, disable app
+  const studyHasCollections = entities.some(
+    (entity) => !!entity.collections?.length
+  );
+  if (!studyHasCollections) return false;
+
   const hasMetagenomicData =
     entities.filter((entity) => entity.id === 'OBI_0002623').length > 0; // OBI_0002623 = Metagenomic sequencing assay
 

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -212,14 +212,12 @@ function isEnabledInPicker({
   if (!studyMetadata) return false;
 
   const entities = entityTreeToArray(studyMetadata.rootEntity);
-  // Ensure there are collections in this study. Otherwise, disable app
-  const studyHasCollections = entities.some(
-    (entity) => !!entity.collections?.length
-  );
-  if (!studyHasCollections) return false;
 
-  const hasMetagenomicData =
-    entities.filter((entity) => entity.id === 'OBI_0002623').length > 0; // OBI_0002623 = Metagenomic sequencing assay
+  // Check that the metagenomic entity exists _and_ that it has
+  // at least one collection.
+  const hasMetagenomicData = entities.some(
+    (entity) => entity.id === 'OBI_0002623' && !!entity.collections?.length
+  ); // OBI_0002623 = Metagenomic sequencing assay
 
   return hasMetagenomicData;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -205,15 +205,16 @@ export function CorrelationAssayAssayConfiguration(
   );
 }
 
-// Decide if the app is available for this study
+// The correlation assay x assay app should only be available
+// for studies with metagenomic data.
 function isEnabledInPicker({
   studyMetadata,
 }: IsEnabledInPickerParams): boolean {
   if (!studyMetadata) return false;
 
-  // The following was originally memoized in EDAWorkspaceContainer.tsx
-  // Cant use a hook here bc this is not a component or function
   const entities = entityTreeToArray(studyMetadata.rootEntity);
+  const hasMetagenomicData =
+    entities.filter((entity) => entity.id === 'OBI_0002623').length > 0; // OBI_0002623 = Metagenomic sequencing assay
 
-  return entities.filter((entity) => entity.id === 'OBI_0002623').length > 0; // Metagenomic sequencing assay
+  return hasMetagenomicData;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -20,7 +20,6 @@ import { variableCollectionsAreUnique } from '../../../utils/visualization';
 import PluginError from '../../visualizations/PluginError';
 import { VariableCollectionSelectList } from '../../variableSelectors/VariableCollectionSingleSelect';
 import { IsEnabledInPickerParams } from '../../visualizations/VisualizationTypes';
-import { useMemo } from 'react';
 import { entityTreeToArray } from '../../../utils/study-metadata';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
@@ -78,6 +77,8 @@ export const plugin: ComputationPlugin = {
     }), // Must match name in data service and in visualization.tsx
   },
   isEnabledInPicker: isEnabledInPicker,
+  studyRequirements:
+    'These visualizations are only available for studies with metagenomic data.',
 };
 
 // Renders on the thumbnail page to give a summary of the app instance
@@ -209,12 +210,9 @@ function isEnabledInPicker({
   studyMetadata,
 }: IsEnabledInPickerParams): boolean {
   if (!studyMetadata) return false;
-  console.log(studyMetadata);
   // The following was originally memoized in EDAWorkspaceContainer.tsx
   // Cant use a hook here bc this is not a component or function
   const entities = entityTreeToArray(studyMetadata.rootEntity);
-  console.log(
-    entities.filter((entity) => entity.id === 'OBI_0002623').length > 0
-  );
+  // @ts-ignore
   return entities.filter((entity) => entity.id === 'OBI_0002623').length > 0; // Metagenomic sequencing assay
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -1,4 +1,5 @@
 import { useFindEntityAndVariableCollection } from '../../..';
+import { useStudyEntities } from '../../../hooks/workspace';
 import { VariableCollectionDescriptor } from '../../../types/variable';
 import { ComputationConfigProps, ComputationPlugin } from '../Types';
 import { partial } from 'lodash';
@@ -18,6 +19,9 @@ import { bipartiteNetworkVisualization } from '../../visualizations/implementati
 import { variableCollectionsAreUnique } from '../../../utils/visualization';
 import PluginError from '../../visualizations/PluginError';
 import { VariableCollectionSelectList } from '../../variableSelectors/VariableCollectionSingleSelect';
+import { IsEnabledInPickerParams } from '../../visualizations/VisualizationTypes';
+import { useMemo } from 'react';
+import { entityTreeToArray } from '../../../utils/study-metadata';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
@@ -73,6 +77,7 @@ export const plugin: ComputationPlugin = {
       },
     }), // Must match name in data service and in visualization.tsx
   },
+  isEnabledInPicker: isEnabledInPicker,
 };
 
 // Renders on the thumbnail page to give a summary of the app instance
@@ -197,4 +202,19 @@ export function CorrelationAssayAssayConfiguration(
       </div>
     </ComputationStepContainer>
   );
+}
+
+// Decide if the app is available for this study
+function isEnabledInPicker({
+  studyMetadata,
+}: IsEnabledInPickerParams): boolean {
+  if (!studyMetadata) return false;
+  console.log(studyMetadata);
+  // The following was originally memoized in EDAWorkspaceContainer.tsx
+  // Cant use a hook here bc this is not a component or function
+  const entities = entityTreeToArray(studyMetadata.rootEntity);
+  console.log(
+    entities.filter((entity) => entity.id === 'OBI_0002623').length > 0
+  );
+  return entities.filter((entity) => entity.id === 'OBI_0002623').length > 0; // Metagenomic sequencing assay
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -210,6 +210,7 @@ function isEnabledInPicker({
   studyMetadata,
 }: IsEnabledInPickerParams): boolean {
   if (!studyMetadata) return false;
+
   // The following was originally memoized in EDAWorkspaceContainer.tsx
   // Cant use a hook here bc this is not a component or function
   const entities = entityTreeToArray(studyMetadata.rootEntity);

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -213,6 +213,6 @@ function isEnabledInPicker({
   // The following was originally memoized in EDAWorkspaceContainer.tsx
   // Cant use a hook here bc this is not a component or function
   const entities = entityTreeToArray(studyMetadata.rootEntity);
-  // @ts-ignore
+
   return entities.filter((entity) => entity.id === 'OBI_0002623').length > 0; // Metagenomic sequencing assay
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -192,7 +192,7 @@ function isEnabledInPicker({
   const firstAssayEntityIndex = entities.findIndex((entity) =>
     ASSAY_ENTITIES.includes(entity.id)
   );
-  if (!firstAssayEntityIndex) return false;
+  if (firstAssayEntityIndex === -1) return false;
 
   // Step 2. Find all ancestor entites of the assayEntity that are on a one-to-one path with assayEntity.
   // Step 2a. Grab ancestor entities.
@@ -213,9 +213,9 @@ function isEnabledInPicker({
   );
 
   // Step 3. Check if there are any continuous variables in the filtered entities
-  const hasContinuousVariable = !!oneToOneAncestors
+  const hasContinuousVariable = oneToOneAncestors
     .flatMap((entity) => entity.variables)
-    .find(
+    .some(
       (variable) =>
         'dataShape' in variable &&
         variable.dataShape === 'continuous' &&

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -219,7 +219,7 @@ function isEnabledInPicker({
       (variable) =>
         'dataShape' in variable &&
         variable.dataShape === 'continuous' &&
-        variable.type === 'number' // Support for dates coming soon! Can remove this line once the backend is ready.
+        (variable.type === 'number' || variable.type === 'integer') // Support for dates coming soon! Can remove this line once the backend is ready.
     );
 
   return hasContinuousVariable;

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -181,6 +181,12 @@ function isEnabledInPicker({
 }: IsEnabledInPickerParams): boolean {
   if (!studyMetadata) return false;
   const entities = entityTreeToArray(studyMetadata.rootEntity);
+  // Ensure there are collections in this study. Otherwise, disable app
+  const studyHasCollections = !!entities.filter(
+    (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
+      !!e.collections?.length
+  ).length;
+  if (!studyHasCollections) return false;
 
   // Step 1. Find the first assay node. Doesn't need to be any one in particular just any assay will do
   const firstAssayEntityIndex = entities.findIndex((entity) =>

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -1,4 +1,4 @@
-import { StudyEntity, useFindEntityAndVariableCollection } from '../../..';
+import { useFindEntityAndVariableCollection } from '../../..';
 import { VariableCollectionDescriptor } from '../../../types/variable';
 import { ComputationConfigProps, ComputationPlugin } from '../Types';
 import { partial } from 'lodash';
@@ -181,10 +181,9 @@ function isEnabledInPicker({
 
   const entities = entityTreeToArray(studyMetadata.rootEntity);
   // Ensure there are collections in this study. Otherwise, disable app
-  const studyHasCollections = !!entities.filter(
-    (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
-      !!e.collections?.length
-  ).length;
+  const studyHasCollections = entities.some(
+    (entity) => !!entity.collections?.length
+  );
   if (!studyHasCollections) return false;
 
   // Check for appropriate metadata

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -1,7 +1,6 @@
 import {
   ContinuousVariableDataShape,
   LabeledRange,
-  StudyEntity,
   usePromise,
   useStudyMetadata,
 } from '../../..';
@@ -478,10 +477,9 @@ function isEnabledInPicker({
 
   const entities = entityTreeToArray(studyMetadata.rootEntity);
   // Ensure there are collections in this study. Otherwise, disable app
-  const studyHasCollections = !!entities.filter(
-    (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
-      !!e.collections?.length
-  ).length;
+  const studyHasCollections = entities.some(
+    (entity) => !!entity.collections?.length
+  );
 
   return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialabundance.tsx
@@ -475,12 +475,13 @@ function isEnabledInPicker({
   studyMetadata,
 }: IsEnabledInPickerParams): boolean {
   if (!studyMetadata) return false;
+
   const entities = entityTreeToArray(studyMetadata.rootEntity);
   // Ensure there are collections in this study. Otherwise, disable app
   const studyHasCollections = !!entities.filter(
     (e): e is StudyEntity & Required<Pick<StudyEntity, 'collections'>> =>
       !!e.collections?.length
   ).length;
-  if (!studyHasCollections) return false;
+
   return studyHasCollections;
 }

--- a/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
+++ b/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
@@ -100,10 +100,9 @@
   // Add disabled effects for the app rows
   &-AppPicker {
     &__disabled {
-      opacity: 0.75;
       cursor: not-allowed;
-      background: #eee;
       border-radius: 20px;
+      color: #a6a6a6;
     }
   }
 

--- a/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
+++ b/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
@@ -97,6 +97,15 @@
       font-weight: 300;
     }
   }
+  // Add disabled effects for the app rows
+  &-AppPicker {
+    &__disabled {
+      opacity: 0.75;
+      cursor: not-allowed;
+      background: #eee;
+      border-radius: 20px;
+    }
+  }
 
   // add hover effect for thumbnail icons
   &-ConfiguredVisualization:hover &-ConfiguredVisualizationActions {

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
@@ -1,7 +1,10 @@
 import * as t from 'io-ts';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
 import { PlotLayout } from '../../layouts/PlotLayout';
-import { VisualizationProps } from '../VisualizationTypes';
+import {
+  IsEnabledInPickerParams,
+  VisualizationProps,
+} from '../VisualizationTypes';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
 import {
   LayoutOptions,
@@ -63,6 +66,7 @@ export const bipartiteNetworkVisualization = createVisualizationPlugin({
   selectorIcon: BipartiteNetworkSVG,
   fullscreenComponent: BipartiteNetworkViz,
   createDefaultConfig: createDefaultConfig,
+  isEnabledInPicker: isEnabledInPicker,
 });
 
 function createDefaultConfig(): BipartiteNetworkConfig {
@@ -388,4 +392,9 @@ function BipartiteNetworkViz(props: VisualizationProps<Options>) {
       />
     </div>
   );
+}
+
+// Decide if this visualization should be enabled in the menu.
+function isEnabledInPicker({ geoConfigs }: IsEnabledInPickerParams): boolean {
+  return geoConfigs != null && geoConfigs.length > 0;
 }

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
@@ -10,6 +10,7 @@ import {
   LayoutOptions,
   TitleOptions,
   LegendOptions,
+  AvailabilityOptions,
 } from '../../layouts/types';
 import { RequestOptions } from '../options/types';
 
@@ -66,7 +67,6 @@ export const bipartiteNetworkVisualization = createVisualizationPlugin({
   selectorIcon: BipartiteNetworkSVG,
   fullscreenComponent: BipartiteNetworkViz,
   createDefaultConfig: createDefaultConfig,
-  isEnabledInPicker: isEnabledInPicker,
 });
 
 function createDefaultConfig(): BipartiteNetworkConfig {
@@ -392,9 +392,4 @@ function BipartiteNetworkViz(props: VisualizationProps<Options>) {
       />
     </div>
   );
-}
-
-// Decide if this visualization should be enabled in the menu.
-function isEnabledInPicker({ geoConfigs }: IsEnabledInPickerParams): boolean {
-  return geoConfigs != null && geoConfigs.length > 0;
 }

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
@@ -1,16 +1,12 @@
 import * as t from 'io-ts';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
 import { PlotLayout } from '../../layouts/PlotLayout';
-import {
-  IsEnabledInPickerParams,
-  VisualizationProps,
-} from '../VisualizationTypes';
+import { VisualizationProps } from '../VisualizationTypes';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
 import {
   LayoutOptions,
   TitleOptions,
   LegendOptions,
-  AvailabilityOptions,
 } from '../../layouts/types';
 import { RequestOptions } from '../options/types';
 

--- a/packages/libs/eda/src/lib/core/utils/study-metadata.ts
+++ b/packages/libs/eda/src/lib/core/utils/study-metadata.ts
@@ -12,7 +12,7 @@ import {
 } from '../types/variable';
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 
-export function entityTreeToArray(rootEntity: StudyEntity) {
+export function entityTreeToArray(rootEntity: StudyEntity): StudyEntity[] {
   return Array.from(preorder(rootEntity, (e) => e.children ?? []));
 }
 


### PR DESCRIPTION
Resolves #731 , child of #667

The two correlation apps require particular data to run. Some studies don't have these data, so for those cases we want to show a disabled app. More specifically,
- correlation assay x metadata requires at least one continuous metadata variable on an entity that is on a one-to-one path with the assay
- correlation assay x assay is specifically for taxa vs functional data. "Functional data" means data from a metagenomic assay, which is an entity that not all studies have. 

I also used the same architecture for the above checks to address #723 

To Dos

- [x] add some isEnabled function to the apps
- [x] disable all vizs in the app if the app is disabled
- [x] can also do this one https://github.com/VEuPathDB/web-monorepo/issues/723 ?
- [x] have the app give a reason that it's not available
- [x] remove all the ts-ignores :)
- [x] repeat for correlation assay v metadata
- [x] improve comments


For testing, some helpful studies include:
- BONUS. Both corrleation apps should be available
- DailyBaby. Should have only the assay x metadata correlation app
- HMP WGS. Should have only the assay x assay (Functional associations) app
- HMP V1-V3. Should have neither app
- 