### PR TITLE
draft some correlation prefilter inputs

### DIFF
--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -445,6 +445,15 @@ export interface BipartiteNetworkRequestParams {
   };
 }
 
+export type FeaturePrefilterThresholds = TypeOf<
+  typeof FeaturePrefilterThresholds
+>;
+export const FeaturePrefilterThresholds = type({
+  proportionNonZero: number,
+  variance: number,
+  standardDeviation: number,
+});
+
 ////////////////
 // Table Data //
 ////////////////

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -1,4 +1,7 @@
-import { useFindEntityAndVariableCollection } from '../../..';
+import {
+  FeaturePrefilterThresholds,
+  useFindEntityAndVariableCollection,
+} from '../../..';
 import { VariableCollectionDescriptor } from '../../../types/variable';
 import { ComputationConfigProps, ComputationPlugin } from '../Types';
 import { capitalize, partial } from 'lodash';
@@ -21,6 +24,7 @@ import { VariableCollectionSelectList } from '../../variableSelectors/VariableCo
 import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
 import { IsEnabledInPickerParams } from '../../visualizations/VisualizationTypes';
 import { entityTreeToArray } from '../../../utils/study-metadata';
+import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
@@ -45,6 +49,7 @@ export const CorrelationAssayAssayConfig = t.partial({
   collectionVariable1: VariableCollectionDescriptor,
   collectionVariable2: VariableCollectionDescriptor,
   correlationMethod: t.string,
+  prefilterThresholds: FeaturePrefilterThresholds,
 });
 
 const CompleteCorrelationAssayAssayConfig = partialToCompleteCodec(
@@ -136,6 +141,9 @@ function CorrelationAssayAssayConfigDescriptionComponent({
 }
 
 const CORRELATION_METHODS = ['spearman', 'pearson'];
+const DEFAULT_PROPORTION_NON_ZERO_THRESHOLD = 0.05;
+const DEFAULT_VARIANCE_THRESHOLD = 0;
+const DEFAULT_STANDARD_DEVIATION_THRESHOLD = 0;
 
 // Shows as Step 1 in the full screen visualization page
 export function CorrelationAssayAssayConfiguration(
@@ -200,6 +208,65 @@ export function CorrelationAssayAssayConfiguration(
                   display: capitalize(method),
                 }))}
                 onSelect={partial(changeConfigHandler, 'correlationMethod')}
+              />
+            </div>
+          </div>
+          <div className={cx('-CorrelationOuterConfigContainer')}>
+            <H6>Prefilters</H6>
+            <div className={cx('-InputContainer')}>
+              <span>Proportion non-zero</span>
+              <NumberInput
+                minValue={0}
+                maxValue={1}
+                step={0.01}
+                value={configuration.prefilterThresholds?.proportionNonZero}
+                onValueChange={(newValue) => {
+                  changeConfigHandler('prefilterThresholds', {
+                    proportionNonZero:
+                      Number(newValue) ?? DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+                    variance:
+                      configuration.prefilterThresholds?.variance ??
+                      DEFAULT_VARIANCE_THRESHOLD,
+                    standardDeviation:
+                      configuration.prefilterThresholds?.standardDeviation ??
+                      DEFAULT_STANDARD_DEVIATION_THRESHOLD,
+                  });
+                }}
+              />
+              <span>Variance</span>
+              <NumberInput
+                minValue={0}
+                step={1}
+                value={configuration.prefilterThresholds?.variance}
+                onValueChange={(newValue) => {
+                  changeConfigHandler('prefilterThresholds', {
+                    proportionNonZero:
+                      configuration.prefilterThresholds?.proportionNonZero ??
+                      DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+                    variance: Number(newValue) ?? DEFAULT_VARIANCE_THRESHOLD,
+                    standardDeviation:
+                      configuration.prefilterThresholds?.standardDeviation ??
+                      DEFAULT_STANDARD_DEVIATION_THRESHOLD,
+                  });
+                }}
+              />
+              <span>Standard deviation</span>
+              <NumberInput
+                minValue={0}
+                step={1}
+                value={configuration.prefilterThresholds?.standardDeviation}
+                onValueChange={(newValue) => {
+                  changeConfigHandler('prefilterThresholds', {
+                    proportionNonZero:
+                      configuration.prefilterThresholds?.proportionNonZero ??
+                      DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+                    variance:
+                      configuration.prefilterThresholds?.variance ??
+                      DEFAULT_VARIANCE_THRESHOLD,
+                    standardDeviation:
+                      Number(newValue) ?? DEFAULT_STANDARD_DEVIATION_THRESHOLD,
+                  });
+                }}
               />
             </div>
           </div>

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -219,7 +219,10 @@ export function CorrelationAssayAssayConfiguration(
                 minValue={0}
                 maxValue={1}
                 step={0.01}
-                value={configuration.prefilterThresholds?.proportionNonZero}
+                value={
+                  configuration.prefilterThresholds?.proportionNonZero ??
+                  DEFAULT_PROPORTION_NON_ZERO_THRESHOLD
+                }
                 onValueChange={(newValue) => {
                   changeConfigHandler('prefilterThresholds', {
                     proportionNonZero:
@@ -237,7 +240,10 @@ export function CorrelationAssayAssayConfiguration(
               <NumberInput
                 minValue={0}
                 step={1}
-                value={configuration.prefilterThresholds?.variance}
+                value={
+                  configuration.prefilterThresholds?.variance ??
+                  DEFAULT_VARIANCE_THRESHOLD
+                }
                 onValueChange={(newValue) => {
                   changeConfigHandler('prefilterThresholds', {
                     proportionNonZero:
@@ -254,7 +260,10 @@ export function CorrelationAssayAssayConfiguration(
               <NumberInput
                 minValue={0}
                 step={1}
-                value={configuration.prefilterThresholds?.standardDeviation}
+                value={
+                  configuration.prefilterThresholds?.standardDeviation ??
+                  DEFAULT_STANDARD_DEVIATION_THRESHOLD
+                }
                 onValueChange={(newValue) => {
                   changeConfigHandler('prefilterThresholds', {
                     proportionNonZero:

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -190,7 +190,10 @@ export function CorrelationAssayMetadataConfiguration(
               minValue={0}
               maxValue={1}
               step={0.01}
-              value={configuration.prefilterThresholds?.proportionNonZero}
+              value={
+                configuration.prefilterThresholds?.proportionNonZero ??
+                DEFAULT_PROPORTION_NON_ZERO_THRESHOLD
+              }
               onValueChange={(newValue) => {
                 changeConfigHandler('prefilterThresholds', {
                   proportionNonZero:
@@ -208,7 +211,10 @@ export function CorrelationAssayMetadataConfiguration(
             <NumberInput
               minValue={0}
               step={1}
-              value={configuration.prefilterThresholds?.variance}
+              value={
+                configuration.prefilterThresholds?.variance ??
+                DEFAULT_VARIANCE_THRESHOLD
+              }
               onValueChange={(newValue) => {
                 changeConfigHandler('prefilterThresholds', {
                   proportionNonZero:
@@ -225,7 +231,10 @@ export function CorrelationAssayMetadataConfiguration(
             <NumberInput
               minValue={0}
               step={1}
-              value={configuration.prefilterThresholds?.standardDeviation}
+              value={
+                configuration.prefilterThresholds?.standardDeviation ??
+                DEFAULT_STANDARD_DEVIATION_THRESHOLD
+              }
               onValueChange={(newValue) => {
                 changeConfigHandler('prefilterThresholds', {
                   proportionNonZero:

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -1,4 +1,7 @@
-import { useFindEntityAndVariableCollection } from '../../..';
+import {
+  FeaturePrefilterThresholds,
+  useFindEntityAndVariableCollection,
+} from '../../..';
 import { VariableCollectionDescriptor } from '../../../types/variable';
 import { ComputationConfigProps, ComputationPlugin } from '../Types';
 import { capitalize, partial } from 'lodash';
@@ -20,6 +23,7 @@ import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
 import { entityTreeToArray } from '../../../utils/study-metadata';
 import { IsEnabledInPickerParams } from '../../visualizations/VisualizationTypes';
 import { ancestorEntitiesForEntityId } from '../../../utils/data-element-constraints';
+import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
@@ -43,6 +47,7 @@ export type CorrelationAssayMetadataConfig = t.TypeOf<
 export const CorrelationAssayMetadataConfig = t.partial({
   collectionVariable: VariableCollectionDescriptor,
   correlationMethod: t.string,
+  prefilterThresholds: FeaturePrefilterThresholds,
 });
 
 const CompleteCorrelationAssayMetadataConfig = partialToCompleteCodec(
@@ -113,6 +118,9 @@ function CorrelationAssayMetadataConfigDescriptionComponent({
 }
 
 const CORRELATION_METHODS = ['spearman', 'pearson'];
+const DEFAULT_PROPORTION_NON_ZERO_THRESHOLD = 0.05;
+const DEFAULT_VARIANCE_THRESHOLD = 0;
+const DEFAULT_STANDARD_DEVIATION_THRESHOLD = 0;
 
 // Shows as Step 1 in the full screen visualization page
 export function CorrelationAssayMetadataConfiguration(
@@ -171,6 +179,65 @@ export function CorrelationAssayMetadataConfiguration(
                 display: capitalize(method),
               }))}
               onSelect={partial(changeConfigHandler, 'correlationMethod')}
+            />
+          </div>
+        </div>
+        <div className={cx('-CorrelationOuterConfigContainer')}>
+          <H6>Prefilters</H6>
+          <div className={cx('-InputContainer')}>
+            <span>Proportion non-zero</span>
+            <NumberInput
+              minValue={0}
+              maxValue={1}
+              step={0.01}
+              value={configuration.prefilterThresholds?.proportionNonZero}
+              onValueChange={(newValue) => {
+                changeConfigHandler('prefilterThresholds', {
+                  proportionNonZero:
+                    Number(newValue) ?? DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+                  variance:
+                    configuration.prefilterThresholds?.variance ??
+                    DEFAULT_VARIANCE_THRESHOLD,
+                  standardDeviation:
+                    configuration.prefilterThresholds?.standardDeviation ??
+                    DEFAULT_STANDARD_DEVIATION_THRESHOLD,
+                });
+              }}
+            />
+            <span>Variance</span>
+            <NumberInput
+              minValue={0}
+              step={1}
+              value={configuration.prefilterThresholds?.variance}
+              onValueChange={(newValue) => {
+                changeConfigHandler('prefilterThresholds', {
+                  proportionNonZero:
+                    configuration.prefilterThresholds?.proportionNonZero ??
+                    DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+                  variance: Number(newValue) ?? DEFAULT_VARIANCE_THRESHOLD,
+                  standardDeviation:
+                    configuration.prefilterThresholds?.standardDeviation ??
+                    DEFAULT_STANDARD_DEVIATION_THRESHOLD,
+                });
+              }}
+            />
+            <span>Standard deviation</span>
+            <NumberInput
+              minValue={0}
+              step={1}
+              value={configuration.prefilterThresholds?.standardDeviation}
+              onValueChange={(newValue) => {
+                changeConfigHandler('prefilterThresholds', {
+                  proportionNonZero:
+                    configuration.prefilterThresholds?.proportionNonZero ??
+                    DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+                  variance:
+                    configuration.prefilterThresholds?.variance ??
+                    DEFAULT_VARIANCE_THRESHOLD,
+                  standardDeviation:
+                    Number(newValue) ?? DEFAULT_STANDARD_DEVIATION_THRESHOLD,
+                });
+              }}
             />
           </div>
         </div>


### PR DESCRIPTION
so im not worried about this being 'good' or 'pretty'. i dont think this is a thing to release, just a thing to let people play w prefilters. then we can decide what we do and dont like for defaults, whether to offer user controls, if there are other things wed like to prefilter on, etc. then at that point presumably this gets reverted or obviated by some newer change.