### PR TITLE
Restore interactvitiy of Data Table sticky column headers

### DIFF
--- a/packages/libs/coreui/src/components/Mesa/Ui/DataTable.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/DataTable.jsx
@@ -51,6 +51,7 @@ class DataTable extends React.Component {
 
         return {
           ...column,
+          moveable: false,
           headingStyle: {
             ...column.headingStyle,
             position: 'sticky',

--- a/packages/libs/coreui/src/components/Mesa/style/Ui/HeadingCell.scss
+++ b/packages/libs/coreui/src/components/Mesa/style/Ui/HeadingCell.scss
@@ -6,6 +6,8 @@
       flex-direction: row;
       flex-wrap: nowrap;
       align-items: center;
+      position: relative;
+      z-index: 1;
 
       .HeadingCell-Content-Aside {
         flex-basis: 0 1 30px;


### PR DESCRIPTION
Fixes https://github.com/VEuPathDB/web-monorepo/issues/777