### PR TITLE
limits decimal points for SAM barplot marker

### DIFF
--- a/packages/libs/components/src/plots/Barplot.tsx
+++ b/packages/libs/components/src/plots/Barplot.tsx
@@ -121,7 +121,12 @@ const Barplot = makePlotlyPlotComponent(
               orientation: orientation === 'vertical' ? 'v' : 'h',
               opacity: calculatedOpacity,
               type: 'bar',
-              text: showValues ? el.value : undefined,
+              // two decimal points for y values
+              text: showValues
+                ? el.value.map(
+                    (value: number) => `${Number.parseFloat(value.toFixed(2))}`
+                  )
+                : undefined,
               textposition: showValues ? 'auto' : undefined,
               marker: {
                 color: el.color,


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/760.

Screenshots are attached for before and after this PR. SCORE S. mansoni Cluster Randomized Trial is used.

# before
![SAM bar decimal points1](https://github.com/VEuPathDB/web-monorepo/assets/12802305/9821b033-c882-482f-a446-e7d7acd3419d)


# after
![SAM bar decimal points2](https://github.com/VEuPathDB/web-monorepo/assets/12802305/13228360-2d65-4254-b68f-ebdff0835028)
