### PR TITLE
break word for long variable name for coverage table

### DIFF
--- a/packages/libs/eda/src/lib/core/components/VariableCoverageTable.tsx
+++ b/packages/libs/eda/src/lib/core/components/VariableCoverageTable.tsx
@@ -78,7 +78,7 @@ export function VariableCoverageTable({
               <tr key={row.role}>
                 <th>{row.role}</th>
                 <td>{row.display}</td>
-                <td className="numeric">
+                <td className="numeric" style={{ minWidth: '5em' }}>
                   {row.completeCount?.toLocaleString()}
                   <br />
                   {row.completePercent != null && (

--- a/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
+++ b/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
@@ -219,6 +219,7 @@ $data-table-thick-border: 2px solid #262626;
   th,
   td {
     padding-right: 20px;
+    word-break: break-word;
   }
 
   th {

--- a/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
+++ b/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
@@ -219,7 +219,6 @@ $data-table-thick-border: 2px solid #262626;
   th,
   td {
     padding-right: 20px;
-    word-break: break-word;
   }
 
   th {
@@ -251,6 +250,10 @@ $data-table-thick-border: 2px solid #262626;
   }
   th {
     vertical-align: baseline;
+  }
+  td {
+    padding-right: 10px;
+    word-break: break-word;
   }
 }
 


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/817

The culprit in the ticket's screenshot was a very long variable name without specific separation in words, fructose/glucose/galactose:HIL-neg: Metabolite. So, if we want to keep all table contents inside the table, then we need to use a css, word-break. Screenshot is attached with this PR.

![mass table fix01](https://github.com/VEuPathDB/web-monorepo/assets/12802305/d0f858a7-d164-4fc7-a249-43f7760d8b38)

(update) I didn't like the style for Data column so I made some changes. Here is new one:
![mass table fix02](https://github.com/VEuPathDB/web-monorepo/assets/12802305/10136181-8a47-4e48-9242-20ab71beb117)
