### PR TITLE
Remove compute id from route

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -80,7 +80,7 @@ interface Props {
  */
 export function VisualizationsContainer(props: Props) {
   const { baseUrl } = { ...props };
-  const { url } = useRouteMatch();
+  // const { url } = useRouteMatch();
 
   const currentStudyRecordId = useStudyRecord().id[0].value;
   const studiesForPerformanceWarning = [
@@ -117,14 +117,14 @@ export function VisualizationsContainer(props: Props) {
         ></Banner>
       ) : null}
       <Switch>
-        <Route exact path={url}>
+        <Route exact path={baseUrl}>
           <ConfiguredVisualizations {...props} />
         </Route>
-        <Route exact path={`${baseUrl || url}/new`}>
+        <Route exact path={`${baseUrl}/new`}>
           <NewVisualizationPicker {...props} />
         </Route>
         <Route
-          path={`${baseUrl || url}/:id`}
+          path={`${baseUrl}/:id`}
           render={(routeProps: RouteComponentProps<{ id: string }>) => (
             <FullScreenVisualization
               id={routeProps.match.params.id}
@@ -320,7 +320,7 @@ export function NewVisualizationPicker(props: NewVisualizationPickerProps) {
     computation,
     geoConfigs,
     onVisualizationCreated = function (visualizationId, computationId) {
-      history.replace(`../${computationId}/${visualizationId}`);
+      history.replace(`${visualizationId}`);
     },
     includeHeader = true,
   } = props;
@@ -592,10 +592,7 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
                       );
                     }
                     history.replace(
-                      Path.resolve(
-                        history.location.pathname,
-                        isSingleAppMode ? '..' : '../..'
-                      )
+                      Path.resolve(history.location.pathname, '..')
                     );
                   }}
                 >

--- a/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -80,8 +80,6 @@ interface Props {
  */
 export function VisualizationsContainer(props: Props) {
   const { baseUrl } = { ...props };
-  // const { url } = useRouteMatch();
-
   const currentStudyRecordId = useStudyRecord().id[0].value;
   const studiesForPerformanceWarning = [
     'DS_a885240fc4',
@@ -319,7 +317,7 @@ export function NewVisualizationPicker(props: NewVisualizationPickerProps) {
     visualizationsOverview,
     computation,
     geoConfigs,
-    onVisualizationCreated = function (visualizationId, computationId) {
+    onVisualizationCreated = function (visualizationId) {
       history.replace(`${visualizationId}`);
     },
     includeHeader = true,

--- a/packages/libs/eda/src/lib/workspace/ComputationRoute.tsx
+++ b/packages/libs/eda/src/lib/workspace/ComputationRoute.tsx
@@ -214,7 +214,7 @@ export function ComputationRoute(props: Props) {
                       routeProps.match.params.visualizationId
                     );
                   if (result == null) {
-                    return null;
+                    return <div>Cannot find visualization!</div>;
                   }
 
                   const { computation } = result;


### PR DESCRIPTION
Closes #778 

This PR removed the computation ID from the url of a visualization. This makes the url stable when changing the configuration of a compute.