### PR TITLE
Wire marker selection to floaters

### DIFF
--- a/packages/libs/components/src/map/BoundsDriftMarker.tsx
+++ b/packages/libs/components/src/map/BoundsDriftMarker.tsx
@@ -290,9 +290,12 @@ export default function BoundsDriftMarker({
             setSelectedMarkers(
               selectedMarkers.filter((id: string) => id !== props.id)
             );
-          } else {
-            // select
+          } else if (e.originalEvent.shiftKey) {
+            // add to selection if SHIFT key pressed
             setSelectedMarkers([...(selectedMarkers ?? []), props.id]);
+          } else {
+            // replace selection
+            setSelectedMarkers([props.id]);
           }
         }
 

--- a/packages/libs/components/src/map/BoundsDriftMarker.tsx
+++ b/packages/libs/components/src/map/BoundsDriftMarker.tsx
@@ -1,5 +1,5 @@
 import { useMap, Popup } from 'react-leaflet';
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 // use new ReactLeafletDriftMarker instead of DriftMarker
 import ReactLeafletDriftMarker from 'react-leaflet-drift-marker';
 import { MarkerProps, Bounds } from './Types';
@@ -15,7 +15,7 @@ export interface BoundsDriftMarkerProps extends MarkerProps {
   // selectedMarkers state
   selectedMarkers?: string[];
   // selectedMarkers setState
-  setSelectedMarkers?: React.Dispatch<React.SetStateAction<string[]>>;
+  setSelectedMarkers?: (selectedMarkers: string[] | undefined) => void;
 }
 
 /**
@@ -281,30 +281,30 @@ export default function BoundsDriftMarker({
   };
 
   // add click events for highlighting markers
-  const handleClick = (e: LeafletMouseEvent) => {
-    // check the number of mouse click and enable function for single click only
-    if (e.originalEvent.detail === 1) {
-      if (setSelectedMarkers) {
-        if (selectedMarkers?.find((id) => id === props.id)) {
-          setSelectedMarkers((prevSelectedMarkers: string[]) =>
-            prevSelectedMarkers.filter((id: string) => id !== props.id)
-          );
-        } else {
-          // select
-          setSelectedMarkers((prevSelectedMarkers: string[]) => [
-            ...prevSelectedMarkers,
-            props.id,
-          ]);
+  const handleClick = useCallback(
+    (e: LeafletMouseEvent) => {
+      // check the number of mouse click and enable function for single click only
+      if (e.originalEvent.detail === 1) {
+        if (setSelectedMarkers) {
+          if (selectedMarkers?.find((id) => id === props.id)) {
+            setSelectedMarkers(
+              selectedMarkers.filter((id: string) => id !== props.id)
+            );
+          } else {
+            // select
+            setSelectedMarkers([...(selectedMarkers ?? []), props.id]);
+          }
         }
-      }
 
-      // Sometimes clicking throws off the popup's orientation, so reorient it
-      orientPopup(popupOrientationRef.current);
-      // Default popup behavior is to open on marker click
-      // Prevent by immediately closing it
-      e.target.closePopup();
-    }
-  };
+        // Sometimes clicking throws off the popup's orientation, so reorient it
+        orientPopup(popupOrientationRef.current);
+        // Default popup behavior is to open on marker click
+        // Prevent by immediately closing it
+        e.target.closePopup();
+      }
+    },
+    [setSelectedMarkers, selectedMarkers, props.id]
+  );
 
   const handleDoubleClick = () => {
     if (map) {

--- a/packages/libs/components/src/map/MapVEuMap.tsx
+++ b/packages/libs/components/src/map/MapVEuMap.tsx
@@ -250,7 +250,7 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
       zoom={viewport.zoom}
       minZoom={1}
       zoomSnap={zoomSnap}
-      wheelPxPerZoomLevel={1000}
+      wheelPxPerZoomLevel={100}
       // We add our own custom zoom control below
       zoomControl={false}
       style={{ height, width, ...style }}

--- a/packages/libs/components/src/map/MapVEuMap.tsx
+++ b/packages/libs/components/src/map/MapVEuMap.tsx
@@ -151,8 +151,6 @@ export interface MapVEuMapProps {
   scrollingEnabled?: boolean;
   /** pass default viewport */
   defaultViewport?: Viewport;
-  /* selectedMarkers setState (for on-click reset) **/
-  setSelectedMarkers?: React.Dispatch<React.SetStateAction<string[]>>;
   children?: React.ReactNode;
   onMapClick?: () => void;
   onMapDrag?: () => void;
@@ -179,7 +177,6 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
     scrollingEnabled = true,
     interactive = true,
     defaultViewport,
-    setSelectedMarkers,
     onMapClick,
     onMapDrag,
     onMapZoom,
@@ -291,7 +288,6 @@ function MapVEuMap(props: MapVEuMapProps, ref: Ref<PlotRef>) {
       <MapVEuMapEvents
         onViewportChanged={onViewportChanged}
         onBaseLayerChanged={onBaseLayerChanged}
-        setSelectedMarkers={setSelectedMarkers}
         onBoundsChanged={onBoundsChanged}
         onMapClick={onMapClick}
         onMapDrag={onMapDrag}
@@ -311,13 +307,10 @@ interface MapVEuMapEventsProps {
   onViewportChanged: (viewport: Viewport) => void;
   onBoundsChanged: (bondsViewport: BoundsViewport) => void;
   onBaseLayerChanged?: (newBaseLayer: BaseLayerChoice) => void;
-  setSelectedMarkers?: React.Dispatch<React.SetStateAction<string[]>>;
   onMapClick?: () => void;
   onMapDrag?: () => void;
   onMapZoom?: () => void;
 }
-
-const EMPTY_MARKERS: string[] = [];
 
 // function to handle map events such as onViewportChanged and baselayerchange
 function MapVEuMapEvents(props: MapVEuMapEventsProps) {
@@ -325,7 +318,6 @@ function MapVEuMapEvents(props: MapVEuMapEventsProps) {
     onViewportChanged,
     onBaseLayerChanged,
     onBoundsChanged,
-    setSelectedMarkers,
     onMapClick,
     onMapDrag,
     onMapZoom,
@@ -368,8 +360,6 @@ function MapVEuMapEvents(props: MapVEuMapEventsProps) {
     },
     // map click event: remove selected highlight markers
     click: () => {
-      if (setSelectedMarkers != null) setSelectedMarkers(EMPTY_MARKERS);
-
       if (onMapClick != null) onMapClick();
     },
   });

--- a/packages/libs/components/src/map/SemanticMarkers.tsx
+++ b/packages/libs/components/src/map/SemanticMarkers.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { AnimationFunction, Bounds } from './Types';
 import { BoundsDriftMarkerProps } from './BoundsDriftMarker';
-import { useMap } from 'react-leaflet';
+import { useMap, useMapEvents } from 'react-leaflet';
 import { LatLngBounds } from 'leaflet';
 import { debounce, isEqual } from 'lodash';
 
@@ -30,6 +30,8 @@ export interface SemanticMarkersProps {
   setSelectedMarkers?: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
+const EMPTY_MARKERS: string[] = [];
+
 /**
  * Renders the semantic markers layer
  *
@@ -47,6 +49,13 @@ export default function SemanticMarkers({
 }: SemanticMarkersProps) {
   // react-leaflet v3
   const map = useMap();
+
+  // cancel marker selection with a single click on the map
+  useMapEvents({
+    click: () => {
+      if (setSelectedMarkers != null) setSelectedMarkers(EMPTY_MARKERS);
+    },
+  });
 
   const [prevRecenteredMarkers, setPrevRecenteredMarkers] =
     useState<ReactElement<BoundsDriftMarkerProps>[]>(markers);

--- a/packages/libs/components/src/map/SemanticMarkers.tsx
+++ b/packages/libs/components/src/map/SemanticMarkers.tsx
@@ -27,10 +27,8 @@ export interface SemanticMarkersProps {
   /* selectedMarkers state **/
   selectedMarkers?: string[];
   /* selectedMarkers setState **/
-  setSelectedMarkers?: React.Dispatch<React.SetStateAction<string[]>>;
+  setSelectedMarkers?: (selectedMarkers: string[] | undefined) => void;
 }
-
-const EMPTY_MARKERS: string[] = [];
 
 /**
  * Renders the semantic markers layer
@@ -53,7 +51,7 @@ export default function SemanticMarkers({
   // cancel marker selection with a single click on the map
   useMapEvents({
     click: () => {
-      if (setSelectedMarkers != null) setSelectedMarkers(EMPTY_MARKERS);
+      if (setSelectedMarkers != null) setSelectedMarkers(undefined);
     },
   });
 

--- a/packages/libs/components/src/map/SemanticMarkers.tsx
+++ b/packages/libs/components/src/map/SemanticMarkers.tsx
@@ -135,7 +135,13 @@ export default function SemanticMarkers({
         });
         // set them as current
         // any marker that already existed will move to the modified position
-        setConsolidatedMarkers(animationValues.markers);
+        if (
+          !isEqual(
+            animationValues.markers.map(({ props }) => props),
+            consolidatedMarkers.map(({ props }) => props)
+          )
+        )
+          setConsolidatedMarkers(animationValues.markers);
         // then set a timer to remove the old markers when zooming out
         // or if zooming in, switch to just the new markers straight away
         // (their starting position was set by `animationFunction`)
@@ -146,7 +152,13 @@ export default function SemanticMarkers({
         );
       } else {
         /** First render of markers **/
-        setConsolidatedMarkers(recenteredMarkers);
+        if (
+          !isEqual(
+            recenteredMarkers.map(({ props }) => props),
+            consolidatedMarkers.map(({ props }) => props)
+          )
+        )
+          setConsolidatedMarkers(recenteredMarkers);
       }
 
       // To prevent infinite loops, especially when in "other worlds",
@@ -183,7 +195,14 @@ export default function SemanticMarkers({
         );
       }
     }
-  }, [animation, map, markers, prevRecenteredMarkers, recenterMarkers]);
+  }, [
+    animation,
+    map,
+    markers,
+    prevRecenteredMarkers,
+    recenterMarkers,
+    consolidatedMarkers,
+  ]);
 
   // remove any selectedMarkers that no longer exist in the current markers
   useEffect(() => {
@@ -195,7 +214,7 @@ export default function SemanticMarkers({
       if (prunedSelectedMarkers.length < selectedMarkers.length)
         setSelectedMarkers(prunedSelectedMarkers);
     }
-  }, [consolidatedMarkers, selectedMarkers]);
+  }, [consolidatedMarkers, selectedMarkers, setSelectedMarkers]);
 
   // add the selectedMarkers props and callback
   // (and the scheduled-for-removal showPopup prop)
@@ -208,7 +227,7 @@ export default function SemanticMarkers({
           setSelectedMarkers,
         })
       ),
-    [consolidatedMarkers, selectedMarkers]
+    [consolidatedMarkers, selectedMarkers, setSelectedMarkers]
   );
 
   // this should use the unadulterated markers (which are always in the "main world")

--- a/packages/libs/components/src/map/animation_functions/geohash.tsx
+++ b/packages/libs/components/src/map/animation_functions/geohash.tsx
@@ -40,7 +40,7 @@ export default function geohashAnimation({
   } else {
     /** No difference in geohashes - Render markers as they are **/
     zoomType = null;
-    consolidatedMarkers = [...markers];
+    consolidatedMarkers = markers;
   }
 
   return { zoomType: zoomType, markers: consolidatedMarkers };

--- a/packages/libs/components/src/stories/MarkerSelection.stories.tsx
+++ b/packages/libs/components/src/stories/MarkerSelection.stories.tsx
@@ -45,7 +45,8 @@ export const DonutMarkers: Story<MapVEuMapProps> = (args) => {
   });
 
   // make an array of objects state to list highlighted markers
-  const [selectedMarkers, setSelectedMarkers] = useState<string[]>([]);
+  const [selectedMarkers, setSelectedMarkers] =
+    useState<string[] | undefined>();
 
   console.log('selectedMarkers =', selectedMarkers);
 
@@ -109,7 +110,8 @@ export const ChartMarkers: Story<MapVEuMapProps> = (args) => {
   const duration = defaultAnimationDuration;
 
   // make an array of objects state to list highlighted markers
-  const [selectedMarkers, setSelectedMarkers] = useState<string[]>([]);
+  const [selectedMarkers, setSelectedMarkers] =
+    useState<string[] | undefined>();
 
   console.log('selectedMarkers =', selectedMarkers);
 

--- a/packages/libs/components/src/stories/MarkerSelection.stories.tsx
+++ b/packages/libs/components/src/stories/MarkerSelection.stories.tsx
@@ -72,7 +72,6 @@ export const DonutMarkers: Story<MapVEuMapProps> = (args) => {
         onViewportChanged={setViewport}
         onBoundsChanged={handleViewportChanged}
         zoomLevelToGeohashLevel={leafletZoomLevelToGeohashLevel}
-        setSelectedMarkers={setSelectedMarkers}
       >
         <SemanticMarkers
           markers={markerElements}
@@ -142,7 +141,6 @@ export const ChartMarkers: Story<MapVEuMapProps> = (args) => {
         onBoundsChanged={handleViewportChanged}
         showGrid={true}
         zoomLevelToGeohashLevel={leafletZoomLevelToGeohashLevel}
-        setSelectedMarkers={setSelectedMarkers}
       >
         <SemanticMarkers
           markers={markerElements}

--- a/packages/libs/eda/src/lib/core/components/layouts/types.ts
+++ b/packages/libs/eda/src/lib/core/components/layouts/types.ts
@@ -23,7 +23,7 @@ export interface LayoutOptions {
 }
 
 export interface TitleOptions {
-  getPlotSubtitle?(config: unknown): ReactNode;
+  getPlotSubtitle?(config?: unknown): ReactNode;
 }
 
 export interface LegendOptions {

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BarplotVisualization.tsx
@@ -98,7 +98,7 @@ import {
   barplotDefaultDependentAxisMinPos,
 } from '../../../utils/axis-range-calculations';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
-import { LayoutOptions } from '../../layouts/types';
+import { LayoutOptions, TitleOptions } from '../../layouts/types';
 import { OverlayOptions, RequestOptions } from '../options/types';
 import { useDeepValue } from '../../../hooks/immutability';
 
@@ -138,6 +138,7 @@ export const barplotVisualization = createVisualizationPlugin({
 interface Options
   extends LayoutOptions,
     OverlayOptions,
+    TitleOptions,
     RequestOptions<BarplotConfig, {}, BarplotRequestParams> {}
 
 function FullscreenComponent(props: VisualizationProps<Options>) {
@@ -902,6 +903,7 @@ function BarplotViz(props: VisualizationProps<Options>) {
       .every((reqdVar) => !!(vizConfig as any)[reqdVar[0]]);
 
   const LayoutComponent = options?.layoutComponent ?? PlotLayout;
+  const plotSubtitle = options?.getPlotSubtitle?.();
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -935,7 +937,11 @@ function BarplotViz(props: VisualizationProps<Options>) {
 
       <PluginError error={data.error} outputSize={outputSize} />
       {!hideInputsAndControls && (
-        <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
+        <OutputEntityTitle
+          entity={outputEntity}
+          outputSize={outputSize}
+          subtitle={plotSubtitle}
+        />
       )}
       <LayoutComponent
         isFaceted={isFaceted(data.value)}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -849,7 +849,6 @@ function BoxplotViz(props: VisualizationProps<Options>) {
     </>
   );
 
-  // plot subtitle
   const plotSubtitle = options?.getPlotSubtitle?.(
     computation.descriptor.configuration
   );

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -114,12 +114,11 @@ import {
   histogramDefaultIndependentAxisMinMax,
   histogramDefaultDependentAxisMinMax,
 } from '../../../utils/axis-range-calculations';
-import { LayoutOptions } from '../../layouts/types';
+import { LayoutOptions, TitleOptions } from '../../layouts/types';
 import {
   OverlayOptions,
   RequestOptionProps,
   RequestOptions,
-  VerbiageOptions,
 } from '../options/types';
 import { useDeepValue } from '../../../hooks/immutability';
 import { ResetButtonCoreUI } from '../../ResetButton';
@@ -199,7 +198,7 @@ export const HistogramConfig = t.intersection([
 interface Options
   extends LayoutOptions,
     OverlayOptions,
-    VerbiageOptions,
+    TitleOptions,
     RequestOptions<
       HistogramConfig,
       FloatingHistogramExtraProps,
@@ -1344,7 +1343,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
   );
 
   const LayoutComponent = options?.layoutComponent ?? PlotLayout;
-  const entitySubtitle = options?.getEntitySubtitleForViz?.();
+  const plotSubtitle = options?.getPlotSubtitle?.();
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -1382,7 +1381,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
         {!hideInputsAndControls && (
           <OutputEntityTitle
             entity={outputEntity}
-            subtitle={entitySubtitle}
+            subtitle={plotSubtitle}
             outputSize={outputSize}
           />
         )}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -667,21 +667,22 @@ function HistogramViz(props: VisualizationProps<Options>) {
     if (
       !distributionDataPromise.pending &&
       distributionDataPromise.value != null
-    )
-      return {
-        min: DateVariable.is(xAxisVariable)
-          ? (
-              (distributionDataPromise?.value?.series[0]?.summary
-                ?.min as string) ?? ''
-            ).split('T')[0]
-          : distributionDataPromise?.value?.series[0]?.summary?.min,
-        max: DateVariable.is(xAxisVariable)
-          ? (
-              (distributionDataPromise?.value?.series[0]?.summary
-                ?.max as string) ?? ''
-            ).split('T')[0]
-          : distributionDataPromise?.value?.series[0]?.summary?.max,
-      };
+    ) {
+      const min = distributionDataPromise.value.series[0]?.summary?.min;
+      const max = distributionDataPromise.value.series[0]?.summary?.max;
+
+      if (min != null && max != null) {
+        if (DateVariable.is(xAxisVariable)) {
+          return {
+            min: (min as string).split('T')[0],
+            max: (max as string).split('T')[0],
+          };
+        } else {
+          return { min, max };
+        }
+      }
+    }
+    return undefined;
   }, [distributionDataPromise]);
 
   const independentAxisMinMax = useMemo(() => {

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -119,6 +119,7 @@ import {
   OverlayOptions,
   RequestOptionProps,
   RequestOptions,
+  VerbiageOptions,
 } from '../options/types';
 import { useDeepValue } from '../../../hooks/immutability';
 import { ResetButtonCoreUI } from '../../ResetButton';
@@ -198,6 +199,7 @@ export const HistogramConfig = t.intersection([
 interface Options
   extends LayoutOptions,
     OverlayOptions,
+    VerbiageOptions,
     RequestOptions<
       HistogramConfig,
       FloatingHistogramExtraProps,
@@ -1341,6 +1343,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
   );
 
   const LayoutComponent = options?.layoutComponent ?? PlotLayout;
+  const entitySubtitle = options?.getEntitySubtitleForViz?.();
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -1376,7 +1379,11 @@ function HistogramViz(props: VisualizationProps<Options>) {
 
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         {!hideInputsAndControls && (
-          <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
+          <OutputEntityTitle
+            entity={outputEntity}
+            subtitle={entitySubtitle}
+            outputSize={outputSize}
+          />
         )}
         <LayoutComponent
           isFaceted={isFaceted(data.value)}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -123,7 +123,7 @@ import { useDefaultAxisRange } from '../../../hooks/computeDefaultAxisRange';
 
 import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
-import { LayoutOptions } from '../../layouts/types';
+import { LayoutOptions, TitleOptions } from '../../layouts/types';
 import {
   OverlayOptions,
   RequestOptionProps,
@@ -259,6 +259,7 @@ export const LineplotConfig = t.intersection([
 interface Options
   extends LayoutOptions,
     OverlayOptions,
+    TitleOptions,
     RequestOptions<
       LineplotConfig,
       FloatingLineplotExtraProps,
@@ -1767,7 +1768,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
   );
 
   const LayoutComponent = options?.layoutComponent ?? PlotLayout;
-
+  const plotSubtitle = options?.getPlotSubtitle?.();
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <div style={{ display: 'flex', alignItems: 'center', zIndex: 1 }}>
@@ -1825,7 +1826,11 @@ function LineplotViz(props: VisualizationProps<Options>) {
 
       <PluginError error={data.error} outputSize={outputSize} />
       {!hideInputsAndControls && (
-        <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
+        <OutputEntityTitle
+          entity={outputEntity}
+          outputSize={outputSize}
+          subtitle={plotSubtitle}
+        />
       )}
       <LayoutComponent
         isFaceted={isFaceted(data.value?.dataSetProcess)}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/MosaicVisualization.tsx
@@ -65,7 +65,7 @@ import { isFaceted } from '@veupathdb/components/lib/types/guards';
 import FacetedMosaicPlot from '@veupathdb/components/lib/plots/facetedPlots/FacetedMosaicPlot';
 import { useVizConfig } from '../../../hooks/visualizations';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
-import { LayoutOptions } from '../../layouts/types';
+import { LayoutOptions, TitleOptions } from '../../layouts/types';
 import SingleSelect from '@veupathdb/coreui/lib/components/inputs/SingleSelect';
 import { useInputStyles } from '../inputStyles';
 import { ClearSelectionButton } from '../../variableSelectors/VariableTreeDropdown';
@@ -152,7 +152,7 @@ export const twoByTwoVisualization = createVisualizationPlugin({
   createDefaultConfig: createDefaultConfig,
 });
 
-interface Options extends LayoutOptions {}
+interface Options extends LayoutOptions, TitleOptions {}
 
 function ContTableFullscreenComponent(props: VisualizationProps<Options>) {
   return <MosaicViz {...props} />;
@@ -736,7 +736,7 @@ function MosaicViz(props: Props<Options>) {
   }, [dataElementConstraints, isTwoByTwo, vizConfig]);
 
   const LayoutComponent = options?.layoutComponent ?? PlotLayout;
-
+  const plotSubtitle = options?.getPlotSubtitle?.();
   const classes = useInputStyles();
 
   /**
@@ -1022,7 +1022,11 @@ function MosaicViz(props: Props<Options>) {
 
         <PluginError error={data.error} outputSize={outputSize} />
         {!hideInputsAndControls && (
-          <OutputEntityTitle entity={outputEntity} outputSize={outputSize} />
+          <OutputEntityTitle
+            entity={outputEntity}
+            outputSize={outputSize}
+            subtitle={plotSubtitle}
+          />
         )}
         <LayoutComponent
           isFaceted={isFaceted(data.value)}

--- a/packages/libs/eda/src/lib/core/components/visualizations/options/types.ts
+++ b/packages/libs/eda/src/lib/core/components/visualizations/options/types.ts
@@ -23,6 +23,10 @@ export interface OverlayOptions {
   getCheckedLegendItems?: (computeConfig: unknown) => string[] | undefined;
 }
 
+export interface VerbiageOptions {
+  getEntitySubtitleForViz?: () => ReactNode;
+}
+
 export type RequestOptionProps<ConfigType> = {
   studyId: string;
   filters: Filter[] | undefined;

--- a/packages/libs/eda/src/lib/core/components/visualizations/options/types.ts
+++ b/packages/libs/eda/src/lib/core/components/visualizations/options/types.ts
@@ -23,10 +23,6 @@ export interface OverlayOptions {
   getCheckedLegendItems?: (computeConfig: unknown) => string[] | undefined;
 }
 
-export interface VerbiageOptions {
-  getEntitySubtitleForViz?: () => ReactNode;
-}
-
 export type RequestOptionProps<ConfigType> = {
   studyId: string;
   filters: Filter[] | undefined;

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -697,6 +697,7 @@ function MapAnalysisImpl(props: ImplProps) {
     if (appState.isSidePanelExpanded && activeSideMenuId === nextSideMenuId)
       enqueueSnackbar('Marker configuration panel is already open', {
         variant: 'info',
+        anchorOrigin: { vertical: 'top', horizontal: 'center' },
       });
 
     if (!appState.isSidePanelExpanded) setIsSidePanelExpanded(true);

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -327,9 +327,6 @@ function MapAnalysisImpl(props: ImplProps) {
     if (redirectURL) history.push(redirectURL);
   }, [history, redirectURL]);
 
-  // make an array of objects state to list highlighted markers
-  const [selectedMarkers, setSelectedMarkers] = useState<string[]>([]);
-
   const sidePanelMenuEntries: SidePanelMenuEntry[] = [
     {
       type: 'heading',
@@ -766,10 +763,6 @@ function MapAnalysisImpl(props: ImplProps) {
           filteredCounts,
           hideVizInputsAndControls,
           setHideVizInputsAndControls,
-          /* disabled until wired in fully:
-             selectedMarkers,
-             setSelectedMarkers,
-          */
           headerButtons: HeaderButtons,
         };
 
@@ -855,8 +848,6 @@ function MapAnalysisImpl(props: ImplProps) {
                     }
                     // pass defaultViewport & isStandAloneMap props for custom zoom control
                     defaultViewport={defaultViewport}
-                    // for multiple markers cancelation of selection only
-                    setSelectedMarkers={setSelectedMarkers}
                     // close left-side panel when map events happen
                     onMapClick={closePanel}
                     onMapDrag={closePanel}

--- a/packages/libs/eda/src/lib/map/analysis/appState.ts
+++ b/packages/libs/eda/src/lib/map/analysis/appState.ts
@@ -49,20 +49,34 @@ export const MarkerConfiguration = t.intersection([
     activeVisualizationId: t.string,
   }),
   t.union([
-    t.type({
-      type: t.literal('barplot'),
-      selectedValues: SelectedValues,
-      selectedPlotMode: t.union([t.literal('count'), t.literal('proportion')]),
-      binningMethod: BinningMethod,
-      dependentAxisLogScale: t.boolean,
-      selectedCountsOption: SelectedCountsOption,
-    }),
-    t.type({
-      type: t.literal('pie'),
-      selectedValues: SelectedValues,
-      binningMethod: BinningMethod,
-      selectedCountsOption: SelectedCountsOption,
-    }),
+    t.intersection([
+      t.type({
+        type: t.literal('barplot'),
+        selectedValues: SelectedValues,
+        selectedPlotMode: t.union([
+          t.literal('count'),
+          t.literal('proportion'),
+        ]),
+        binningMethod: BinningMethod,
+        dependentAxisLogScale: t.boolean,
+        selectedCountsOption: SelectedCountsOption,
+      }),
+      t.partial({
+        // yes all the modes have selectedMarkers but maybe in the future one won't
+        selectedMarkers: t.array(t.string),
+      }),
+    ]),
+    t.intersection([
+      t.type({
+        type: t.literal('pie'),
+        selectedValues: SelectedValues,
+        binningMethod: BinningMethod,
+        selectedCountsOption: SelectedCountsOption,
+      }),
+      t.partial({
+        selectedMarkers: t.array(t.string),
+      }),
+    ]),
     t.intersection([
       t.type({
         type: t.literal('bubble'),
@@ -71,6 +85,7 @@ export const MarkerConfiguration = t.intersection([
         aggregator: t.union([t.literal('mean'), t.literal('median')]),
         numeratorValues: t.union([t.array(t.string), t.undefined]),
         denominatorValues: t.union([t.array(t.string), t.undefined]),
+        selectedMarkers: t.array(t.string),
       }),
     ]),
   ]),

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -76,7 +76,11 @@ export function useStandaloneVizPlugins({
         getOverlayVariableHelp: () => overlayHelp,
         getEntitySubtitleForViz: () =>
           selectedMarkers && selectedMarkers.length > 0
-            ? EntitySubtitleForViz({ subtitle: 'for selected markers' })
+            ? selectedMarkers.length > 1
+              ? EntitySubtitleForViz({ subtitle: 'for selected markers' })
+              : EntitySubtitleForViz({
+                  subtitle: 'for selected marker - shift-click to add more',
+                })
             : EntitySubtitleForViz({
                 subtitle:
                   'for all visible data on map - click markers to refine',

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -8,6 +8,7 @@ import {
   OverlayOptions,
   RequestOptionProps,
   RequestOptions,
+  VerbiageOptions,
 } from '../../../core/components/visualizations/options/types';
 import { VisualizationPlugin } from '../../../core/components/visualizations/VisualizationPlugin';
 
@@ -30,17 +31,20 @@ import { scatterplotRequest } from './plugins/scatterplot';
 
 import TimeSeriesSVG from '../../../core/components/visualizations/implementations/selectorIcons/TimeSeriesSVG';
 import _ from 'lodash';
+import { EntitySubtitleForViz } from '../mapTypes/shared';
 
 interface Props {
   selectedOverlayConfig?: OverlayConfig | BubbleOverlayConfig;
   overlayHelp?: ReactNode;
+  selectedMarkers?: string[] | undefined;
 }
 
-type StandaloneVizOptions = LayoutOptions & OverlayOptions;
+type StandaloneVizOptions = LayoutOptions & OverlayOptions & VerbiageOptions;
 
 export function useStandaloneVizPlugins({
   selectedOverlayConfig,
   overlayHelp = 'The overlay variable can be selected via the top-right panel.',
+  selectedMarkers,
 }: Props): Record<string, ComputationPlugin> {
   return useMemo(() => {
     function vizWithOptions(
@@ -70,6 +74,10 @@ export function useStandaloneVizPlugins({
           }
         },
         getOverlayVariableHelp: () => overlayHelp,
+        getEntitySubtitleForViz: () =>
+          selectedMarkers && selectedMarkers.length > 0
+            ? EntitySubtitleForViz({ subtitle: 'for selected markers' })
+            : EntitySubtitleForViz({ subtitle: 'for all visible data on map' }),
       });
     }
 
@@ -154,5 +162,5 @@ export function useStandaloneVizPlugins({
         },
       },
     };
-  }, [overlayHelp, selectedOverlayConfig]);
+  }, [overlayHelp, selectedOverlayConfig, selectedMarkers]);
 }

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -3,12 +3,14 @@ import * as t from 'io-ts';
 import { ComputationPlugin } from '../../../core/components/computations/Types';
 import { ZeroConfiguration } from '../../../core/components/computations/ZeroConfiguration';
 import { FloatingLayout } from '../../../core/components/layouts/FloatingLayout';
-import { LayoutOptions } from '../../../core/components/layouts/types';
+import {
+  LayoutOptions,
+  TitleOptions,
+} from '../../../core/components/layouts/types';
 import {
   OverlayOptions,
   RequestOptionProps,
   RequestOptions,
-  VerbiageOptions,
 } from '../../../core/components/visualizations/options/types';
 import { VisualizationPlugin } from '../../../core/components/visualizations/VisualizationPlugin';
 
@@ -39,7 +41,7 @@ interface Props {
   selectedMarkers?: string[] | undefined;
 }
 
-type StandaloneVizOptions = LayoutOptions & OverlayOptions & VerbiageOptions;
+type StandaloneVizOptions = LayoutOptions & OverlayOptions & TitleOptions;
 
 export function useStandaloneVizPlugins({
   selectedOverlayConfig,
@@ -74,7 +76,7 @@ export function useStandaloneVizPlugins({
           }
         },
         getOverlayVariableHelp: () => overlayHelp,
-        getEntitySubtitleForViz: () =>
+        getPlotSubtitle: () =>
           selectedMarkers && selectedMarkers.length > 0
             ? selectedMarkers.length > 1
               ? EntitySubtitleForViz({ subtitle: 'for selected markers' })

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -77,7 +77,10 @@ export function useStandaloneVizPlugins({
         getEntitySubtitleForViz: () =>
           selectedMarkers && selectedMarkers.length > 0
             ? EntitySubtitleForViz({ subtitle: 'for selected markers' })
-            : EntitySubtitleForViz({ subtitle: 'for all visible data on map' }),
+            : EntitySubtitleForViz({
+                subtitle:
+                  'for all visible data on map - click markers to refine',
+              }),
       });
     }
 

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -316,7 +316,19 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
 }
 
 function MapLayerComponent(props: MapTypeMapLayerProps) {
-  const { studyEntities, studyId, filters, geoConfigs, appState } = props;
+  const {
+    studyEntities,
+    studyId,
+    filters,
+    geoConfigs,
+    appState,
+    appState: {
+      boundsZoomLevel,
+      markerConfigurations,
+      activeMarkerConfigurationType,
+    },
+    updateConfiguration,
+  } = props;
 
   const {
     selectedVariable,
@@ -340,7 +352,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     studyId,
     filters: filtersForMarkerData,
     geoConfigs,
-    boundsZoomLevel: appState.boundsZoomLevel,
+    boundsZoomLevel,
     selectedVariable,
     selectedValues,
     binningMethod,
@@ -348,15 +360,30 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     valueSpec: selectedPlotMode,
   });
 
+  const setSelectedMarkers = useCallback(
+    (selectedMarkers?: string[]) => {
+      updateConfiguration({
+        ...(props.configuration as BarPlotMarkerConfiguration),
+        selectedMarkers,
+      });
+    },
+    [props.configuration, updateConfiguration]
+  );
+
   if (markerData.error && !markerData.isFetching)
     return isNoDataError(markerData.error) ? null : (
       <MapFloatingErrorDiv error={markerData.error} />
     );
 
-  // pass selectedMarkers and its state function
+  // convert marker data to markers
   const markers = markerData.markerProps?.map((markerProps) => (
     <ChartMarker {...markerProps} />
   ));
+
+  const selectedMarkers = markerConfigurations.find(
+    (markerConfiguration) =>
+      markerConfiguration.type === activeMarkerConfigurationType
+  )?.selectedMarkers;
 
   return (
     <>
@@ -369,8 +396,8 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
             !markerData.isFetching &&
             isApproxSameViewport(appState.viewport, defaultViewport)
           }
-          // selectedMarkers={selectedMarkers}
-          // setSelectedMarkers={setSelectedMarkers}
+          selectedMarkers={selectedMarkers}
+          setSelectedMarkers={setSelectedMarkers}
           flyToMarkersDelay={2000}
         />
       )}

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -316,15 +316,7 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
 }
 
 function MapLayerComponent(props: MapTypeMapLayerProps) {
-  const {
-    studyEntities,
-    studyId,
-    filters,
-    geoConfigs,
-    appState,
-    selectedMarkers,
-    setSelectedMarkers,
-  } = props;
+  const { studyEntities, studyId, filters, geoConfigs, appState } = props;
 
   const {
     selectedVariable,
@@ -377,8 +369,8 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
             !markerData.isFetching &&
             isApproxSameViewport(appState.viewport, defaultViewport)
           }
-          selectedMarkers={selectedMarkers}
-          setSelectedMarkers={setSelectedMarkers}
+          // selectedMarkers={selectedMarkers}
+          // setSelectedMarkers={setSelectedMarkers}
           flyToMarkersDelay={2000}
         />
       )}

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -46,6 +46,7 @@ import {
   useCommonData,
   useDistributionMarkerData,
   useDistributionOverlayConfig,
+  useSelectedMarkerSnackbars,
   visibleOptionFilterFuncs,
 } from '../shared';
 import {
@@ -336,6 +337,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     binningMethod,
     dependentAxisLogScale,
     selectedPlotMode,
+    activeVisualizationId,
   } = props.configuration as BarPlotMarkerConfiguration;
 
   const { filters: filtersForMarkerData } = useLittleFilters(
@@ -360,14 +362,19 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     valueSpec: selectedPlotMode,
   });
 
+  const handleSelectedMarkerSnackbars = useSelectedMarkerSnackbars(
+    activeVisualizationId
+  );
+
   const setSelectedMarkers = useCallback(
     (selectedMarkers?: string[]) => {
+      handleSelectedMarkerSnackbars(selectedMarkers);
       updateConfiguration({
         ...(props.configuration as BarPlotMarkerConfiguration),
         selectedMarkers,
       });
     },
-    [props.configuration, updateConfiguration]
+    [props.configuration, updateConfiguration, handleSelectedMarkerSnackbars]
   );
 
   if (markerData.error && !markerData.isFetching)
@@ -412,6 +419,7 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
     filters,
     geoConfigs,
     appState,
+    appState: { markerConfigurations, activeMarkerConfigurationType },
     updateConfiguration,
     headerButtons,
   } = props;
@@ -443,9 +451,15 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
     valueSpec: configuration.selectedPlotMode,
   });
 
+  const selectedMarkers = markerConfigurations.find(
+    (markerConfiguration) =>
+      markerConfiguration.type === activeMarkerConfigurationType
+  )?.selectedMarkers;
+
   const legendItems = markerData.legendItems;
   const plugins = useStandaloneVizPlugins({
     selectedOverlayConfig: markerData.overlayConfig,
+    selectedMarkers,
   });
   const toggleStarredVariable = useToggleStarredVariable(props.analysisState);
   const noDataError = isNoDataError(markerData.error)

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -188,8 +188,6 @@ function BubbleMapLayer(props: MapTypeMapLayerProps) {
     appState,
     appState: { boundsZoomLevel },
     geoConfigs,
-    selectedMarkers,
-    setSelectedMarkers,
   } = props;
 
   const configuration = props.configuration as BubbleMarkerConfiguration;
@@ -234,8 +232,8 @@ function BubbleMapLayer(props: MapTypeMapLayerProps) {
             !(markersData.isFetching || markersData.isPreviousData) &&
             isApproxSameViewport(appState.viewport, defaultViewport)
           }
-          selectedMarkers={selectedMarkers}
-          setSelectedMarkers={setSelectedMarkers}
+          // selectedMarkers={selectedMarkers}
+          // setSelectedMarkers={setSelectedMarkers}
           flyToMarkersDelay={2000}
         />
       )}

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -186,7 +186,12 @@ function BubbleMapLayer(props: MapTypeMapLayerProps) {
     studyId,
     filters,
     appState,
-    appState: { boundsZoomLevel },
+    appState: {
+      boundsZoomLevel,
+      markerConfigurations,
+      activeMarkerConfigurationType,
+    },
+    updateConfiguration,
     geoConfigs,
   } = props;
 
@@ -214,12 +219,28 @@ function BubbleMapLayer(props: MapTypeMapLayerProps) {
     studyId,
     filters: filtersForMarkerData,
   });
+
+  const setSelectedMarkers = useCallback(
+    (selectedMarkers?: string[]) => {
+      updateConfiguration({
+        ...(props.configuration as BubbleMarkerConfiguration),
+        selectedMarkers,
+      });
+    },
+    [props.configuration, updateConfiguration]
+  );
+
   if (markersData.error && !markersData.isFetching)
     return <MapFloatingErrorDiv error={markersData.error} />;
 
   const markers = markersData.data?.markersData?.map((markerProps) => (
     <BubbleMarker {...markerProps} />
   ));
+
+  const selectedMarkers = markerConfigurations.find(
+    (markerConfiguration) =>
+      markerConfiguration.type === activeMarkerConfigurationType
+  )?.selectedMarkers;
 
   return (
     <>
@@ -232,8 +253,8 @@ function BubbleMapLayer(props: MapTypeMapLayerProps) {
             !(markersData.isFetching || markersData.isPreviousData) &&
             isApproxSameViewport(appState.viewport, defaultViewport)
           }
-          // selectedMarkers={selectedMarkers}
-          // setSelectedMarkers={setSelectedMarkers}
+          selectedMarkers={selectedMarkers}
+          setSelectedMarkers={setSelectedMarkers}
           flyToMarkersDelay={2000}
         />
       )}

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -42,6 +42,7 @@ import {
   isApproxSameViewport,
   markerDataFilterFuncs,
   useCommonData,
+  useSelectedMarkerSnackbars,
 } from '../shared';
 import {
   MapTypeConfigPanelProps,
@@ -65,7 +66,7 @@ export const plugin: MapTypePlugin = {
   displayName,
   ConfigPanelComponent: BubbleMapConfigurationPanel,
   MapLayerComponent: BubbleMapLayer,
-  MapOverlayComponent: BubbleLegends,
+  MapOverlayComponent: BubbleLegendsAndFloater,
   MapTypeHeaderDetails,
   TimeSliderComponent,
 };
@@ -220,8 +221,13 @@ function BubbleMapLayer(props: MapTypeMapLayerProps) {
     filters: filtersForMarkerData,
   });
 
+  const handleSelectedMarkerSnackbars = useSelectedMarkerSnackbars(
+    configuration.activeVisualizationId
+  );
+
   const setSelectedMarkers = useCallback(
     (selectedMarkers?: string[]) => {
+      handleSelectedMarkerSnackbars(selectedMarkers);
       updateConfiguration({
         ...(props.configuration as BubbleMarkerConfiguration),
         selectedMarkers,
@@ -262,12 +268,13 @@ function BubbleMapLayer(props: MapTypeMapLayerProps) {
   );
 }
 
-function BubbleLegends(props: MapTypeMapLayerProps) {
+function BubbleLegendsAndFloater(props: MapTypeMapLayerProps) {
   const {
     studyId,
     filters,
     geoConfigs,
     appState,
+    appState: { markerConfigurations, activeMarkerConfigurationType },
     updateConfiguration,
     headerButtons,
   } = props;
@@ -300,8 +307,14 @@ function BubbleLegends(props: MapTypeMapLayerProps) {
     [configuration, updateConfiguration]
   );
 
+  const selectedMarkers = markerConfigurations.find(
+    (markerConfiguration) =>
+      markerConfiguration.type === activeMarkerConfigurationType
+  )?.selectedMarkers;
+
   const plugins = useStandaloneVizPlugins({
     overlayHelp: 'Overlay variables are not available for this map type',
+    selectedMarkers,
   });
 
   const toggleStarredVariable = useToggleStarredVariable(props.analysisState);

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -11,7 +11,7 @@ import {
   ColorPaletteDefault,
   gradientSequentialColorscaleMap,
 } from '@veupathdb/components/lib/types/plots/addOns';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { UNSELECTED_DISPLAY_TEXT, UNSELECTED_TOKEN } from '../../../constants';
 import {
   StandaloneMapMarkersResponse,
@@ -63,6 +63,7 @@ import { MapFloatingErrorDiv } from '../../MapFloatingErrorDiv';
 import { MapTypeHeaderCounts } from '../MapTypeHeaderCounts';
 import { useLittleFilters } from '../../littleFilters';
 import TimeSliderQuickFilter from '../../TimeSliderQuickFilter';
+import useSnackbar from '@veupathdb/coreui/lib/components/notifications/useSnackbar';
 
 const displayName = 'Donuts';
 
@@ -293,8 +294,16 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     updateConfiguration,
   } = props;
 
-  const { selectedVariable, binningMethod, selectedValues } =
-    props.configuration as PieMarkerConfiguration;
+  const {
+    selectedVariable,
+    binningMethod,
+    selectedValues,
+    activeVisualizationId,
+  } = props.configuration as PieMarkerConfiguration;
+
+  const [shownSelectedMarkersSnackbar, setShownSelectedMarkersSnackbar] =
+    useState(false);
+  const { enqueueSnackbar } = useSnackbar();
 
   const { filters: filtersForMarkerData } = useLittleFilters(
     {
@@ -319,12 +328,32 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
 
   const setSelectedMarkers = useCallback(
     (selectedMarkers?: string[]) => {
+      if (
+        selectedMarkers != null &&
+        !shownSelectedMarkersSnackbar &&
+        activeVisualizationId == null
+      ) {
+        enqueueSnackbar(
+          `Marker selections currently only affect supporting plots`,
+          {
+            variant: 'info',
+          }
+        );
+        setShownSelectedMarkersSnackbar(true);
+      }
+
       updateConfiguration({
         ...(props.configuration as PieMarkerConfiguration),
         selectedMarkers,
       });
     },
-    [props.configuration, updateConfiguration]
+    [
+      props.configuration,
+      updateConfiguration,
+      shownSelectedMarkersSnackbar,
+      activeVisualizationId,
+      enqueueSnackbar,
+    ]
   );
 
   // no markers and no error div for certain known error strings

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -317,11 +317,6 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     valueSpec: 'count',
   });
 
-  const selectedMarkers = markerConfigurations.find(
-    (markerConfiguration) =>
-      markerConfiguration.type === activeMarkerConfigurationType
-  )?.selectedMarkers;
-
   const setSelectedMarkers = useCallback(
     (selectedMarkers?: string[]) => {
       updateConfiguration({
@@ -342,6 +337,11 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
   const markers = markerDataResponse.markerProps?.map((markerProps) => (
     <DonutMarker {...markerProps} />
   ));
+
+  const selectedMarkers = markerConfigurations.find(
+    (markerConfiguration) =>
+      markerConfiguration.type === activeMarkerConfigurationType
+  )?.selectedMarkers;
 
   return (
     <>

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -279,16 +279,18 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
 }
 
 function MapLayerComponent(props: MapTypeMapLayerProps) {
-  // selectedMarkers and its state function
   const {
     studyId,
     studyEntities,
-    selectedMarkers,
-    setSelectedMarkers,
     appState,
-    appState: { boundsZoomLevel },
+    appState: {
+      boundsZoomLevel,
+      markerConfigurations,
+      activeMarkerConfigurationType,
+    },
     geoConfigs,
     filters,
+    updateConfiguration,
   } = props;
 
   const { selectedVariable, binningMethod, selectedValues } =
@@ -315,16 +317,32 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     valueSpec: 'count',
   });
 
+  const selectedMarkers = markerConfigurations.find(
+    (markerConfiguration) =>
+      markerConfiguration.type === activeMarkerConfigurationType
+  )?.selectedMarkers;
+
+  const setSelectedMarkers = useCallback(
+    (selectedMarkers?: string[]) => {
+      updateConfiguration({
+        ...(props.configuration as PieMarkerConfiguration),
+        selectedMarkers,
+      });
+    },
+    [props.configuration, updateConfiguration]
+  );
+
   // no markers and no error div for certain known error strings
   if (markerDataResponse.error && !markerDataResponse.isFetching)
     return isNoDataError(markerDataResponse.error) ? null : (
       <MapFloatingErrorDiv error={markerDataResponse.error} />
     );
 
-  // pass selectedMarkers and its state function
+  // convert marker data into markers
   const markers = markerDataResponse.markerProps?.map((markerProps) => (
     <DonutMarker {...markerProps} />
   ));
+
   return (
     <>
       {markerDataResponse.isFetching && <Spinner />}

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -81,6 +81,7 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
     apps,
     analysisState,
     appState,
+    appState: { markerConfigurations, activeMarkerConfigurationType },
     geoConfigs,
     updateConfiguration,
     studyId,
@@ -223,8 +224,14 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
     configurationMenu,
   };
 
+  const selectedMarkers = markerConfigurations.find(
+    (markerConfiguration) =>
+      markerConfiguration.type === activeMarkerConfigurationType
+  )?.selectedMarkers;
+
   const plugins = useStandaloneVizPlugins({
     selectedOverlayConfig: overlayConfiguration.data,
+    selectedMarkers, // probably not needed for the config panel (but needed for floater)
   });
 
   const setActiveVisualizationId = useCallback(
@@ -334,7 +341,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
         activeVisualizationId == null
       ) {
         enqueueSnackbar(
-          `Marker selections currently only affect supporting plots`,
+          `Marker selections currently only apply to supporting plots`,
           {
             variant: 'info',
           }
@@ -399,6 +406,7 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
     geoConfigs,
     updateConfiguration,
     appState,
+    appState: { markerConfigurations, activeMarkerConfigurationType },
     filters,
     headerButtons,
   } = props;
@@ -441,9 +449,16 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
     valueSpec: 'count',
   });
 
+  const selectedMarkers = markerConfigurations.find(
+    (markerConfiguration) =>
+      markerConfiguration.type === activeMarkerConfigurationType
+  )?.selectedMarkers;
+
   const plugins = useStandaloneVizPlugins({
     selectedOverlayConfig: data.overlayConfig,
+    selectedMarkers,
   });
+
   const toggleStarredVariable = useToggleStarredVariable(props.analysisState);
   const noDataError = isNoDataError(data.error)
     ? noDataErrorMessage

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -344,6 +344,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
           `Marker selections currently only apply to supporting plots`,
           {
             variant: 'info',
+            anchorOrigin: { vertical: 'top', horizontal: 'center' },
           }
         );
         setShownSelectedMarkersSnackbar(true);

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -11,7 +11,7 @@ import {
   ColorPaletteDefault,
   gradientSequentialColorscaleMap,
 } from '@veupathdb/components/lib/types/plots/addOns';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { UNSELECTED_DISPLAY_TEXT, UNSELECTED_TOKEN } from '../../../constants';
 import {
   StandaloneMapMarkersResponse,
@@ -64,7 +64,6 @@ import { MapFloatingErrorDiv } from '../../MapFloatingErrorDiv';
 import { MapTypeHeaderCounts } from '../MapTypeHeaderCounts';
 import { useLittleFilters } from '../../littleFilters';
 import TimeSliderQuickFilter from '../../TimeSliderQuickFilter';
-import useSnackbar from '@veupathdb/coreui/lib/components/notifications/useSnackbar';
 
 const displayName = 'Donuts';
 
@@ -82,7 +81,6 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
     apps,
     analysisState,
     appState,
-    appState: { markerConfigurations, activeMarkerConfigurationType },
     geoConfigs,
     updateConfiguration,
     studyId,
@@ -225,14 +223,8 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
     configurationMenu,
   };
 
-  const selectedMarkers = markerConfigurations.find(
-    (markerConfiguration) =>
-      markerConfiguration.type === activeMarkerConfigurationType
-  )?.selectedMarkers;
-
   const plugins = useStandaloneVizPlugins({
     selectedOverlayConfig: overlayConfiguration.data,
-    selectedMarkers, // probably not needed for the config panel (but needed for floater)
   });
 
   const setActiveVisualizationId = useCallback(

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -43,6 +43,7 @@ import {
   markerDataFilterFuncs,
   floaterFilterFuncs,
   pieOrBarMarkerConfigLittleFilter,
+  useSelectedMarkerSnackbars,
 } from '../shared';
 import {
   MapTypeConfigPanelProps,
@@ -308,10 +309,6 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     activeVisualizationId,
   } = props.configuration as PieMarkerConfiguration;
 
-  const [shownSelectedMarkersSnackbar, setShownSelectedMarkersSnackbar] =
-    useState(false);
-  const { enqueueSnackbar } = useSnackbar();
-
   const { filters: filtersForMarkerData } = useLittleFilters(
     {
       filters,
@@ -333,35 +330,19 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     valueSpec: 'count',
   });
 
+  const handleSelectedMarkerSnackbars = useSelectedMarkerSnackbars(
+    activeVisualizationId
+  );
+
   const setSelectedMarkers = useCallback(
     (selectedMarkers?: string[]) => {
-      if (
-        selectedMarkers != null &&
-        !shownSelectedMarkersSnackbar &&
-        activeVisualizationId == null
-      ) {
-        enqueueSnackbar(
-          `Marker selections currently only apply to supporting plots`,
-          {
-            variant: 'info',
-            anchorOrigin: { vertical: 'top', horizontal: 'center' },
-          }
-        );
-        setShownSelectedMarkersSnackbar(true);
-      }
-
+      handleSelectedMarkerSnackbars(selectedMarkers);
       updateConfiguration({
         ...(props.configuration as PieMarkerConfiguration),
         selectedMarkers,
       });
     },
-    [
-      props.configuration,
-      updateConfiguration,
-      shownSelectedMarkersSnackbar,
-      activeVisualizationId,
-      enqueueSnackbar,
-    ]
+    [props.configuration, updateConfiguration, handleSelectedMarkerSnackbars]
   );
 
   // no markers and no error div for certain known error strings

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -532,7 +532,7 @@ export function pieOrBarMarkerConfigLittleFilter(
 // to the current zoom level and creates a little filter
 // on that variable using `selectedMarkers`
 //
-function selectedMarkersLittleFilter(props: useLittleFiltersProps): Filter[] {
+function selectedMarkersLittleFilter(props: UseLittleFiltersProps): Filter[] {
   const {
     appState: {
       markerConfigurations,

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -403,6 +403,7 @@ export function useSelectedMarkerSnackbars(
         setShownSelectedMarkersSnackbar(true);
       }
       if (
+        (shownSelectedMarkersSnackbar || activeVisualizationId != null) &&
         !shownShiftKeySnackbar &&
         selectedMarkers != null &&
         selectedMarkers.length === 1
@@ -413,6 +414,9 @@ export function useSelectedMarkerSnackbars(
         });
         setShownShiftKeySnackbar(true);
       }
+      // if the user has managed to select more than one marker, then they don't need help
+      if (selectedMarkers != null && selectedMarkers.length > 1)
+        setShownShiftKeySnackbar(true);
     },
     [
       shownSelectedMarkersSnackbar,

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -603,3 +603,11 @@ export const noDataErrorMessage = (
     <p>Please check your filters or choose another variable.</p>
   </div>
 );
+
+/**
+ * Simple styling for the optional visualization subtitle as used in
+ * standaloneVizPlugins.ts (Bob didn't want to convert it to tsx)
+ */
+export function EntitySubtitleForViz({ subtitle }: { subtitle: string }) {
+  return <div style={{ marginTop: 8, fontStyle: 'italic' }}>({subtitle})</div>;
+}

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -32,6 +32,8 @@ import { getCategoricalValues } from '../utils/categoricalValues';
 import { Viewport } from '@veupathdb/components/lib/map/MapVEuMap';
 import { UseLittleFiltersProps } from '../littleFilters';
 import { filtersFromBoundingBox } from '../../../core/utils/visualization';
+import { useCallback, useState } from 'react';
+import useSnackbar from '@veupathdb/coreui/lib/components/notifications/useSnackbar';
 
 export const defaultAnimation = {
   method: 'geohash',
@@ -372,6 +374,52 @@ export function isApproxSameViewport(v1: Viewport, v2: Viewport) {
     v1.zoom === v2.zoom &&
     Math.abs(v1.center[0] - v2.center[0]) < epsilon &&
     Math.abs(v1.center[1] - v2.center[1]) < epsilon
+  );
+}
+
+// returns a function (selectedMarkers?) => voi
+export function useSelectedMarkerSnackbars(
+  activeVisualizationId: string | undefined
+) {
+  const { enqueueSnackbar } = useSnackbar();
+  const [shownSelectedMarkersSnackbar, setShownSelectedMarkersSnackbar] =
+    useState(false);
+  const [shownShiftKeySnackbar, setShownShiftKeySnackbar] = useState(false);
+
+  return useCallback(
+    (selectedMarkers: string[] | undefined) => {
+      if (
+        !shownSelectedMarkersSnackbar &&
+        selectedMarkers != null &&
+        activeVisualizationId == null
+      ) {
+        enqueueSnackbar(
+          `Marker selections currently only apply to supporting plots`,
+          {
+            variant: 'info',
+            anchorOrigin: { vertical: 'top', horizontal: 'center' },
+          }
+        );
+        setShownSelectedMarkersSnackbar(true);
+      }
+      if (
+        !shownShiftKeySnackbar &&
+        selectedMarkers != null &&
+        selectedMarkers.length === 1
+      ) {
+        enqueueSnackbar(`Use shift-click to select multiple markers`, {
+          variant: 'info',
+          anchorOrigin: { vertical: 'top', horizontal: 'center' },
+        });
+        setShownShiftKeySnackbar(true);
+      }
+    },
+    [
+      shownSelectedMarkersSnackbar,
+      shownShiftKeySnackbar,
+      enqueueSnackbar,
+      activeVisualizationId,
+    ]
   );
 }
 

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
@@ -41,9 +41,6 @@ export interface MapTypeMapLayerProps {
   filteredCounts: PromiseHookState<EntityCounts>;
   hideVizInputsAndControls: boolean;
   setHideVizInputsAndControls: (hide: boolean) => void;
-  // selectedMarkers and its state function
-  selectedMarkers?: string[];
-  setSelectedMarkers?: React.Dispatch<React.SetStateAction<string[]>>;
   setTimeSliderConfig?: (
     newConfig: NonNullable<AppState['timeSliderConfig']>
   ) => void;

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
@@ -39,6 +39,8 @@ export interface MapTypeMapLayerProps {
   updateConfiguration: (configuration: unknown) => void;
   totalCounts: PromiseHookState<EntityCounts>;
   filteredCounts: PromiseHookState<EntityCounts>;
+  // TO DO: the hideVizInputsAndControls props are currently required
+  // and sent to plugin components that don't need it - we should also address this
   hideVizInputsAndControls: boolean;
   setHideVizInputsAndControls: (hide: boolean) => void;
   setTimeSliderConfig?: (


### PR DESCRIPTION
Resolves #432 

Currently branched off #794 

First off, as suggested by Dave months ago, I have moved the event handling of "single click to unselect all" out of MapVEuMap and into SemanticMarkers.  This sets the scene for wiring up selected markers to appState per marker mode (which makes sense, because some marker modes might have no markers!)

<s>Testing the floaters is tricky - there's a performance issue with sample-level variables, and assays are affected by this https://github.com/VEuPathDB/EdaDataService/issues/351 However, for PoC you can make a floating barplot on "continent" and click around to see what happens quite quickly.</s> SOLVED :heavy_check_mark: 

- [x] check story still works
- [x] wire up donut mode
- [x] and bar and bubble
- [x] and wire to floaters
- [x] address double data-requests made by histogram
- [x] think more about UX and feedback for users (what if they select markers with no floater - nothing will really happen) - and then just implement a straw man and have a meeting
- [x] move snackbars to top
- [x] make multiple select require shift-click
- [x] add extra snackbar to explain shift-click for multiple select
- [x] fix flashing popups after selection
- [x] increase mouse wheel sensitivity
- [x] roll out to other marker modes and viz types

![image](https://github.com/VEuPathDB/web-monorepo/assets/308639/c0c069a6-e85e-4937-b678-1cc6f00d9282)
