### PR TITLE
Update styling for embedded record pages

### DIFF
--- a/packages/libs/wdk-client/src/Controllers/RecordController.tsx
+++ b/packages/libs/wdk-client/src/Controllers/RecordController.tsx
@@ -54,6 +54,7 @@ type OwnProps = {
   primaryKey: string;
   attributes?: string[];
   tables?: string[];
+  compressedUI?: boolean;
 };
 type Props = { ownProps: OwnProps } & StateProps & DispatchProps;
 

--- a/packages/libs/wdk-client/src/Core/routes.tsx
+++ b/packages/libs/wdk-client/src/Core/routes.tsx
@@ -154,14 +154,13 @@ const routes: RouteEntry[] = [
     ) => {
       const { attributes = '', tables = '' } = parseQueryString(props);
       return (
-        <div style={{ padding: '1rem' }}>
-          <RecordController
-            recordClass={props.match.params.recordClass}
-            primaryKey={props.match.params.primaryKey}
-            attributes={attributes ? attributes.split(',') : undefined}
-            tables={tables ? tables.split(',') : undefined}
-          />
-        </div>
+        <RecordController
+          recordClass={props.match.params.recordClass}
+          primaryKey={props.match.params.primaryKey}
+          attributes={attributes ? attributes.split(',') : undefined}
+          tables={tables ? tables.split(',') : undefined}
+          compressedUI
+        />
       );
     },
   },

--- a/packages/libs/wdk-client/src/Views/Records/Record.css
+++ b/packages/libs/wdk-client/src/Views/Records/Record.css
@@ -287,3 +287,25 @@ h2.wdk-RecordNavigationSectionHeader {
   display: inline-block;
   min-width: 20%;
 }
+
+.wdk-Compressed.wdk-RecordContainer {
+  font-size: 0.8em;
+}
+
+.wdk-Compressed h1 {
+  font-size: 1em;
+}
+
+.wdk-Compressed .wdk-RecordMain {
+  padding: 0;
+}
+
+.wdk-Compressed .wdk-DataTable th,
+.wdk-Compressed .wdk-DataTable td {
+  padding: 4px;
+  border-color: #d0d0d0;
+}
+
+.wdk-Compressed .wdk-RecordSidebar {
+  display: none;
+}

--- a/packages/libs/wdk-client/src/Views/Records/Record.css
+++ b/packages/libs/wdk-client/src/Views/Records/Record.css
@@ -292,12 +292,21 @@ h2.wdk-RecordNavigationSectionHeader {
   font-size: 0.8em;
 }
 
-.wdk-Compressed h1 {
+.wdk-Compressed.wdk-RecordContainer h1 {
   font-size: 1em;
 }
 
 .wdk-Compressed .wdk-RecordMain {
   padding: 0;
+}
+
+.wdk-Compressed .wdk-DataTableContainer {
+  max-height: 50vh;
+}
+
+.wdk-Compressed .wdk-DataTableContainer thead {
+  position: sticky;
+  top: 0;
 }
 
 .wdk-Compressed .wdk-DataTable th,

--- a/packages/libs/wdk-client/src/Views/Records/RecordUI.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordUI.jsx
@@ -114,6 +114,7 @@ class RecordUI extends Component {
       'wdk-RecordContainer__' + this.props.recordClass.fullName,
       {
         'wdk-RecordContainer__withSidebar': this.props.navigationVisible,
+        'wdk-Compressed': this.props.ownProps.compressedUI,
       }
     );
 

--- a/packages/libs/web-common/src/component-wrappers/RecordPage.jsx
+++ b/packages/libs/web-common/src/component-wrappers/RecordPage.jsx
@@ -11,7 +11,7 @@ export function RecordHeading(DefaultComponent) {
     makeDynamicWrapper('RecordHeading')(DefaultComponent);
   return function EbrcRecordHeading(props) {
     return (
-      <div>
+      <div className="eupathdb-RecordOverviewContainer">
         <DynamicRecordHeading {...props} />
         {renderWithCustomElements(props.record.attributes.record_overview)}
       </div>

--- a/packages/libs/web-common/src/styles/client.scss
+++ b/packages/libs/web-common/src/styles/client.scss
@@ -126,6 +126,14 @@ td.wdk-DataTableCell__thumbnail {
   color: black;
 }
 
+.wdk-Compressed .eupathdb-RecordOverviewContainer {
+  position: sticky;
+  top: 0;
+  background: white;
+  border-bottom: 1px solid #aaa;
+  z-index: 1;
+}
+
 .eupathdb-RecordOverviewItem {
   width: 100%;
 }

--- a/packages/libs/web-common/src/styles/client.scss
+++ b/packages/libs/web-common/src/styles/client.scss
@@ -126,14 +126,6 @@ td.wdk-DataTableCell__thumbnail {
   color: black;
 }
 
-.wdk-Compressed .eupathdb-RecordOverviewContainer {
-  position: sticky;
-  top: 0;
-  background: white;
-  border-bottom: 1px solid #aaa;
-  z-index: 1;
-}
-
 .eupathdb-RecordOverviewItem {
   width: 100%;
 }


### PR DESCRIPTION
closes #730 

This PR introduces a new optional boolean `compressUI` prop that can be passed to `RecordController`. When `true`, a `wdk-Compressed` class is added to the `wdk-RecordContainer` element, allowing various style overrides to compress the page's layout.

Overrides include:
- Smaller font size.
- Less white space in table and between page elements.
- Scrolling tables w/ fixed header. Alternatively, we can make the record overview fixed, but I think this option works well when there is only one table on the page.  
- Removed sidebar.

**Before:**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/183713b1-a313-4cc2-a974-6d9c598e8b86)


**After:**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/2187d473-69b9-4688-a333-2f3b2512a1e7)

