### PR TITLE
remove absolute abundance collections via annotations

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/Utils.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Utils.ts
@@ -71,10 +71,16 @@ export function removeAbsoluteAbundanceVariableCollections(
 export function isNotAbsoluteAbundanceVariableCollection(
   variableCollection: CollectionVariableTreeNode
 ): boolean {
-  return variableCollection.displayName
-    ? !variableCollection.displayName.includes('absolute abundance')
+  // Absolute abundance collections have the following annotations:
+  // 1. normalizationMethod = NULL
+  // 2. isCompositional = true
+  // 3. isProportion = false
+  return variableCollection.normalizationMethod
+    ? variableCollection.normalizationMethod !== 'NULL' ||
+        !variableCollection.isCompositional ||
+        !!variableCollection.isProportion
     : true;
-  // DIY may not have the normalizationMethod annotations, but we still want those datasets to pass.
+  // DIY may not have these annotations, but we still want those datasets to pass.
 }
 
 /**


### PR DESCRIPTION
Resolves #804 

During a previous PR I simplified the `isNotAbsoluteAbundance` logic but ended up introducing a bug. Turns out the display name does not include "absolute" ever! Instead of reverting to the previous logic, which still included looking up by display name, this PR uses the hard core collection annotation properties to check if a collection is for absolute abundance. Reminder, those properties are set [here](https://github.com/VEuPathDB/ApiCommonData/blob/master/Load/ontology/General/collections/collections.yaml)

I've tested with a metagenomic study, a 16S study, and the FARMM study that has extra funky assays. All look good now 👍 
Third time's a charm!