### PR TITLE
Proposal to make MapTypePlugin little filters more widely available

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -87,6 +87,8 @@ import { Page } from '@veupathdb/wdk-client/lib/Components';
 import { Link } from 'react-router-dom';
 import { AnalysisError } from '../../core/components/AnalysisError';
 
+const plugins = [barMarkerPlugin, bubbleMarkerPlugin, donutMarkerPlugin];
+
 enum MapSideNavItemLabels {
   Download = 'Download',
   Filter = 'Filter',
@@ -204,6 +206,9 @@ function MapAnalysisImpl(props: ImplProps) {
 
   const activeMarkerConfiguration = markerConfigurations.find(
     (markerConfig) => markerConfig.type === activeMarkerConfigurationType
+  );
+  const activeMapModePlugin = plugins.find(
+    (plugin) => plugin.type === activeMarkerConfigurationType
   );
 
   const updateMarkerConfigurations = useCallback(
@@ -842,6 +847,9 @@ function MapAnalysisImpl(props: ImplProps) {
                         entities={studyEntities}
                         subsettingClient={subsettingClient}
                         filters={filters}
+                        littleFilters={activeMapModePlugin?.getLittleFilters?.(
+                          mapTypeMapLayerProps
+                        )}
                         starredVariables={
                           analysisState.analysis?.descriptor.starredVariables ??
                           []

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -86,6 +86,7 @@ import { FetchClientError } from '@veupathdb/http-utils';
 import { Page } from '@veupathdb/wdk-client/lib/Components';
 import { Link } from 'react-router-dom';
 import { AnalysisError } from '../../core/components/AnalysisError';
+import { useDeepValue } from '../../core/hooks/immutability';
 
 const plugins = [barMarkerPlugin, bubbleMarkerPlugin, donutMarkerPlugin];
 
@@ -783,6 +784,14 @@ function MapAnalysisImpl(props: ImplProps) {
       ? donutMarkerPlugin
       : undefined;
 
+  // we have to wrap the `getLittleFilters` call in a hook to get a stable value
+  const littleFilters = useDeepValue(
+    activeMapModePlugin?.getLittleFilters?.({
+      configuration: activeMarkerConfiguration,
+      studyEntities,
+    })
+  );
+
   return (
     <PromiseResult state={appsPromiseState}>
       {(apps: ComputationAppOverview[]) => {
@@ -847,9 +856,7 @@ function MapAnalysisImpl(props: ImplProps) {
                         entities={studyEntities}
                         subsettingClient={subsettingClient}
                         filters={filters}
-                        littleFilters={activeMapModePlugin?.getLittleFilters?.(
-                          mapTypeMapLayerProps
-                        )}
+                        littleFilters={littleFilters}
                         starredVariables={
                           analysisState.analysis?.descriptor.starredVariables ??
                           []

--- a/packages/libs/eda/src/lib/map/analysis/TimeSliderQuickFilter.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/TimeSliderQuickFilter.tsx
@@ -26,6 +26,7 @@ interface Props {
   // to handle filters
   subsettingClient: SubsettingClient;
   filters: Filter[] | undefined;
+  littleFilters: Filter[] | undefined;
   starredVariables: VariableDescriptor[];
   toggleStarredVariable: (targetVariableId: VariableDescriptor) => void;
 
@@ -39,13 +40,14 @@ export default function TimeSliderQuickFilter({
   entities,
   subsettingClient,
   filters,
+  littleFilters,
   starredVariables,
   toggleStarredVariable,
   config,
   updateConfig,
   siteInformation,
 }: Props) {
-  const findEntityAndVariable = useFindEntityAndVariable(filters); // filter sensitivity
+  const findEntityAndVariable = useFindEntityAndVariable(filters); // filter sensitivity only on main filters
   const theme = useUITheme();
   const [minimized, setMinimized] = useState(true);
 
@@ -106,7 +108,7 @@ export default function TimeSliderQuickFilter({
         variable.variableId,
         {
           valueSpec: 'count',
-          filters: filters ?? [],
+          filters: [...(filters ?? []), ...(littleFilters ?? [])],
           binSpec,
         }
       );
@@ -125,6 +127,7 @@ export default function TimeSliderQuickFilter({
       variable,
       subsettingClient,
       filters,
+      littleFilters,
       extendedDisplayRange?.start,
       extendedDisplayRange?.end,
     ])

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -68,6 +68,7 @@ import { MapTypeHeaderCounts } from '../MapTypeHeaderCounts';
 const displayName = 'Bar plots';
 
 export const plugin: MapTypePlugin = {
+  type: 'barplot',
   displayName,
   ConfigPanelComponent,
   MapLayerComponent,

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -57,6 +57,7 @@ import { MapTypeHeaderCounts } from '../MapTypeHeaderCounts';
 const displayName = 'Bubbles';
 
 export const plugin: MapTypePlugin = {
+  type: 'bubble',
   displayName,
   ConfigPanelComponent: BubbleMapConfigurationPanel,
   MapLayerComponent: BubbleMapLayer,

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -15,6 +15,7 @@ import {
 import { useCallback, useMemo } from 'react';
 import { UNSELECTED_DISPLAY_TEXT, UNSELECTED_TOKEN } from '../../../constants';
 import {
+  Filter,
   StandaloneMapMarkersResponse,
   StringVariable,
   Variable,
@@ -47,6 +48,7 @@ import {
   MapTypeConfigPanelProps,
   MapTypeMapLayerProps,
   MapTypePlugin,
+  GetLittleFiltersProps,
 } from '../types';
 import DraggableVisualization from '../../DraggableVisualization';
 import { useStandaloneVizPlugins } from '../../hooks/standaloneVizPlugins';
@@ -461,7 +463,7 @@ function MapTypeHeaderDetails(props: MapTypeMapLayerProps) {
   ) : null;
 }
 
-function getLittleFilters(props: MapTypeConfigPanelProps) {
+function getLittleFilters(props: GetLittleFiltersProps) {
   const configuration = props.configuration as PieMarkerConfiguration;
   const { selectedVariable } = configuration;
 

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -16,6 +16,7 @@ import { useCallback, useMemo } from 'react';
 import { UNSELECTED_DISPLAY_TEXT, UNSELECTED_TOKEN } from '../../../constants';
 import {
   StandaloneMapMarkersResponse,
+  StringSetFilter,
   Variable,
   useFindEntityAndVariable,
   useSubsettingClient,
@@ -63,12 +64,35 @@ import { MapTypeHeaderCounts } from '../MapTypeHeaderCounts';
 const displayName = 'Donuts';
 
 export const plugin: MapTypePlugin = {
+  type: 'pie',
   displayName,
   ConfigPanelComponent,
   MapLayerComponent,
   MapOverlayComponent,
   MapTypeHeaderDetails,
+  getLittleFilters,
 };
+
+// TO DO: This function may only need the `configuration` arg/prop
+function getLittleFilters(props: MapTypeConfigPanelProps) {
+  const configuration = props.configuration as PieMarkerConfiguration;
+
+  // FIXME TO DO: fully implement - this is just a test for low-cardinality vars
+  // The logic here can be shared with bar marker mode
+  if (
+    configuration.selectedValues?.length &&
+    !configuration.selectedValues.includes(UNSELECTED_TOKEN)
+  ) {
+    return [
+      {
+        ...configuration.selectedVariable,
+        type: 'stringSet' as const,
+        stringSet: configuration.selectedValues,
+      },
+    ];
+  }
+  return [];
+}
 
 function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
   const {

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
@@ -44,6 +44,11 @@ export interface MapTypeMapLayerProps {
   setSelectedMarkers?: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
+export type GetLittleFiltersProps = Pick<
+  MapTypeMapLayerProps,
+  'configuration' | 'studyEntities'
+>;
+
 /**
  * A plugin containing the pieces needed to render
  * and configure a map type
@@ -76,5 +81,5 @@ export interface MapTypePlugin {
   /**
    * Returns a list of 'little' filters based on marker configuration
    */
-  getLittleFilters?: (props: MapTypeMapLayerProps) => Filter[];
+  getLittleFilters?: (props: GetLittleFiltersProps) => Filter[];
 }

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../core';
 import { GeoConfig } from '../../../core/types/geoConfig';
 import { ComputationAppOverview } from '../../../core/types/visualization';
-import { AppState } from '../appState';
+import { AppState, MarkerConfiguration } from '../appState';
 import { EntityCounts } from '../../../core/hooks/entityCounts';
 
 export interface MapTypeConfigPanelProps {
@@ -50,6 +50,10 @@ export interface MapTypeMapLayerProps {
  */
 export interface MapTypePlugin {
   /**
+   * Internal type
+   */
+  type: MarkerConfiguration['type'];
+  /**
    * Display name of map type used for menu, etc.
    */
   displayName: string;
@@ -69,4 +73,8 @@ export interface MapTypePlugin {
    * Returns a ReactNode that is rendered in the map header
    */
   MapTypeHeaderDetails?: ComponentType<MapTypeMapLayerProps>;
+  /**
+   * Returns a list of 'little' filters based on marker configuration
+   */
+  getLittleFilters?: (props: MapTypeMapLayerProps) => Filter[];
 }


### PR DESCRIPTION
I've added a `getLittleFilters` method to the map type plugin so that the implied little filters that a map type creates can be retrieved as actual filters.

It's partially implemented for donut map mode as a proof-of-concept.  When a string categorical variable is chosen, we will add a new filter to the timeslider data request in the following ways
1. filter on `variable in [ALL_VALUES]` when no values have been user-selected in the marker config table, or of "All other values" is in effect
2. filter on `variable in [USER_SELECTED_VALUES]` in all other cases.

We would need to do something for other variable types, and also implement for bubble numerator/denominator configs.

Is this a good way to go about this?

The places that need "explicit little filters" are
* timeslider and floating viz https://github.com/VEuPathDB/web-monorepo/issues/596 (UX debate needed maybe)
* when requesting sub-study counts in the new header in https://github.com/VEuPathDB/web-monorepo/issues/696
* also in #696 when requesting the list of sub-studies to display in the floater

In future possibly also https://github.com/VEuPathDB/web-monorepo/issues/548 