### PR TITLE
allow plot references to be null or omitted

### DIFF
--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -87,17 +87,20 @@ const variableSpec = type({
 });
 
 export type PlotReferenceValue = TypeOf<typeof plotReferenceValue>;
-const plotReferenceValue = keyof({
-  xAxis: null,
-  yAxis: null,
-  zAxis: null,
-  overlay: null,
-  facet1: null,
-  facet2: null,
-  geo: null,
-  latitude: null,
-  longitude: null,
-});
+const plotReferenceValue = union([
+  keyof({
+    xAxis: null,
+    yAxis: null,
+    zAxis: null,
+    overlay: null,
+    facet1: null,
+    facet2: null,
+    geo: null,
+    latitude: null,
+    longitude: null,
+  }),
+  nullType,
+]);
 
 export type API_VariableType = TypeOf<typeof API_VariableType>;
 const API_VariableType = keyof({
@@ -122,13 +125,13 @@ export const VariableMapping = intersection([
   type({
     variableClass,
     variableSpec,
-    plotReference: plotReferenceValue,
     dataType: API_VariableType,
     dataShape: API_VariableDataShape,
     isCollection: boolean,
     imputeZero: boolean,
   }),
   partial({
+    plotReference: plotReferenceValue,
     displayName: string,
     displayRangeMin: union([string, number]),
     displayRangeMax: union([string, number]),


### PR DESCRIPTION
wip

i made this change so i could test some backend changes locally, but would like to know if people have reasons why i shouldnt merge it. mostly im collecting thoughts/ opinions right now, if anyone has any.

i made a change in https://github.com/VEuPathDB/EdaDataService/pull/342 that means sometimes well see empty plot refs. theyre just variables that i am keeping track of for one reason or another but arent actually in the plot. in this case it was so they could be used to properly impute zeroes in the popbio megastudy.

there is also a pr to discuss what these should actually look like as json https://github.com/VEuPathDB/veupathUtils/pull/33

