### PR TITLE
Change defline option verbiage

### DIFF
--- a/packages/libs/web-common/src/components/reporters/FastaGeneReporterForm.jsx
+++ b/packages/libs/web-common/src/components/reporters/FastaGeneReporterForm.jsx
@@ -18,7 +18,7 @@ let sequenceTypes = [
 ];
 
 let defLineOptions = [
-  { value: '1', display: 'Only Gene ID' },
+  { value: '1', display: 'Only Unique ID' },
   { value: '0', display: 'Full Fasta Header' },
 ];
 

--- a/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
+++ b/packages/libs/web-common/src/components/reporters/SequenceFormFactory.jsx
@@ -20,7 +20,7 @@ const SINGLE_TRANSCRIPT_VIEW_FILTER_VALUE = {
 const util = Object.assign({}, ComponentUtils, ReporterUtils);
 
 const deflineFieldOptions = [
-  { value: 'gene_id', display: 'Gene ID', disabled: true },
+  { value: 'gene_id', display: 'Unique ID', disabled: true },
   { value: 'organism', display: 'Organism' },
   { value: 'description', display: 'Description' },
   { value: 'position', display: 'Location' },


### PR DESCRIPTION
Minor change to the defline options that changes references to "Gene ID" to be "Unique ID" instead.