### PR TITLE
allow wgcna collections in correlation metadata app

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/Utils.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Utils.ts
@@ -75,12 +75,11 @@ export function isNotAbsoluteAbundanceVariableCollection(
   // 1. normalizationMethod = NULL
   // 2. isCompositional = true
   // 3. isProportion = false
-  // return variableCollection.normalizationMethod
-  //   ? variableCollection.normalizationMethod !== 'NULL' ||
-  //       !variableCollection.isCompositional ||
-  //       !!variableCollection.isProportion
-  //   : true;
-  return true;
+  return variableCollection.normalizationMethod
+    ? variableCollection.normalizationMethod !== 'NULL' ||
+        !variableCollection.isCompositional ||
+        !!variableCollection.isProportion
+    : true;
   // DIY may not have these annotations, but we still want those datasets to pass.
 }
 

--- a/packages/libs/eda/src/lib/core/components/computations/Utils.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Utils.ts
@@ -75,11 +75,12 @@ export function isNotAbsoluteAbundanceVariableCollection(
   // 1. normalizationMethod = NULL
   // 2. isCompositional = true
   // 3. isProportion = false
-  return variableCollection.normalizationMethod
-    ? variableCollection.normalizationMethod !== 'NULL' ||
-        !variableCollection.isCompositional ||
-        !!variableCollection.isProportion
-    : true;
+  // return variableCollection.normalizationMethod
+  //   ? variableCollection.normalizationMethod !== 'NULL' ||
+  //       !variableCollection.isCompositional ||
+  //       !!variableCollection.isProportion
+  //   : true;
+  return true;
   // DIY may not have these annotations, but we still want those datasets to pass.
 }
 

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -261,6 +261,7 @@ const ASSAY_ENTITIES = [
   'EUPATH_0000809',
   'EUPATH_0000813',
   'EUPATH_0000812',
+  'OBI_0000626', // should just find whatever entity has collections!!!
 ];
 
 // The correlation assay x metadata app is only available for studies

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -256,14 +256,6 @@ export function CorrelationAssayMetadataConfiguration(
   );
 }
 
-const ASSAY_ENTITIES = [
-  'OBI_0002623',
-  'EUPATH_0000809',
-  'EUPATH_0000813',
-  'EUPATH_0000812',
-  'OBI_0000626', // should just find whatever entity has collections!!!
-];
-
 // The correlation assay x metadata app is only available for studies
 // with appropriate metadata. Specifically, the study
 // must have at least one continuous metadata variable that is on a one-to-one path
@@ -293,9 +285,10 @@ function isEnabledInPicker({
     // Then we're in a curated study. So we can expect to find an entity with an id in ASSAY_ENTITIES,
     // which we can use to limit our metadata search to only appropriate entities.
 
-    // Step 1. Find the first assay node. Doesn't need to be any assay in particular just any mbio assay will do
-    const firstAssayEntityIndex = entities.findIndex((entity) =>
-      ASSAY_ENTITIES.includes(entity.id)
+    // Step 1. Find the first assay node. Right now Assays are the only entities with collections,
+    // so we can just grab the first entity we see that has a collection.
+    const firstAssayEntityIndex = entities.findIndex(
+      (entity) => !!entity.collections?.length
     );
     if (firstAssayEntityIndex === -1) return false;
 


### PR DESCRIPTION
This PR includes changes that let folks see the wgcna data working in the correlations apps.

To run, use jbrestel plasmo backend.

02/02/24 - can select the collections for the correlation app. Found issue on the backend https://github.com/VEuPathDB/microbiomeComputations/issues/81

02/09/24 - all resolved. Data looks good and works!

## To Do before asking for review
- [x] Change the hard-coded assay entity ids to a function that just finds the entities with collections. 


For testing, please check that there are two collections options in the Correlation (assay x metadata) app.

I've left the Functional Associations correlations app out for now. There are open questions about how to handle that app. 


