### PR TITLE
Configure legacy UDs in EDA sites

### DIFF
--- a/packages/libs/web-common/package.json
+++ b/packages/libs/web-common/package.json
@@ -55,6 +55,7 @@
     "@veupathdb/react-scripts": "workspace:^",
     "@veupathdb/study-data-access": "workspace:^",
     "@veupathdb/user-datasets": "workspace:^",
+    "@veupathdb/user-datasets-legacy": "workspace:^",
     "bubleify": "^2.0.0",
     "icon-font-generator": "^2.1.11",
     "ify-loader": "^1.1.0",

--- a/packages/libs/web-common/src/hooks/diyStudySummaries.tsx
+++ b/packages/libs/web-common/src/hooks/diyStudySummaries.tsx
@@ -6,7 +6,8 @@ import { keyBy } from 'lodash';
 
 import { Link } from '@veupathdb/wdk-client/lib/Components';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
-import { assertIsVdiCompatibleWdkService } from '@veupathdb/user-datasets/lib/Service';
+// import { assertIsVdiCompatibleWdkService } from '@veupathdb/user-datasets/lib/Service';
+import { assertIsUserDatasetCompatibleWdkService } from '@veupathdb/user-datasets-legacy/lib/Service/UserDatasetWrappers';
 
 import { useDiyDatasets } from './diyDatasets';
 
@@ -70,7 +71,7 @@ export function useDiyStudySummaryRows(): UserStudySummaryRow[] | undefined {
 
   const currentUserDatasets = useWdkService(
     async (wdkService) => {
-      assertIsVdiCompatibleWdkService(wdkService);
+      assertIsUserDatasetCompatibleWdkService(wdkService);
       if (currentUser == null) {
         return undefined;
       }
@@ -94,10 +95,7 @@ export function useDiyStudySummaryRows(): UserStudySummaryRow[] | undefined {
       return undefined;
     }
 
-    const currentUserDatasetsById = keyBy(
-      currentUserDatasets,
-      ({ datasetId }) => datasetId
-    );
+    const currentUserDatasetsById = keyBy(currentUserDatasets, ({ id }) => id);
 
     return diyDatasets.flatMap((diyDataset) => {
       const userDataset = currentUserDatasetsById[diyDataset.userDatasetId];
@@ -111,14 +109,14 @@ export function useDiyStudySummaryRows(): UserStudySummaryRow[] | undefined {
           name: diyDataset.name,
           userDatasetWorkspaceUrl: diyDataset.userDatasetsRoute,
           edaWorkspaceUrl: `${diyDataset.baseEdaRoute}/new`,
-          summary: userDataset.summary ?? '',
+          summary: userDataset.meta.summary ?? '',
           owner:
-            userDataset.owner.userId === currentUser.id
+            userDataset.ownerUserId === currentUser.id
               ? 'Me'
-              : userDataset.owner.firstName + ' ' + userDataset.owner.lastName,
+              : userDataset.owner,
           sharedWith:
-            userDataset.shares
-              ?.map(({ firstName, lastName }) => `${firstName} ${lastName}`)
+            userDataset.sharedWith
+              ?.map(({ userDisplayName }) => userDisplayName)
               ?.join(', ') ?? '',
         },
       ];

--- a/packages/sites/clinepi-site/package.json
+++ b/packages/sites/clinepi-site/package.json
@@ -43,7 +43,7 @@
     "@veupathdb/site-tsconfig": "workspace:^",
     "@veupathdb/site-webpack-config": "workspace:^",
     "@veupathdb/study-data-access": "workspace:^",
-    "@veupathdb/user-datasets": "workspace:^",
+    "@veupathdb/user-datasets-legacy": "workspace:^",
     "@veupathdb/wdk-client": "workspace:^",
     "@veupathdb/web-common": "workspace:^",
     "babel-loader": "^8.3.0",

--- a/packages/sites/clinepi-site/webapp/js/client/controllers/UserDatasetRouter.tsx
+++ b/packages/sites/clinepi-site/webapp/js/client/controllers/UserDatasetRouter.tsx
@@ -1,1 +1,1 @@
-export { UserDatasetRouter as default } from '@veupathdb/user-datasets/lib/Controllers/UserDatasetRouter';
+export { UserDatasetRouter as default } from '@veupathdb/user-datasets-legacy/lib/Controllers/UserDatasetRouter';

--- a/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
+++ b/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
@@ -8,9 +8,9 @@ import { RouteEntry } from '@veupathdb/wdk-client/lib/Core/RouteEntry';
 import { makeEdaRoute, makeMapRoute } from '@veupathdb/web-common/lib/routes';
 import { diyUserDatasetIdToWdkRecordId } from '@veupathdb/wdk-client/lib/Utils/diyDatasets';
 
-import { UserDatasetDetailProps } from '@veupathdb/user-datasets/lib/Controllers/UserDatasetDetailController';
+import { UserDatasetDetailProps } from '@veupathdb/user-datasets-legacy/lib/Controllers/UserDatasetDetailController';
 
-import { uploadTypeConfig } from '@veupathdb/user-datasets/lib/Utils/upload-config';
+import { uploadTypeConfig } from '@veupathdb/user-datasets-legacy/lib/Utils/upload-config';
 
 import {
   communitySite,
@@ -25,7 +25,9 @@ import { useStudyMetadata } from '@veupathdb/eda/lib/core/hooks/study';
 
 const IsaDatasetDetail = React.lazy(
   () =>
-    import('@veupathdb/user-datasets/lib/Components/Detail/IsaDatasetDetail')
+    import(
+      '@veupathdb/user-datasets-legacy/lib/Components/Detail/IsaDatasetDetail'
+    )
 );
 
 const UserDatasetRouter = React.lazy(

--- a/packages/sites/clinepi-site/webapp/js/client/wrapStoreModules.js
+++ b/packages/sites/clinepi-site/webapp/js/client/wrapStoreModules.js
@@ -2,7 +2,7 @@ import { compose, identity, set } from 'lodash/fp';
 
 import { useUserDatasetsWorkspace } from '@veupathdb/web-common/lib/config';
 
-import { wrapStoreModules as addUserDatasetStoreModules } from '@veupathdb/user-datasets/lib/StoreModules';
+import { wrapStoreModules as addUserDatasetStoreModules } from '@veupathdb/user-datasets-legacy/lib/StoreModules';
 
 import * as accessRequest from './store-modules/AccessRequestStoreModule';
 import * as record from './store-modules/RecordStoreModule';

--- a/packages/sites/clinepi-site/webapp/js/client/wrapWdkService.ts
+++ b/packages/sites/clinepi-site/webapp/js/client/wrapWdkService.ts
@@ -1,16 +1,20 @@
 import { flowRight, identity, partial } from 'lodash';
 
 import {
+  endpoint,
+  datasetImportUrl,
   useUserDatasetsWorkspace,
-  vdiServiceUrl,
+  // vdiServiceUrl,
 } from '@veupathdb/web-common/lib/config';
 
-import { wrapWdkService as addUserDatasetServices } from '@veupathdb/user-datasets/lib/Service';
+import { wrapWdkService as addUserDatasetServices } from '@veupathdb/user-datasets-legacy/lib/Service';
 
 export default flowRight(
   useUserDatasetsWorkspace
     ? partial(addUserDatasetServices, {
-        vdiServiceUrl,
+        datasetImportUrl,
+        fullWdkServiceUrl: `${window.location.origin}${endpoint}`,
+        // vdiServiceUrl,
       })
     : identity
 );

--- a/packages/sites/mbio-site/package.json
+++ b/packages/sites/mbio-site/package.json
@@ -43,7 +43,7 @@
     "@veupathdb/site-tsconfig": "workspace:^",
     "@veupathdb/site-webpack-config": "workspace:^",
     "@veupathdb/study-data-access": "workspace:^",
-    "@veupathdb/user-datasets": "workspace:^",
+    "@veupathdb/user-datasets-legacy": "workspace:^",
     "@veupathdb/wdk-client": "workspace:^",
     "@veupathdb/web-common": "workspace:^",
     "babel-loader": "^8.3.0",

--- a/packages/sites/mbio-site/webapp/wdkCustomization/js/client/controllers/UserDatasetRouter.ts
+++ b/packages/sites/mbio-site/webapp/wdkCustomization/js/client/controllers/UserDatasetRouter.ts
@@ -1,1 +1,1 @@
-export { UserDatasetRouter as default } from '@veupathdb/user-datasets/lib/Controllers/UserDatasetRouter';
+export { UserDatasetRouter as default } from '@veupathdb/user-datasets-legacy/lib/Controllers/UserDatasetRouter';

--- a/packages/sites/mbio-site/webapp/wdkCustomization/js/client/routes/userDatasetRoutes.tsx
+++ b/packages/sites/mbio-site/webapp/wdkCustomization/js/client/routes/userDatasetRoutes.tsx
@@ -8,9 +8,9 @@ import { RouteEntry } from '@veupathdb/wdk-client/lib/Core/RouteEntry';
 import { makeEdaRoute } from '@veupathdb/web-common/lib/routes';
 import { diyUserDatasetIdToWdkRecordId } from '@veupathdb/wdk-client/lib/Utils/diyDatasets';
 
-import { UserDatasetDetailProps } from '@veupathdb/user-datasets/lib/Controllers/UserDatasetDetailController';
+import { UserDatasetDetailProps } from '@veupathdb/user-datasets-legacy/lib/Controllers/UserDatasetDetailController';
 
-import { uploadTypeConfig } from '@veupathdb/user-datasets/lib/Utils/upload-config';
+import { uploadTypeConfig } from '@veupathdb/user-datasets-legacy/lib/Utils/upload-config';
 
 import { communitySite, projectId } from '@veupathdb/web-common/lib/config';
 
@@ -18,7 +18,9 @@ import ExternalContentController from '@veupathdb/web-common/lib/controllers/Ext
 
 const BiomDatasetDetail = React.lazy(
   () =>
-    import('@veupathdb/user-datasets/lib/Components/Detail/BiomDatasetDetail')
+    import(
+      '@veupathdb/user-datasets-legacy/lib/Components/Detail/BiomDatasetDetail'
+    )
 );
 
 const UserDatasetRouter = React.lazy(

--- a/packages/sites/mbio-site/webapp/wdkCustomization/js/client/wrapStoreModules.js
+++ b/packages/sites/mbio-site/webapp/wdkCustomization/js/client/wrapStoreModules.js
@@ -4,7 +4,7 @@ import { getLeaves } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 
 import { useUserDatasetsWorkspace } from '@veupathdb/web-common/lib/config';
 
-import { wrapStoreModules as addUserDatasetStoreModules } from '@veupathdb/user-datasets/lib/StoreModules';
+import { wrapStoreModules as addUserDatasetStoreModules } from '@veupathdb/user-datasets-legacy/lib/StoreModules';
 
 /** Compose reducer functions from right to left */
 const composeReducers =

--- a/packages/sites/mbio-site/webapp/wdkCustomization/js/client/wrapWdkService.ts
+++ b/packages/sites/mbio-site/webapp/wdkCustomization/js/client/wrapWdkService.ts
@@ -1,16 +1,20 @@
 import { flowRight, identity, partial } from 'lodash';
 
 import {
+  endpoint,
+  datasetImportUrl,
   useUserDatasetsWorkspace,
-  vdiServiceUrl,
+  // vdiServiceUrl,
 } from '@veupathdb/web-common/lib/config';
 
-import { wrapWdkService as addUserDatasetServices } from '@veupathdb/user-datasets/lib/Service';
+import { wrapWdkService as addUserDatasetServices } from '@veupathdb/user-datasets-legacy/lib/Service';
 
 export default flowRight(
   useUserDatasetsWorkspace
     ? partial(addUserDatasetServices, {
-        vdiServiceUrl,
+        datasetImportUrl,
+        fullWdkServiceUrl: `${window.location.origin}${endpoint}`,
+        // vdiServiceUrl,
       })
     : identity
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8053,7 +8053,7 @@ __metadata:
     "@veupathdb/site-tsconfig": "workspace:^"
     "@veupathdb/site-webpack-config": "workspace:^"
     "@veupathdb/study-data-access": "workspace:^"
-    "@veupathdb/user-datasets": "workspace:^"
+    "@veupathdb/user-datasets-legacy": "workspace:^"
     "@veupathdb/wdk-client": "workspace:^"
     "@veupathdb/web-common": "workspace:^"
     babel-loader: ^8.3.0
@@ -8472,7 +8472,7 @@ __metadata:
     "@veupathdb/site-tsconfig": "workspace:^"
     "@veupathdb/site-webpack-config": "workspace:^"
     "@veupathdb/study-data-access": "workspace:^"
-    "@veupathdb/user-datasets": "workspace:^"
+    "@veupathdb/user-datasets-legacy": "workspace:^"
     "@veupathdb/wdk-client": "workspace:^"
     "@veupathdb/web-common": "workspace:^"
     babel-loader: ^8.3.0
@@ -8817,7 +8817,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@veupathdb/user-datasets-legacy@workspace:packages/libs/user-datasets-legacy":
+"@veupathdb/user-datasets-legacy@workspace:^, @veupathdb/user-datasets-legacy@workspace:packages/libs/user-datasets-legacy":
   version: 0.0.0-use.local
   resolution: "@veupathdb/user-datasets-legacy@workspace:packages/libs/user-datasets-legacy"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9064,6 +9064,7 @@ __metadata:
     "@veupathdb/react-scripts": "workspace:^"
     "@veupathdb/study-data-access": "workspace:^"
     "@veupathdb/user-datasets": "workspace:^"
+    "@veupathdb/user-datasets-legacy": "workspace:^"
     "@veupathdb/wdk-client": "workspace:^"
     bubleify: ^2.0.0
     custom-event-polyfill: ^1.0.7


### PR DESCRIPTION
This branch configures EDA sites to use the current ("legacy") version of UDs rather than VDI. Previous work duplicated the "legacy" version of the `user-datasets` package and named it `user-datasets-legacy` since VDI is being integrated into the `user-datasets` package.