### PR TITLE
Fix excessive spinner behaviour when checking boxes in categorical marker config table

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
@@ -61,8 +61,6 @@ interface Props
    * Only defined and used in categorical table if selectedCountsOption is 'visible'
    */
   allVisibleCategoricalValues: AllValuesDefinition[] | undefined;
-  /* check if allFilteredCategoricalValues or allVisibleCategoricalValues is loading */
-  isAllCategoricalValuesLoading: boolean;
 }
 
 // TODO: generalize this and PieMarkerConfigMenu into MarkerConfigurationMenu. Lots of code repetition...
@@ -82,7 +80,6 @@ export function BarPlotMarkerConfigurationMenu({
   continuousMarkerPreview,
   allFilteredCategoricalValues,
   allVisibleCategoricalValues,
-  isAllCategoricalValuesLoading,
 }: Props) {
   /**
    * Used to track the CategoricalMarkerConfigurationTable's selection state, which allows users to
@@ -307,7 +304,6 @@ export function BarPlotMarkerConfigurationMenu({
                 : allVisibleCategoricalValues
             }
             selectedCountsOption={configuration.selectedCountsOption}
-            isAllCategoricalValuesLoading={isAllCategoricalValuesLoading}
           />
         </div>
       )}

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
@@ -18,7 +18,6 @@ type Props<T> = {
   setUncontrolledSelections: (v: Set<string>) => void;
   allCategoricalValues: AllValuesDefinition[] | undefined;
   selectedCountsOption: SelectedCountsOption;
-  isAllCategoricalValuesLoading: boolean;
 };
 
 const DEFAULT_SORTING: MesaSortObject = {
@@ -36,7 +35,6 @@ export function CategoricalMarkerConfigurationTable<T>({
   setUncontrolledSelections,
   allCategoricalValues = [],
   selectedCountsOption,
-  isAllCategoricalValuesLoading,
 }: Props<T>) {
   const [sort, setSort] = useState<MesaSortObject>(DEFAULT_SORTING);
   const totalCount = allCategoricalValues?.reduce(
@@ -212,10 +210,10 @@ export function CategoricalMarkerConfigurationTable<T>({
           maxWidth: '340px',
           maxHeight: 300,
           minHeight: 60,
-          overflow: isAllCategoricalValuesLoading ? 'none' : 'auto',
+          overflow: 'auto',
         }}
       >
-        {isAllCategoricalValuesLoading ? (
+        {tableState.rows.length === 0 ? (
           <Spinner
             size={50}
             styleOverrides={{

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
@@ -57,8 +57,6 @@ interface Props
    * Only defined and used in categorical table if selectedCountsOption is 'visible'
    */
   allVisibleCategoricalValues: AllValuesDefinition[] | undefined;
-  /* check if allFilteredCategoricalValues or allVisibleCategoricalValues is loading */
-  isAllCategoricalValuesLoading: boolean;
 }
 
 // TODO: generalize this and BarPlotMarkerConfigMenu into MarkerConfigurationMenu. Lots of code repetition...
@@ -78,7 +76,6 @@ export function PieMarkerConfigurationMenu({
   continuousMarkerPreview,
   allFilteredCategoricalValues,
   allVisibleCategoricalValues,
-  isAllCategoricalValuesLoading,
 }: Props) {
   /**
    * Used to track the CategoricalMarkerConfigurationTable's selection state, which allows users to
@@ -241,7 +238,6 @@ export function PieMarkerConfigurationMenu({
               : allVisibleCategoricalValues
           }
           selectedCountsOption={configuration.selectedCountsOption}
-          isAllCategoricalValuesLoading={isAllCategoricalValuesLoading}
         />
       )}
       {overlayConfiguration?.overlayType === 'continuous' && barplotData.value && (

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -256,13 +256,6 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
         analysisState.analysis?.descriptor.starredVariables ?? []
       }
       toggleStarredVariable={toggleStarredVariable}
-      // pass react-query's isLoading (allXXXCategoricalValues) or isFetching (overlayConfiguration)
-      isAllCategoricalValuesLoading={
-        overlayConfiguration.isFetching ||
-        (configuration.selectedCountsOption === 'filtered'
-          ? allFilteredCategoricalValues.isLoading
-          : allVisibleCategoricalValues.isLoading)
-      }
     />
   );
 

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -220,13 +220,6 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
         analysisState.analysis?.descriptor.starredVariables ?? []
       }
       toggleStarredVariable={toggleStarredVariable}
-      // pass react-query's isLoading (allXXXCategoricalValues) or isFetching (overlayConfiguration)
-      isAllCategoricalValuesLoading={
-        overlayConfiguration.isFetching ||
-        (configuration.selectedCountsOption === 'filtered'
-          ? allFilteredCategoricalValues.isLoading
-          : allVisibleCategoricalValues.isLoading)
-      }
     />
   );
 


### PR DESCRIPTION
Going back to a very simple solution: replacing the "No results" placeholder table with a spinner. This only showed when Mesa received an empty table. We now anticipate this and show the spinner instead.  There is no more dependence on `isLoading` or `isFetching` of the various data requests.

We still need to revisit and do https://github.com/VEuPathDB/web-monorepo/issues/726 at some point.
