### PR TITLE
Restrict inputs for functional associations app

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/Utils.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Utils.ts
@@ -65,8 +65,8 @@ export function removeAbsoluteAbundanceVariableCollections(
 /**
  * Returns false for absolute abundance variable collections, based on certain conditions.
  *
- * @param {CollectionVariableTreeNode} variableCollection - The array of variable collections.
- * @return {boolean} The filtered array of variable collections.
+ * @param {CollectionVariableTreeNode} variableCollection - A variable collection.
+ * @return {boolean} True if the collection is not an absolute abundance variable collection.
  */
 export function isNotAbsoluteAbundanceVariableCollection(
   variableCollection: CollectionVariableTreeNode
@@ -78,6 +78,33 @@ export function isNotAbsoluteAbundanceVariableCollection(
         !!variableCollection.displayName?.includes('pathway')
     : true;
   // DIY may not have the normalizationMethod annotations, but we still want those datasets to pass.
+}
+
+/**
+ * Returns true for taxonomic variable collections and false for all others.
+ *
+ * @param {CollectionVariableTreeNode} variableCollection - A variable collection.
+ * @return {boolean}
+ */
+export function isTaxonomicVariableCollection(
+  variableCollection: CollectionVariableTreeNode
+): boolean {
+  return (
+    isNotAbsoluteAbundanceVariableCollection(variableCollection) &&
+    variableCollection.normalizationMethod === 'sumToUnity'
+  );
+}
+
+/**
+ * Returns true for functional genomics (eg pathways, gene abundances) variable collections and false for all others.
+ *
+ * @param {CollectionVariableTreeNode} variableCollection - A variable collection.
+ * @return {boolean}
+ */
+export function isFunctionalCollection(
+  variableCollection: CollectionVariableTreeNode
+): boolean {
+  return variableCollection.normalizationMethod === 'RPK'; // reads per kilobase
 }
 
 /**

--- a/packages/libs/eda/src/lib/core/components/computations/Utils.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Utils.ts
@@ -71,11 +71,8 @@ export function removeAbsoluteAbundanceVariableCollections(
 export function isNotAbsoluteAbundanceVariableCollection(
   variableCollection: CollectionVariableTreeNode
 ): boolean {
-  return variableCollection.normalizationMethod
-    ? variableCollection.normalizationMethod !== 'NULL' ||
-        // most data we want to keep has been normalized, except pathway coverage data which were leaving apparently
-        // should consider better ways to do this in the future, or if we really want to keep the coverage data.
-        !!variableCollection.displayName?.includes('pathway')
+  return variableCollection.displayName
+    ? !variableCollection.displayName.includes('absolute abundance')
     : true;
   // DIY may not have the normalizationMethod annotations, but we still want those datasets to pass.
 }

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -99,11 +99,10 @@ function CorrelationAssayAssayConfigDescriptionComponent({
   const entityAndCollectionVariableTreeNode2 =
     findEntityAndVariableCollection(collectionVariable2);
 
-  // Data 1 and Data 2 are placeholder labels, we can decide what to call them later.
   return (
     <div className="ConfigDescriptionContainer">
       <h4>
-        Data 1:{' '}
+        Taxonomic level:{' '}
         <span>
           {entityAndCollectionVariableTreeNode1 ? (
             `${entityAndCollectionVariableTreeNode1.entity.displayName} > ${entityAndCollectionVariableTreeNode1.variableCollection.displayName}`
@@ -113,7 +112,7 @@ function CorrelationAssayAssayConfigDescriptionComponent({
         </span>
       </h4>
       <h4>
-        Data 2:{' '}
+        Functional data:{' '}
         <span>
           {entityAndCollectionVariableTreeNode2 ? (
             `${entityAndCollectionVariableTreeNode2.entity.displayName} > ${entityAndCollectionVariableTreeNode2.variableCollection.displayName}`
@@ -171,13 +170,13 @@ export function CorrelationAssayAssayConfiguration(
           <div className={cx('-CorrelationOuterConfigContainer')}>
             <H6>Input Data</H6>
             <div className={cx('-InputContainer')}>
-              <span>Taxonomic Level</span>
+              <span>Taxonomic level</span>
               <VariableCollectionSelectList
                 value={configuration.collectionVariable1}
                 onSelect={partial(changeConfigHandler, 'collectionVariable1')}
                 collectionPredicate={isTaxonomicVariableCollection}
               />
-              <span>Functional Data</span>
+              <span>Functional data</span>
               <VariableCollectionSelectList
                 value={configuration.collectionVariable2}
                 onSelect={partial(changeConfigHandler, 'collectionVariable2')}

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -7,6 +7,8 @@ import {
   assertComputationWithConfig,
   isNotAbsoluteAbundanceVariableCollection,
   partialToCompleteCodec,
+  isTaxonomicVariableCollection,
+  isFunctionalCollection,
 } from '../Utils';
 import * as t from 'io-ts';
 import { Computation } from '../../../types/visualization';
@@ -29,11 +31,10 @@ const cx = makeClassNameHelper('AppStepConfigurationContainer');
  *
  * The Correlation Assay vs Assay app takes in a two user-selected collections (ex. Species and Pathways) and
  * runs a pairwise correlation of all the member variables of one collection against the other. The result is
- * a correlation coefficient and (soon) a significance value for each pair.
+ * a correlation coefficient and a significance value for each pair.
  *
- * Importantly, this is the second of a few correlation-type apps that are coming along in the near future.
- * There will also be a Metadata vs Metadata correlation app. It's possible that
- * this PR should see a little refactoring to make the code a bit nicer.
+ * In its current state, this app is targeted toward a specific use case of correlating
+ * taxa with pathways or genes.
  */
 
 export type CorrelationAssayAssayConfig = t.TypeOf<
@@ -170,17 +171,17 @@ export function CorrelationAssayAssayConfiguration(
           <div className={cx('-CorrelationOuterConfigContainer')}>
             <H6>Input Data</H6>
             <div className={cx('-InputContainer')}>
-              <span>Data 1</span>
+              <span>Taxonomic Level</span>
               <VariableCollectionSelectList
                 value={configuration.collectionVariable1}
                 onSelect={partial(changeConfigHandler, 'collectionVariable1')}
-                collectionPredicate={isNotAbsoluteAbundanceVariableCollection}
+                collectionPredicate={isTaxonomicVariableCollection}
               />
-              <span>Data 2</span>
+              <span>Functional Data</span>
               <VariableCollectionSelectList
                 value={configuration.collectionVariable2}
                 onSelect={partial(changeConfigHandler, 'collectionVariable2')}
-                collectionPredicate={isNotAbsoluteAbundanceVariableCollection}
+                collectionPredicate={isFunctionalCollection}
               />
             </div>
           </div>

--- a/packages/libs/eda/src/lib/core/components/variableSelectors/VariableCollectionSingleSelect.tsx
+++ b/packages/libs/eda/src/lib/core/components/variableSelectors/VariableCollectionSingleSelect.tsx
@@ -36,7 +36,8 @@ export function VariableCollectionSelectList(props: Props) {
             })
           ),
         };
-      });
+      })
+      .filter((itemGroup) => itemGroup.items.length > 0); // Remove entites that had all their collections fail the collection predicate.
   }, [entities, collectionPredicate]);
 
   const handleSelect = useCallback(


### PR DESCRIPTION
Resolves #749 

Restricts the collection inputs for the Functional Associations correlation app. The first collection input should be restricted only to taxa, and the second only to functional data. In our case, functional data means pathway or gene abundance data.

With these tough restrictions, often all collections on an entity might get filtered out, which would leave a lonely entity name in the `VariableCollectionSelectList`. I've updated that component to remove entities with no items (collections).

Testing - use my dev site as a backend. QA backend is being updated today.