### PR TITLE
Remove `unknown` types

### DIFF
--- a/packages/libs/coreui/src/components/Mesa/types.ts
+++ b/packages/libs/coreui/src/components/Mesa/types.ts
@@ -1,8 +1,14 @@
 import React, { CSSProperties, ReactElement, ReactNode } from 'react';
 
-export interface MesaStateProps<Row, Key = keyof Row> {
+type DefaultColumnKey<Row> = Extract<keyof Row, string>;
+
+export interface MesaStateProps<
+  Row,
+  Key = DefaultColumnKey<Row>,
+  Value = DefaultColumnValue<Row, Key>
+> {
   rows: Row[];
-  columns: MesaColumn<Row, Key>[];
+  columns: MesaColumn<Row, Key, Value>[];
   filteredRows?: Row[];
   uiState?: {
     sort?: MesaSortObject;
@@ -35,9 +41,9 @@ export interface MesaStateProps<Row, Key = keyof Row> {
     selectedNoun?: string;
     selectedPluralNoun?: string;
     searchPlaceholder?: string;
-    deriveRowClassName?: (row: Row) => string | undefined; // a function
-    renderEmptyState?: () => ReactNode; // a function
-    isRowSelected?: (row: Row) => boolean; // a callback function
+    deriveRowClassName?: (row: Row) => string | undefined;
+    renderEmptyState?: () => ReactNode;
+    isRowSelected?: (row: Row) => boolean;
   };
   actions?: MesaAction<Row, Key>[];
   eventHandlers?: {
@@ -56,27 +62,37 @@ export interface MesaStateProps<Row, Key = keyof Row> {
   };
 }
 
-interface MesaAction<Row, Key> {
+interface MesaAction<Row, Key = DefaultColumnKey<Row>> {
   selectionRequired?: boolean;
   element: React.ReactNode;
   callback?: (row: Row, columns: MesaColumn<Row, Key>[]) => void;
   handler?: (
-    seection: Row[],
+    selection: Row[],
     columns: MesaColumn<Row, Key>[],
     rows: Row[]
   ) => void;
 }
 
-interface CellProps<Row, Key> {
+type DefaultColumnValue<Row, Key> = Key extends keyof Row ? Row[Key] : unknown;
+
+interface CellProps<
+  Row,
+  Key = DefaultColumnKey<Row>,
+  Value = DefaultColumnValue<Row, Key>
+> {
   key: Key;
-  value: Key extends keyof Row ? Row[Key] : unknown;
+  value: Value;
   row: Row;
   column: MesaColumn<Row, Key>;
   rowIndex: number;
   columnIndex: number;
 }
 
-export interface MesaColumn<Row, Key = keyof Row> {
+export interface MesaColumn<
+  Row,
+  Key = DefaultColumnKey<Row>,
+  Value = DefaultColumnValue<Row, Key>
+> {
   key: Key;
   name?: string;
   type?: string;
@@ -89,8 +105,8 @@ export interface MesaColumn<Row, Key = keyof Row> {
   style?: CSSProperties;
   className?: string;
   width?: CSSProperties['width'];
-  // getValue?: (props: { row: Row, index: number }) => ReactElement;
-  renderCell?: (cellProps: CellProps<Row, Key>) => ReactNode; // a function
+  getValue?: (props: { row: Row; index: number }) => Value;
+  renderCell?: (cellProps: CellProps<Row, Key, Value>) => ReactNode;
   renderHeading?:
     | boolean
     | ((
@@ -101,12 +117,12 @@ export interface MesaColumn<Row, Key = keyof Row> {
           HelpTrigger: ReactElement;
           ClickBoundary: ReactElement;
         }
-      ) => ReactNode); // a function
+      ) => ReactNode);
   wrapCustomHeadings?: (props: {
-    column: MesaColumn<Row, Key>;
+    column: MesaColumn<Row, Key, Value>;
     columnIndex: number;
     headerRowIndex: number;
-  }) => boolean; // a function
+  }) => boolean;
 }
 
 export interface MesaSortObject<Key extends string = string> {

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import Mesa from '@veupathdb/coreui/lib/components/Mesa';
-import { MesaSortObject } from '@veupathdb/coreui/lib/components/Mesa/types';
+import {
+  MesaSortObject,
+  MesaStateProps,
+} from '@veupathdb/coreui/lib/components/Mesa/types';
 import { AllValuesDefinition } from '../../../core';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 import { ColorPaletteDefault } from '@veupathdb/components/lib/types/plots';
@@ -113,7 +116,10 @@ export function CategoricalMarkerConfigurationTable<T>({
     });
   }
 
-  const tableState = {
+  const tableState: MesaStateProps<
+    AllValuesDefinition,
+    keyof AllValuesDefinition | 'distribution'
+  > = {
     options: {
       isRowSelected: (value: AllValuesDefinition) =>
         uncontrolledSelections.has(value.label),

--- a/packages/libs/eda/src/lib/workspace/PublicAnalyses.tsx
+++ b/packages/libs/eda/src/lib/workspace/PublicAnalyses.tsx
@@ -241,7 +241,7 @@ function PublicAnalysesTable({
     [filteredRows, tableSort, exampleSort, offerExampleSortControl]
   );
 
-  const columns: MesaColumn<keyof PublicAnalysisRow>[] = useMemo(
+  const columns: MesaColumn<PublicAnalysisRow>[] = useMemo(
     () => [
       {
         key: 'studyId',

--- a/packages/libs/multi-blast/src/lib/hooks/allJobs.tsx
+++ b/packages/libs/multi-blast/src/lib/hooks/allJobs.tsx
@@ -17,7 +17,7 @@ import {
 } from '../utils/allJobs';
 import { BlastApi } from '../utils/api';
 
-export function useAllJobsColumns(): MesaColumn<keyof JobRow>[] {
+export function useAllJobsColumns(): MesaColumn<JobRow>[] {
   return useMemo(
     () => [
       {

--- a/packages/libs/multi-blast/src/lib/hooks/combinedResults.tsx
+++ b/packages/libs/multi-blast/src/lib/hooks/combinedResults.tsx
@@ -236,7 +236,7 @@ function useCombinedResultColumns(
   jobId: string,
   organismToProject: Record<string, string>,
   projectUrls: Record<string, string>
-): MesaColumn<keyof CombinedResultRow>[] {
+): MesaColumn<CombinedResultRow>[] {
   const targetMetadataByDataType = useContext(TargetMetadataByDataType);
 
   const recordLinkUrlSegment =

--- a/packages/libs/study-data-access/src/study-access/components/UserTable.tsx
+++ b/packages/libs/study-data-access/src/study-access/components/UserTable.tsx
@@ -39,8 +39,7 @@ export interface UserTableSortObject<R, K extends UserTableColumnKey<R>>
 type OrderablePrimimitive = boolean | number | string;
 
 export interface UserTableColumn<R, K extends UserTableColumnKey<R>>
-  extends MesaColumn<K> {
-  renderCell?: (props: { row: R; value: R[K] }) => React.ReactNode;
+  extends MesaColumn<R, K> {
   makeSearchableString?: (value: R[K], row: R) => string;
   makeOrder?: (row: R) => OrderablePrimimitive | OrderablePrimimitive[];
 }

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -76,7 +76,7 @@ interface State {
 
 interface MesaDataCellProps {
   row: UserDataset;
-  column: MesaColumn;
+  column: MesaColumn<UserDataset>;
   rowIndex: number;
   columnIndex: number;
   inline?: boolean;
@@ -342,8 +342,8 @@ class UserDatasetList extends React.Component<Props, State> {
     this.setState({ selectedRows: newSelection });
   }
 
-  onSort(column: MesaColumn, direction: string): void {
-    const key: string = column.key;
+  onSort(column: MesaColumn<UserDataset>, direction: string): void {
+    const key = column.key;
     const { state } = this;
     const { setSortColumnKey, setSortDirection } = MesaState;
     const updatedState = setSortDirection(

--- a/packages/libs/wdk-client/src/Components/Shared/CommonResultTable.tsx
+++ b/packages/libs/wdk-client/src/Components/Shared/CommonResultTable.tsx
@@ -21,7 +21,7 @@ const simpleFilterPredicateFactory =
 interface CommonResultTableProps<R> {
   emptyResultMessage: string;
   rows: R[];
-  columns: ColumnSettings[];
+  columns: ColumnSettings<R>[];
   initialSearchQuery?: string;
   initialSortColumnKey?: string;
   initialSortDirection?: 'asc' | 'desc';
@@ -32,7 +32,7 @@ interface CommonResultTableProps<R> {
   searchBoxHeader?: string;
 }
 
-export interface ColumnSettings extends MesaColumn {
+export interface ColumnSettings<Row> extends MesaColumn<Row> {
   type?: 'number' | 'text' | 'html';
   sortType?: 'text' | 'number' | 'htmlText' | 'htmlNumber';
 }

--- a/packages/libs/wdk-client/src/Views/AttributeAnalysis/AttributeAnalysisTabs.tsx
+++ b/packages/libs/wdk-client/src/Views/AttributeAnalysis/AttributeAnalysisTabs.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../Actions/AttributeAnalysisActions';
 
 import '../../Views/AttributeAnalysis/AttributeAnalysisTabs.scss';
+import { MesaColumn } from '@veupathdb/coreui/lib/components/Mesa/types';
 
 export interface TableState {
   currentPage: number;
@@ -42,8 +43,6 @@ type Props<T extends string> = {
   tableConfig: TableConfig<T>;
 };
 
-type Column = { key: 'value' | 'count'; display: string };
-
 export default class AttributeAnalysisTabs<
   T extends string
 > extends React.PureComponent<Props<T>> {
@@ -53,8 +52,10 @@ export default class AttributeAnalysisTabs<
   onRowsPerPageChange = (rowsPerPage: number) =>
     this.props.dispatch(changeTableRowsPerPage(rowsPerPage));
 
-  onSort = (column: Column, direction: 'asc' | 'desc') =>
-    this.props.dispatch(sortTable(column.key, direction));
+  onSort = (
+    column: MesaColumn<TableConfig<T>['data'][number], T>,
+    direction: 'asc' | 'desc'
+  ) => this.props.dispatch(sortTable(column.key, direction));
 
   onSearch = (search: string) => this.props.dispatch(searchTable(search));
 
@@ -109,7 +110,7 @@ export default class AttributeAnalysisTabs<
                   searchTerm={tableState.search}
                   onSearchTermChange={this.onSearch}
                 />
-                <Mesa
+                <Mesa<TableConfig<T>['data'][number], T>
                   state={{
                     options: {
                       useStickyHeader: true,

--- a/packages/libs/wdk-client/src/Views/Strategy/PublicStrategies.tsx
+++ b/packages/libs/wdk-client/src/Views/Strategy/PublicStrategies.tsx
@@ -134,21 +134,16 @@ export const PublicStrategies = ({
   );
 };
 
-interface RenderCellProps<T> {
-  row: StrategySummary;
-  value: T;
-}
-
 function makeMesaColumns(
   recordClassToDisplayString: (urlSegment: string | null) => string
-): MesaColumn<keyof StrategySummary>[] {
+): MesaColumn<StrategySummary>[] {
   return [
     {
       key: 'name',
       name: 'Strategy',
       className: cx('--NameCell'),
       sortable: true,
-      renderCell: (props: RenderCellProps<string>) => (
+      renderCell: (props) => (
         <Link to={`/workspace/strategies/import/${props.row.signature}`}>
           {props.value}
         </Link>
@@ -160,16 +155,19 @@ function makeMesaColumns(
       name: 'Returns',
       className: cx('--RecordClassCell'),
       sortable: true,
-      renderCell: (props: RenderCellProps<string | null>) =>
-        recordClassToDisplayString(props.value),
+      renderCell: (props) =>
+        recordClassToDisplayString(props.value as string | null),
     },
     {
       key: 'description',
       name: 'Description',
       className: cx('--DescriptionCell'),
       sortable: true,
-      renderCell: (props: RenderCellProps<string | undefined>) => (
-        <OverflowingTextCell {...props} key={props.row.strategyId} />
+      renderCell: (props) => (
+        <OverflowingTextCell
+          value={props.value as string}
+          key={props.row.strategyId}
+        />
       ),
       width: '25em',
     },
@@ -190,8 +188,7 @@ function makeMesaColumns(
       name: 'Modified',
       className: cx('--LastModifiedCell'),
       sortable: true,
-      renderCell: (props: RenderCellProps<string>) =>
-        formatDateTimeString(props.value),
+      renderCell: (props) => formatDateTimeString(props.value as string),
     },
   ];
 }
@@ -221,7 +218,7 @@ function makeMesaRows(
 
 function makeMesaFilteredRows(
   rows: Props['publicStrategySummaries'],
-  columns: MesaColumn<keyof StrategySummary>[],
+  columns: MesaColumn<StrategySummary>[],
   searchTerm: string,
   recordClassToDisplayString: (urlSegment: string | null) => string
 ) {

--- a/packages/libs/wdk-client/src/Views/Strategy/StrategyInputSelector.tsx
+++ b/packages/libs/wdk-client/src/Views/Strategy/StrategyInputSelector.tsx
@@ -39,7 +39,10 @@ type OwnProps = {
 type Props = StateProps & OwnProps;
 
 type StrategyInputColumnKey = 'dataType' | 'name' | 'description';
-type StrategyInputColumn = MesaColumn<StrategyInputColumnKey>;
+type StrategyInputColumn = MesaColumn<
+  StrategySummaryWithDataType,
+  StrategyInputColumnKey
+>;
 
 type OptionalMesaSortObject = MesaSortObject | null;
 

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/genomeSummaryView/FeatureTable.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/genomeSummaryView/FeatureTable.tsx
@@ -8,6 +8,7 @@ import {
 } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
 import { GenomeViewSequence } from '../../types/genomeSummaryViewTypes';
 import {
+  GenomeViewFeatureModel,
   GenomeViewRegionModel,
   useIsPortalSite,
 } from '../../util/GenomeSummaryViewUtils';
@@ -53,7 +54,9 @@ const featureColumnsFactory = defaultMemoize(
       //   sortable: true,
       //   sortType: 'text'
       // }
-    ].filter((column) => typeof column !== 'boolean') as ColumnSettings[]
+    ].filter(
+      (column) => typeof column !== 'boolean'
+    ) as ColumnSettings<GenomeViewFeatureModel>[]
 );
 
 interface FeatureTableProps {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/genomeSummaryView/ResultsTable.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/genomeSummaryView/ResultsTable.tsx
@@ -78,7 +78,7 @@ const resultColumnsFactory = defaultMemoize(
         ),
         sortable: false,
       },
-    ] as ColumnSettings[]
+    ] as ColumnSettings<GenomeViewSequenceModel>[]
 );
 
 const locationCellRenderFactory =

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -367,7 +367,7 @@ function InternalGeneDatasetContent(props: Props) {
             },
           },
           {
-            key: 'Searches',
+            key: 'searches',
             name: 'Choose a Search',
             sortable: false,
             renderCell: (cellProps: any) => (

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisGoEnrichmentResults.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisGoEnrichmentResults.tsx
@@ -93,7 +93,7 @@ const goEnrichmentResultColumns = [
     sortable: true,
     sortType: 'number',
   },
-] as ColumnSettings[];
+] as ColumnSettings<any>[];
 
 const goIdRenderFactory =
   (goTermBaseUrl: string) =>

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisHpiGeneListResults.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisHpiGeneListResults.tsx
@@ -10,7 +10,7 @@ import './StepAnalysisEnrichmentResult.scss';
 import { Tooltip } from '@veupathdb/wdk-client/lib/Components';
 
 const baseColumnSettings: Pick<
-  ColumnSettings,
+  ColumnSettings<any>,
   'key' | 'renderCell' | 'sortable' | 'sortType' | 'type'
 >[] = [
   {
@@ -79,7 +79,7 @@ const baseColumnSettings: Pick<
 const hpiGeneListResultColumns = (
   headerRow: any,
   headerDescription: any
-): ColumnSettings[] =>
+): ColumnSettings<any>[] =>
   baseColumnSettings.map((column) => ({
     ...column,
     name: headerRow[column.key],

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisPathwayEnrichmentResults.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisPathwayEnrichmentResults.tsx
@@ -101,7 +101,7 @@ const pathwayEnrichmentResultColumns = [
     sortable: true,
     sortType: 'number',
   },
-] as ColumnSettings[];
+] as ColumnSettings<any>[];
 
 const pathwayIdRenderFactory =
   (pathwayBaseUrl: string) =>

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisWordEnrichmentResults.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisWordEnrichmentResults.tsx
@@ -87,7 +87,7 @@ const wordEnrichmentResultColumns = [
     sortable: true,
     sortType: 'number',
   },
-] as ColumnSettings[];
+] as ColumnSettings<any>[];
 
 const wordEnrichmentButtonsConfigFactory = (
   stepId: number,

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/utils/dataTables.ts
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/utils/dataTables.ts
@@ -12,8 +12,7 @@ export interface DataTableSortObject<R, K extends DataTableColumnKey<R>>
 }
 
 export interface DataTableColumn<R, K extends DataTableColumnKey<R>>
-  extends MesaColumn<K> {
-  renderCell?: (props: { row: R; value: R[K] }) => React.ReactNode;
+  extends MesaColumn<R, K> {
   makeSearchableString?: (value: R[K]) => string;
   makeOrder?: (row: R) => boolean | number | string;
 }


### PR DESCRIPTION
This PR removes `unknown` types from `Mesa` type definitions.

A big change is that `MesaColumn` now takes two generic types: `Row` and `Key`. The `Row` type is required, and the default for `Key` is `keyof Row`. This covers most use cases, and allows us to better infer the type of `value` in `CellProps`.

Getting these types right is tricky, because `Mesa` tries to allow any data structure to be used for a row, and to allow the consumer to compute the rendered value however it sees fit.

In most cases, we simply use objects as rows, and the keys of those objects as column keys, which this PR attempts to make easy.