### PR TITLE
Feature 747 bpnet nodata ux

### DIFF
--- a/packages/libs/components/src/plots/BipartiteNetwork.tsx
+++ b/packages/libs/components/src/plots/BipartiteNetwork.tsx
@@ -5,6 +5,7 @@ import { Graph } from '@visx/network';
 import { Text } from '@visx/text';
 import {
   CSSProperties,
+  ReactNode,
   Ref,
   forwardRef,
   useImperativeHandle,
@@ -42,6 +43,8 @@ export interface BipartiteNetworkProps {
   showSpinner?: boolean;
   /** Length of node label text before truncating with an ellipsis */
   labelTruncationLength?: number;
+  /** Additional error messaging to show when the network is empty */
+  emptyNetworkContent?: ReactNode;
 }
 
 // Show a few gray nodes when there is no real data.
@@ -71,6 +74,7 @@ function BipartiteNetwork(
     containerClass = 'web-components-plot',
     showSpinner = false,
     labelTruncationLength = 20,
+    emptyNetworkContent,
   } = props;
 
   // Use ref forwarding to enable screenshotting of the plot for thumbnail versions.
@@ -160,57 +164,65 @@ function BipartiteNetwork(
       style={{ width: '100%', ...containerStyles, position: 'relative' }}
     >
       <div ref={plotRef} style={{ width: '100%', height: '100%' }}>
-        <svg
-          width={svgStyles.width}
-          height={
-            Math.max(data.column1NodeIDs.length, data.column2NodeIDs.length) *
-              svgStyles.nodeSpacing +
-            svgStyles.topPadding
-          }
-        >
-          {/* Draw names of node colums if they exist */}
-          {column1Name && (
-            <Text
-              x={column1Position}
-              y={svgStyles.topPadding / 2}
-              textAnchor="end"
-              className="BipartiteNetworkColumnTitle"
-            >
-              {column1Name}
-            </Text>
-          )}
-          {column2Name && (
-            <Text
-              x={column2Position}
-              y={svgStyles.topPadding / 2}
-              textAnchor="start"
-              className="BipartiteNetworkColumnTitle"
-            >
-              {column2Name}
-            </Text>
-          )}
+        {nodesByColumnWithCoordinates[0].length > 0 ? (
+          <svg
+            width={svgStyles.width}
+            height={
+              Math.max(data.column1NodeIDs.length, data.column2NodeIDs.length) *
+                svgStyles.nodeSpacing +
+              svgStyles.topPadding
+            }
+          >
+            {/* Draw names of node colums if they exist */}
+            {column1Name && (
+              <Text
+                x={column1Position}
+                y={svgStyles.topPadding / 2}
+                textAnchor="end"
+                className="BipartiteNetworkColumnTitle"
+              >
+                {column1Name}
+              </Text>
+            )}
+            {column2Name && (
+              <Text
+                x={column2Position}
+                y={svgStyles.topPadding / 2}
+                textAnchor="start"
+                className="BipartiteNetworkColumnTitle"
+              >
+                {column2Name}
+              </Text>
+            )}
 
-          <Graph
-            graph={{
-              nodes: nodesByColumnWithCoordinates[0].concat(
-                nodesByColumnWithCoordinates[1]
-              ),
-              links: linksWithCoordinates,
-            }}
-            // Using our Link component so that it uses our nice defaults and
-            // can better expand to handle more complex events (hover and such).
-            linkComponent={({ link }) => <Link link={link} />}
-            nodeComponent={({ node }) => {
-              const nodeWithLabelProps = {
-                node: node,
-                labelPosition: node.labelPosition,
-                truncationLength: labelTruncationLength,
-              };
-              return <NodeWithLabel {...nodeWithLabelProps} />;
-            }}
-          />
-        </svg>
-        {showSpinner && <Spinner />}
+            <Graph
+              graph={{
+                nodes: nodesByColumnWithCoordinates[0].concat(
+                  nodesByColumnWithCoordinates[1]
+                ),
+                links: linksWithCoordinates,
+              }}
+              // Using our Link component so that it uses our nice defaults and
+              // can better expand to handle more complex events (hover and such).
+              linkComponent={({ link }) => <Link link={link} />}
+              nodeComponent={({ node }) => {
+                const nodeWithLabelProps = {
+                  node: node,
+                  labelPosition: node.labelPosition,
+                  truncationLength: labelTruncationLength,
+                };
+                return <NodeWithLabel {...nodeWithLabelProps} />;
+              }}
+            />
+          </svg>
+        ) : (
+          emptyNetworkContent ?? <p>No nodes in the network</p>
+        )}
+        {
+          // Note that the spinner shows up in the middle of the network. So when
+          // the network is very long, the spinner will be further down the page than in other vizs.
+          showSpinner && <Spinner />
+        }
       </div>
     </div>
   );

--- a/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
+++ b/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, CSSProperties } from 'react';
+import { useState, useEffect, useRef, CSSProperties, ReactNode } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import {
   NodeData,
@@ -10,6 +10,7 @@ import BipartiteNetwork, {
   BipartiteNetworkSVGStyles,
 } from '../../plots/BipartiteNetwork';
 import { twoColorPalette } from '../../types/plots/addOns';
+import { Text } from '@visx/text';
 
 export default {
   title: 'Plots/Network/BipartiteNetwork',
@@ -25,6 +26,7 @@ interface TemplateProps {
   containerStyles?: CSSProperties;
   svgStyleOverrides?: BipartiteNetworkSVGStyles;
   labelTruncationLength?: number;
+  emptyNetworkContent?: ReactNode;
 }
 
 // Template for showcasing our BipartiteNetwork component.
@@ -49,6 +51,7 @@ const Template: Story<TemplateProps> = (args) => {
     containerStyles: args.containerStyles,
     svgStyleOverrides: args.svgStyleOverrides,
     labelTruncationLength: args.labelTruncationLength,
+    emptyNetworkContent: args.emptyNetworkContent,
   };
   return (
     <>
@@ -134,6 +137,19 @@ WithStyle.args = {
   column2Name: 'Column 2',
   svgStyleOverrides: svgStyleOverrides,
   labelTruncationLength: 5,
+};
+
+// With a network that has no nodes or links
+const noNodesData = genBipartiteNetwork(0, 0);
+const emptyNetworkContent = (
+  <Text x={100} y={100}>
+    No nodes or links
+  </Text>
+);
+export const NoNodes = Template.bind({});
+NoNodes.args = {
+  data: noNodesData,
+  emptyNetworkContent,
 };
 
 // Gerenate a bipartite network with a given number of nodes and random edges

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BipartiteNetworkVisualization.tsx
@@ -43,6 +43,7 @@ import { NumberInput } from '@veupathdb/components/lib/components/widgets/Number
 import { NumberOrDate } from '@veupathdb/components/lib/types/general';
 import { useVizConfig } from '../../../hooks/visualizations';
 import { FacetedPlotLayout } from '../../layouts/FacetedPlotLayout';
+import { H6 } from '@veupathdb/coreui';
 // end imports
 
 // Defaults
@@ -106,7 +107,7 @@ function BipartiteNetworkViz(props: VisualizationProps<Options>) {
   const { id: studyId } = studyMetadata;
   const entities = useStudyEntities(filters);
   const dataClient: DataClient = useDataClient();
-  // todo  allow this to also be CorrelationAssayAssayConfig
+
   const computationConfiguration:
     | CorrelationAssayMetadataConfig
     | CorrelationAssayAssayConfig = computation.descriptor.configuration as
@@ -267,12 +268,32 @@ function BipartiteNetworkViz(props: VisualizationProps<Options>) {
     [cleanedData]
   );
 
+  // Have the bpnet component say "No nodes" or whatev and have an extra
+  // prop called errorMessage or something that displays when there are no nodes.
+  // that error message can say "your thresholds of blah and blah are too high, change them"
+  const emptyNetworkContent = (
+    <div
+      style={{
+        height: 400,
+        textAlign: 'center',
+        top: '50%',
+        transform: 'translateY(40%)',
+      }}
+    >
+      <H6>No correlation results pass the configured thresholds.</H6>
+      <br />
+      <br />
+      Adjust the correlation magnitude and p-value thresholds to continue.
+    </div>
+  );
+
   const bipartiteNetworkProps: BipartiteNetworkProps = {
     data: cleanedData ?? undefined,
     showSpinner: data.pending,
     containerStyles: finalPlotContainerStyles,
     svgStyleOverrides: bipartiteNetworkSVGStyles,
     labelTruncationLength: 40,
+    emptyNetworkContent,
   };
 
   const plotNode = (
@@ -336,7 +357,7 @@ function BipartiteNetworkViz(props: VisualizationProps<Options>) {
     },
   ];
 
-  const legendNode = cleanedData && (
+  const legendNode = cleanedData && cleanedData.nodes.length > 0 && (
     <div className="MultiLegendContaner">
       <PlotLegend
         type="list"


### PR DESCRIPTION
Resolves #747 

In progress. Adds a nice way to render a custom node when the network is totally empty. However, i'm stuck on getting those darn input boxes to change outline colors. I know they _can_ do it because they turn red with an error, but i gotta figure out how to make them yellow with a warning.

