### PR TITLE
Map sync header list

### DIFF
--- a/packages/libs/eda/src/lib/core/hooks/analysis.ts
+++ b/packages/libs/eda/src/lib/core/hooks/analysis.ts
@@ -489,7 +489,6 @@ export function useAnalysisList(analysisClient: AnalysisClient) {
   const [error, setError] = useState<string>();
 
   const loadList = useCallback(() => {
-    console.log('loading analyses list');
     setLoading(true);
     analysisClient.getAnalyses().then(
       (analyses) => {
@@ -505,11 +504,14 @@ export function useAnalysisList(analysisClient: AnalysisClient) {
 
   useEffect(() => {
     loadList();
-  }, [loadList]);
-
-  useEffect(() => {
     // TODO Merge in change!
-    return analysisEventEmitter.onAnalysisUpdate(loadList);
+    return analysisEventEmitter.onAnalysisUpdate((analysis) => {
+      setAnalyses((analyses) =>
+        analyses?.map((a) =>
+          a.analysisId === analysis.analysisId ? { ...a, ...analysis } : a
+        )
+      );
+    });
   }, [loadList]);
 
   const deleteAnalysis = useCallback(

--- a/packages/libs/eda/src/lib/core/hooks/analysis.ts
+++ b/packages/libs/eda/src/lib/core/hooks/analysis.ts
@@ -21,6 +21,7 @@ import { createComputation } from '../components/computations/Utils';
 import { useHistory } from 'react-router-dom';
 import { getStudyId } from '@veupathdb/study-data-access/lib/shared/studies';
 import { Computation, Visualization } from '../types/visualization';
+import EventEmitter from 'events';
 
 /**
  * Type definition for function that will set an attribute of an Analysis.
@@ -101,6 +102,38 @@ export type AnalysisState = {
 
 // Used to store loaded analyses. Looks to be a performance enhancement.
 const analysisCache = new Map<string, Analysis>();
+
+class AnalysisEventEmitter {
+  private _emitter = new EventEmitter();
+  private _analysisUpdateEvent = 'analysis_update';
+  private _listUpdateEvent = 'list_update';
+
+  onAnalysisUpdate(callback: (analysis: Analysis) => void) {
+    const { _emitter, _analysisUpdateEvent } = this;
+    _emitter.on(_analysisUpdateEvent, callback);
+    return function cancel() {
+      _emitter.off(_analysisUpdateEvent, callback);
+    };
+  }
+
+  onListUpdate(callback: (analysisList: AnalysisSummary[]) => void) {
+    const { _emitter, _listUpdateEvent } = this;
+    _emitter.on(_listUpdateEvent, callback);
+    return function cancel() {
+      _emitter.off(_listUpdateEvent, callback);
+    };
+  }
+
+  triggerAnalysisUpdate(analysis: Analysis) {
+    this._emitter.emit(this._analysisUpdateEvent, analysis);
+  }
+
+  triggerListUpdate(list: AnalysisSummary[]) {
+    this._emitter.emit(this._listUpdateEvent, list);
+  }
+}
+
+const analysisEventEmitter = new AnalysisEventEmitter();
 
 /**
  * Provide access to a user created analysis and associated functionality.
@@ -199,6 +232,7 @@ export function useAnalysis(
     else if (analysis !== analysisCache.get(analysis.analysisId)) {
       await analysisClient.updateAnalysis(analysis.analysisId, analysis);
       analysisCache.set(analysis.analysisId, analysis);
+      analysisEventEmitter.triggerAnalysisUpdate(analysis);
     }
   }, [analysisClient, createAnalysis]);
 
@@ -360,7 +394,7 @@ export function useAnalysis(
   );
 
   // Retrieve an Analysis from the data store whenever `analysisID` updates.
-  useEffect(() => {
+  const loadAnalysis = useCallback(() => {
     setUpdateScheduled(false);
     if (analysisId == null) {
       setStatus(Status.Loaded);
@@ -387,7 +421,26 @@ export function useAnalysis(
         );
       }
     }
-  }, [defaultAnalysis, analysisId, analysisClient]);
+  }, [analysisClient, analysisId, defaultAnalysis]);
+
+  useEffect(() => {
+    loadAnalysis();
+  }, [loadAnalysis]);
+
+  useEffect(() => {
+    // TODO only update if the active analysis has changed... or merge in the change!
+    return analysisEventEmitter.onListUpdate((list) => {
+      if (analysisId == null) return;
+      const update = list.find((summary) => summary.analysisId === analysisId);
+      if (update) {
+        setAnalysis((analysis) => analysis && { ...analysis, ...update });
+        const analysis = analysisCache.get(analysisId);
+        if (analysis) {
+          analysisCache.set(analysisId, { ...analysis, ...update });
+        }
+      }
+    });
+  }, [analysisId, loadAnalysis]);
 
   // Reactively save analysis when it has been modified
   useEffect(() => {
@@ -434,7 +487,9 @@ export function useAnalysisList(analysisClient: AnalysisClient) {
   const [analyses, setAnalyses] = useState<AnalysisSummary[]>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
-  useEffect(() => {
+
+  const loadList = useCallback(() => {
+    console.log('loading analyses list');
     setLoading(true);
     analysisClient.getAnalyses().then(
       (analyses) => {
@@ -447,6 +502,15 @@ export function useAnalysisList(analysisClient: AnalysisClient) {
       }
     );
   }, [analysisClient]);
+
+  useEffect(() => {
+    loadList();
+  }, [loadList]);
+
+  useEffect(() => {
+    // TODO Merge in change!
+    return analysisEventEmitter.onAnalysisUpdate(loadList);
+  }, [loadList]);
 
   const deleteAnalysis = useCallback(
     async (id: string) => {
@@ -497,6 +561,11 @@ export function useAnalysisList(analysisClient: AnalysisClient) {
       setLoading(true);
       try {
         await analysisClient.updateAnalysis(id, patch);
+        const analysis = analysisCache.get(id);
+        if (analysis) {
+          analysisCache.set(id, { ...analysis, ...patch });
+        }
+        analysisCache.delete(id);
         setAnalyses(
           (analyses) =>
             analyses &&
@@ -512,6 +581,10 @@ export function useAnalysisList(analysisClient: AnalysisClient) {
     },
     [analysisClient]
   );
+
+  useEffect(() => {
+    if (analyses) analysisEventEmitter.triggerListUpdate(analyses);
+  }, [analyses]);
 
   return {
     analyses,

--- a/packages/libs/eda/src/lib/map/MapVeuAnalysisList.tsx
+++ b/packages/libs/eda/src/lib/map/MapVeuAnalysisList.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback } from 'react';
-import { makeNewAnalysis, useStudyRecord } from '../core';
+import { makeNewAnalysis, useAnalysisList, useStudyRecord } from '../core';
 import { useRouteMatch, Link, useHistory } from 'react-router-dom';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { AnalysisClient } from '../core/api/AnalysisClient';
-import { usePromise } from '../core/hooks/promise';
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { createComputation } from '../core/components/computations/Utils';
 
@@ -16,12 +15,8 @@ interface Props {
 export function AnalysisList(props: Props) {
   const { analysisStore, studyId, singleAppMode } = props;
   const studyRecord = useStudyRecord();
-  const list = usePromise(
-    useCallback(async () => {
-      const analyses = await analysisStore.getAnalyses();
-      return analyses.filter((analysis) => analysis.studyId === studyId);
-    }, [studyId, analysisStore])
-  );
+  const { analyses } = useAnalysisList(analysisStore);
+  const list = analyses?.filter((analysis) => analysis.studyId === studyId);
   const { url } = useRouteMatch();
   const history = useHistory();
   const createAnalysis = useCallback(async () => {
@@ -51,13 +46,13 @@ export function AnalysisList(props: Props) {
           New Analysis
         </button>
       </div>
-      {list.pending ? (
+      {list == null ? (
         <Loading />
-      ) : list.value?.length === 0 ? (
+      ) : list.length === 0 ? (
         <em>You do not have any analyses for this study.</em>
       ) : (
         <ul>
-          {list.value?.map((analysis) => (
+          {list.map((analysis) => (
             <li key={analysis.analysisId}>
               <Link to={`${url}/${analysis.analysisId}`}>
                 {safeHtml(analysis.displayName)}


### PR DESCRIPTION
fixes #675

This PR uses an EventEmitter to keeps changes to analyses synchronized between the `useAnalysis` and `useAnalysisList` hooks.