### PR TITLE
nicely handle empty data for visualizations in SAM

### DIFF
--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -22,6 +22,8 @@ import {
   BinWidthSlider,
   TimeUnit,
   NumberOrNull,
+  LineplotBinWidthSlider,
+  LineplotBinSpec,
 } from '../../types/general';
 import { VariableDescriptor, StringVariableValue } from '../../types/variable';
 import { ComputationAppOverview } from '../../types/visualization';
@@ -540,8 +542,8 @@ export type LineplotConfig = TypeOf<typeof lineplotConfig>;
 const lineplotConfig = intersection([
   plotConfig,
   partial({
-    binSlider: BinWidthSlider,
-    binSpec: BinSpec,
+    binSlider: LineplotBinWidthSlider,
+    binSpec: LineplotBinSpec,
     viewport: numericViewport,
   }),
 ]);

--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -622,9 +622,9 @@ export const ContTableResponse = intersection([
   partial({
     statsTable: array(
       partial({
-        pvalue: union([number, string]), // TO DO: should these three stats values all be optional?
-        degreesFreedom: number,
-        chisq: number,
+        pvalue: union([number, string, nullType]), // TO DO: should these three stats values all be optional?
+        degreesFreedom: NumberOrNull,
+        chisq: NumberOrNull,
         facetVariableDetails: union([
           tuple([StringVariableValue]),
           tuple([StringVariableValue, StringVariableValue]),

--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -22,8 +22,6 @@ import {
   BinWidthSlider,
   TimeUnit,
   NumberOrNull,
-  LineplotBinWidthSlider,
-  LineplotBinSpec,
 } from '../../types/general';
 import { VariableDescriptor, StringVariableValue } from '../../types/variable';
 import { ComputationAppOverview } from '../../types/visualization';
@@ -542,8 +540,8 @@ export type LineplotConfig = TypeOf<typeof lineplotConfig>;
 const lineplotConfig = intersection([
   plotConfig,
   partial({
-    binSlider: LineplotBinWidthSlider,
-    binSpec: LineplotBinSpec,
+    binSlider: BinWidthSlider,
+    binSpec: BinSpec,
     viewport: numericViewport,
   }),
 ]);

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -614,46 +614,56 @@ function BoxplotViz(props: VisualizationProps<Options>) {
   ) as NumberRange;
 
   // custom legend items for checkbox
-  const legendItems: LegendItemsProps[] = useMemo(() => {
-    const legendData = !isFaceted(data.value)
-      ? data.value?.series
-      : data.value?.facets.find(
-          ({ data }) => data != null && data.series.length > 0
-        )?.data?.series;
+  const [legendItems, isEmptyData]: [LegendItemsProps[], boolean] =
+    useMemo(() => {
+      const legendData = !isFaceted(data.value)
+        ? data.value?.series
+        : data.value?.facets.find(
+            ({ data }) => data != null && data.series.length > 0
+          )?.data?.series;
 
-    return legendData != null
-      ? legendData.map((dataItem: BoxplotDataObject, index: number) => {
-          return {
-            label: dataItem.name ?? '',
-            // histogram plot does not have mode, so set to square for now
-            marker: 'lightSquareBorder',
-            markerColor:
-              dataItem.name === 'No data'
-                ? // boxplot uses slightly fainted color
-                  'rgb(191, 191, 191)' // #bfbfbf
-                : ColorPaletteDefault[index],
-            // deep comparison is required for faceted plot
-            hasData: !isFaceted(data.value) // no faceted plot
-              ? dataItem.q1.some((el: number | string) => el != null)
-                ? true
-                : false
-              : data.value?.facets
-                  .map((el: { label: string; data?: BoxplotData }) => {
-                    // faceted plot: here data.value is full data
-                    // need to check whether el.data.series[index] exists
-                    return el.data?.series[index]?.q1.some(
-                      (el: number | string) => el != null
-                    );
-                  })
-                  .includes(true)
-              ? true
-              : false,
-            group: 1,
-            rank: 1,
-          };
-        })
-      : [];
-  }, [data]);
+      const legendItems =
+        legendData != null
+          ? legendData.map((dataItem: BoxplotDataObject, index: number) => {
+              return {
+                label: dataItem.name ?? '',
+                // histogram plot does not have mode, so set to square for now
+                marker: 'lightSquareBorder' as const,
+                markerColor:
+                  dataItem.name === 'No data'
+                    ? // boxplot uses slightly fainted color
+                      'rgb(191, 191, 191)' // #bfbfbf
+                    : ColorPaletteDefault[index],
+                // deep comparison is required for faceted plot
+                hasData: !isFaceted(data.value) // no faceted plot
+                  ? dataItem.q1.some((el: number | string) => el != null)
+                    ? true
+                    : false
+                  : data.value?.facets
+                      .map((el: { label: string; data?: BoxplotData }) => {
+                        // faceted plot: here data.value is full data
+                        // need to check whether el.data.series[index] exists
+                        return el.data?.series[index]?.q1.some(
+                          (el: number | string) => el != null
+                        );
+                      })
+                      .includes(true)
+                  ? true
+                  : false,
+                group: 1,
+                rank: 1,
+              };
+            })
+          : [];
+
+      // use legendData also to determine if there's no data at all (for PluginError banner)
+      // because outputSize can't always rely on data.value.completeCasesAllVars and friend
+      const isEmptyData =
+        data.value != null &&
+        legendData?.find((series) => series.label.length > 0) == null;
+
+      return [legendItems, isEmptyData];
+    }, [data]);
 
   // set checkedLegendItems to either the config-stored items, or all items if
   // nothing stored (or if no overlay locally configured)
@@ -923,7 +933,10 @@ function BoxplotViz(props: VisualizationProps<Options>) {
         )}
       </div>
 
-      <PluginError error={data.error} outputSize={outputSize} />
+      <PluginError
+        error={data.error}
+        outputSize={isEmptyData ? 0 : outputSize}
+      />
       {!hideInputsAndControls && (
         <OutputEntityTitle
           entity={outputEntity}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/BoxplotVisualization.tsx
@@ -627,7 +627,6 @@ function BoxplotViz(props: VisualizationProps<Options>) {
           ? legendData.map((dataItem: BoxplotDataObject, index: number) => {
               return {
                 label: dataItem.name ?? '',
-                // histogram plot does not have mode, so set to square for now
                 marker: 'lightSquareBorder' as const,
                 markerColor:
                   dataItem.name === 'No data'

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -662,6 +662,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
   // we can't always rely on data.value?.completeCasesXXXVars (e.g. in SAM)
   // in the outputSize determination above, so we make a simple check the data (or one non-empty facet)
   const isEmptyData =
+    data.value &&
     checkData?.series.find((series) => series.bins.length > 0) == null;
 
   // Note: Histogram distribution data contains statistical values such as summary.min/max,

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -869,13 +869,6 @@ function HistogramViz(props: VisualizationProps<Options>) {
 
   const widgetHeight = '4em';
 
-  // controls need the bin info from just one facet (not an empty one)
-  const data0 = isFaceted(data.value)
-    ? data.value.facets.find(
-        ({ data }) => data != null && data.series.length > 0
-      )?.data
-    : data.value;
-
   // set truncation flags: will see if this is reusable with other application
   const {
     truncationConfigIndependentAxisMin,
@@ -1117,18 +1110,18 @@ function HistogramViz(props: VisualizationProps<Options>) {
               }}
             >
               <BinWidthControl
-                binWidth={data0?.binWidthSlider?.binWidth}
+                binWidth={checkData?.binWidthSlider?.binWidth}
                 onBinWidthChange={onBinWidthChange}
-                binWidthRange={data0?.binWidthSlider?.binWidthRange}
-                binWidthStep={data0?.binWidthSlider?.binWidthStep}
-                valueType={data0?.binWidthSlider?.valueType}
+                binWidthRange={checkData?.binWidthSlider?.binWidthRange}
+                binWidthStep={checkData?.binWidthSlider?.binWidthStep}
+                valueType={checkData?.binWidthSlider?.valueType}
                 binUnit={
-                  data0?.binWidthSlider?.valueType === 'date'
-                    ? (data0?.binWidthSlider?.binWidth as TimeDelta).unit
+                  checkData?.binWidthSlider?.valueType === 'date'
+                    ? (checkData?.binWidthSlider?.binWidth as TimeDelta).unit
                     : undefined
                 }
                 binUnitOptions={
-                  data0?.binWidthSlider?.valueType === 'date'
+                  checkData?.binWidthSlider?.valueType === 'date'
                     ? ['day', 'week', 'month', 'year']
                     : undefined
                 }

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -1411,7 +1411,17 @@ export function histogramResponseToData(
   overlayVariable?: Variable,
   facetVariable?: Variable
 ): HistogramDataWithCoverageStatistics {
-  if (response.histogram.data.length === 0)
+  // check if data is empty: there is a case that data.length != 0 but still no data at SAM
+  // dataExist before filter() will have an array of booleans, e.g.,  [true, false, true,...]
+  // if data does not exists, the array consists of all false values
+  // filtering out true cases, then no data  = dataExist.length === 0
+  const dataExist = response.histogram.data
+    .map((item) => {
+      return item.value.length > 0;
+    })
+    .filter((element: boolean) => element);
+
+  if (response.histogram.data.length === 0 || dataExist.length === 0)
     throw Error(`Expected one or more data series, but got zero`);
 
   const facetGroupedResponseData = groupBy(response.histogram.data, (data) =>

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -652,18 +652,22 @@ function HistogramViz(props: VisualizationProps<Options>) {
     ])
   );
 
-  // controls need the bin info from just one facet (not an empty one)
-  const checkData = isFaceted(data.value)
-    ? data.value.facets.find(
-        ({ data }) => data != null && data.series.length > 0
-      )?.data
-    : data.value;
+  const [checkData, isEmptyData] = useMemo(() => {
+    // controls need the bin info from just one facet (not an empty one)
+    const checkData = isFaceted(data.value)
+      ? data.value.facets.find(
+          ({ data }) => data != null && data.series.length > 0
+        )?.data
+      : data.value;
 
-  // we can't always rely on data.value?.completeCasesXXXVars (e.g. in SAM)
-  // in the outputSize determination above, so we make a simple check the data (or one non-empty facet)
-  const isEmptyData =
-    data.value != null &&
-    checkData?.series.find((series) => series.bins.length > 0) == null;
+    // we can't always rely on data.value?.completeCasesXXXVars (e.g. in SAM)
+    // in the outputSize determination above, so we make a simple check the data (or one non-empty facet)
+    const isEmptyData =
+      data.value != null &&
+      checkData?.series.find((series) => series.bins.length > 0) == null;
+
+    return [checkData, isEmptyData];
+  }, [data.value]);
 
   // Note: Histogram distribution data contains statistical values such as summary.min/max,
   // however, it does not fully respect multiple filters.

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -662,7 +662,7 @@ function HistogramViz(props: VisualizationProps<Options>) {
   // we can't always rely on data.value?.completeCasesXXXVars (e.g. in SAM)
   // in the outputSize determination above, so we make a simple check the data (or one non-empty facet)
   const isEmptyData =
-    data.value &&
+    data.value != null &&
     checkData?.series.find((series) => series.bins.length > 0) == null;
 
   // Note: Histogram distribution data contains statistical values such as summary.min/max,

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -1411,17 +1411,7 @@ export function histogramResponseToData(
   overlayVariable?: Variable,
   facetVariable?: Variable
 ): HistogramDataWithCoverageStatistics {
-  // check if data is empty: there is a case that data.length != 0 but still no data at SAM
-  // dataExist before filter() will have an array of booleans, e.g.,  [true, false, true,...]
-  // if data does not exists, the array consists of all false values
-  // filtering out true cases, then no data  = dataExist.length === 0
-  const dataExist = response.histogram.data
-    .map((item) => {
-      return item.value.length > 0;
-    })
-    .filter((element: boolean) => element);
-
-  if (response.histogram.data.length === 0 || dataExist.length === 0)
+  if (!response.histogram.data.find((item) => item.value.length > 0))
     throw Error(`Expected one or more data series, but got zero`);
 
   const facetGroupedResponseData = groupBy(response.histogram.data, (data) =>

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -101,7 +101,11 @@ import { LegendItemsProps } from '@veupathdb/components/lib/components/plotContr
 import { isFaceted, isTimeDelta } from '@veupathdb/components/lib/types/guards';
 import FacetedLinePlot from '@veupathdb/components/lib/plots/facetedPlots/FacetedLinePlot';
 import { useCheckedLegendItems } from '../../../hooks/checkedLegendItemsStatus';
-import { BinSpec, BinWidthSlider, TimeUnit } from '../../../types/general';
+import {
+  TimeUnit,
+  LineplotBinWidthSlider,
+  LineplotBinSpec,
+} from '../../../types/general';
 import {
   useNeutralPaletteProps,
   useVizConfig,
@@ -2154,8 +2158,9 @@ function processInputData(
   showMissingness: boolean,
   hasMissingData: boolean,
   dependentIsProportion: boolean,
-  binSpec?: BinSpec,
-  binWidthSlider?: BinWidthSlider,
+  // allow null for binspec and binslider
+  binSpec?: LineplotBinSpec,
+  binWidthSlider?: LineplotBinWidthSlider,
   overlayVariable?: Variable,
   colorPaletteOverride?: string[],
   showMarginalHistogram?: boolean

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -1129,23 +1129,23 @@ function LineplotViz(props: VisualizationProps<Options>) {
   const widgetHeight = '4em';
 
   // controls need the bin info from just one facet (not an empty one)
-  const data0 = isFaceted(data.value?.dataSetProcess)
+  const checkData = isFaceted(data.value?.dataSetProcess)
     ? data.value?.dataSetProcess.facets.find(
         ({ data }) => data != null && data.series.length > 0
       )?.data
     : data.value?.dataSetProcess;
 
-  // use data0 also to determine if there's no data at all (for PluginError banner)
+  // use checkData also to determine if there's no data at all (for PluginError banner)
   // because outputSize can't always rely on data.value.completeCasesAllVars and friend
   const isEmptyData =
     data.value != null &&
-    data0?.series.find((series) => series.x.length > 0) == null;
+    checkData?.series.find((series) => series.x.length > 0) == null;
 
   // add banner condition to avoid unnecessary disabled
   const neverUseBinning =
     !showIndependentAxisBanner &&
     !showDependentAxisBanner &&
-    data0?.binWidthSlider == null; // for ordinal string x-variables
+    checkData?.binWidthSlider == null; // for ordinal string x-variables
 
   // axis range control
   const neverShowErrorBars = lineplotProps.dependentValueType === 'date';
@@ -1390,18 +1390,18 @@ function LineplotViz(props: VisualizationProps<Options>) {
                 />
               ) : null}
               <BinWidthControl
-                binWidth={data0?.binWidthSlider?.binWidth}
+                binWidth={checkData?.binWidthSlider?.binWidth}
                 onBinWidthChange={onBinWidthChange}
-                binWidthRange={data0?.binWidthSlider?.binWidthRange}
-                binWidthStep={data0?.binWidthSlider?.binWidthStep}
-                valueType={data0?.binWidthSlider?.valueType}
+                binWidthRange={checkData?.binWidthSlider?.binWidthRange}
+                binWidthStep={checkData?.binWidthSlider?.binWidthStep}
+                valueType={checkData?.binWidthSlider?.valueType}
                 binUnit={
-                  data0?.binWidthSlider?.valueType === 'date'
-                    ? (data0?.binWidthSlider?.binWidth as TimeDelta).unit
+                  checkData?.binWidthSlider?.valueType === 'date'
+                    ? (checkData?.binWidthSlider?.binWidth as TimeDelta).unit
                     : undefined
                 }
                 binUnitOptions={
-                  data0?.binWidthSlider?.valueType === 'date'
+                  checkData?.binWidthSlider?.valueType === 'date'
                     ? ['day', 'week', 'month', 'year']
                     : undefined
                 }

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -1138,7 +1138,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
   // use data0 also to determine if there's no data at all (for PluginError banner)
   // because outputSize can't always rely on data.value.completeCasesAllVars and friend
   const isEmptyData =
-    data0?.series.find((series) => series.x.length > 0) == null;
+    data.value && data0?.series.find((series) => series.x.length > 0) == null;
 
   // add banner condition to avoid unnecessary disabled
   const neverUseBinning =

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -1138,7 +1138,8 @@ function LineplotViz(props: VisualizationProps<Options>) {
   // use data0 also to determine if there's no data at all (for PluginError banner)
   // because outputSize can't always rely on data.value.completeCasesAllVars and friend
   const isEmptyData =
-    data.value && data0?.series.find((series) => series.x.length > 0) == null;
+    data.value != null &&
+    data0?.series.find((series) => series.x.length > 0) == null;
 
   // add banner condition to avoid unnecessary disabled
   const neverUseBinning =

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -1136,6 +1136,7 @@ function LineplotViz(props: VisualizationProps<Options>) {
     : data.value?.dataSetProcess;
 
   // use data0 also to determine if there's no data at all (for PluginError banner)
+  // because outputSize can't always rely on data.value.completeCasesAllVars and friend
   const isEmptyData =
     data0?.series.find((series) => series.x.length > 0) == null;
 

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -101,11 +101,7 @@ import { LegendItemsProps } from '@veupathdb/components/lib/components/plotContr
 import { isFaceted, isTimeDelta } from '@veupathdb/components/lib/types/guards';
 import FacetedLinePlot from '@veupathdb/components/lib/plots/facetedPlots/FacetedLinePlot';
 import { useCheckedLegendItems } from '../../../hooks/checkedLegendItemsStatus';
-import {
-  TimeUnit,
-  LineplotBinWidthSlider,
-  LineplotBinSpec,
-} from '../../../types/general';
+import { BinSpec, BinWidthSlider, TimeUnit } from '../../../types/general';
 import {
   useNeutralPaletteProps,
   useVizConfig,
@@ -2163,9 +2159,9 @@ function processInputData(
   showMissingness: boolean,
   hasMissingData: boolean,
   dependentIsProportion: boolean,
-  // allow null for binspec and binslider
-  binSpec?: LineplotBinSpec,
-  binWidthSlider?: LineplotBinWidthSlider,
+  // allow null for binSpec and binWidthSlider
+  binSpec?: BinSpec,
+  binWidthSlider?: BinWidthSlider,
   overlayVariable?: Variable,
   colorPaletteOverride?: string[],
   showMarginalHistogram?: boolean

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -1135,6 +1135,10 @@ function LineplotViz(props: VisualizationProps<Options>) {
       )?.data
     : data.value?.dataSetProcess;
 
+  // use data0 also to determine if there's no data at all (for PluginError banner)
+  const isEmptyData =
+    data0?.series.find((series) => series.x.length > 0) == null;
+
   // add banner condition to avoid unnecessary disabled
   const neverUseBinning =
     !showIndependentAxisBanner &&
@@ -1824,7 +1828,10 @@ function LineplotViz(props: VisualizationProps<Options>) {
         )}
       </div>
 
-      <PluginError error={data.error} outputSize={outputSize} />
+      <PluginError
+        error={data.error}
+        outputSize={isEmptyData ? 0 : outputSize}
+      />
       {!hideInputsAndControls && (
         <OutputEntityTitle
           entity={outputEntity}
@@ -1928,9 +1935,11 @@ export function lineplotResponseToData(
   const yMax = max(map(processedData, ({ yMax }) => yMax));
 
   const dataSetProcess =
-    size(processedData) === 1 && head(keys(processedData)) === '__NO_FACET__'
+    (size(processedData) === 1 &&
+      head(keys(processedData)) === '__NO_FACET__') ||
+    size(processedData) === 0
       ? // unfaceted
-        head(values(processedData))?.dataSetProcess
+        head(values(processedData))?.dataSetProcess ?? { series: [] }
       : // faceted
         {
           facets: vocabularyWithMissingData(

--- a/packages/libs/eda/src/lib/core/types/general.ts
+++ b/packages/libs/eda/src/lib/core/types/general.ts
@@ -61,3 +61,21 @@ export const BinWidthSlider = type({
   max: number,
   step: number,
 });
+
+// allow null for Lineplot's binslider and binspec
+export type LineplotBinWidthSlider = TypeOf<typeof LineplotBinWidthSlider>;
+export const LineplotBinWidthSlider = type({
+  min: NumberOrNull,
+  max: NumberOrNull,
+  step: NumberOrNull,
+});
+
+export type LineplotBinSpec = TypeOf<typeof LineplotBinSpec>;
+export const LineplotBinSpec = intersection([
+  type({ type: keyof({ binWidth: null, numBins: null }) }),
+  partial({
+    value: NumberOrNull,
+    units: TimeUnit,
+    range: NumberOrDateRange,
+  }),
+]);

--- a/packages/libs/eda/src/lib/core/types/general.ts
+++ b/packages/libs/eda/src/lib/core/types/general.ts
@@ -47,7 +47,7 @@ export type BinSpec = TypeOf<typeof BinSpec>;
 export const BinSpec = intersection([
   type({ type: keyof({ binWidth: null, numBins: null }) }),
   partial({
-    value: number,
+    value: NumberOrNull,
     units: TimeUnit,
     range: NumberOrDateRange,
   }),
@@ -57,25 +57,7 @@ export const BinSpec = intersection([
 // perhaps we can make these two consistent somehow?
 export type BinWidthSlider = TypeOf<typeof BinWidthSlider>;
 export const BinWidthSlider = type({
-  min: number,
-  max: number,
-  step: number,
-});
-
-// allow null for Lineplot's binslider and binspec
-export type LineplotBinWidthSlider = TypeOf<typeof LineplotBinWidthSlider>;
-export const LineplotBinWidthSlider = type({
   min: NumberOrNull,
   max: NumberOrNull,
   step: NumberOrNull,
 });
-
-export type LineplotBinSpec = TypeOf<typeof LineplotBinSpec>;
-export const LineplotBinSpec = intersection([
-  type({ type: keyof({ binWidth: null, numBins: null }) }),
-  partial({
-    value: NumberOrNull,
-    units: TimeUnit,
-    range: NumberOrDateRange,
-  }),
-]);


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-eda/issues/1631.

Following on from some changes in back end responses (see #836) we are revisiting the behaviour of floating plots when there is nothing to plot. A key background point here is that the SAM floating plot endpoints (e.g. histogram, lineplot etc) don't return `completeCasesAllVars` and `completeCasesAxesVars` for performance reasons and because missing data is not handled the same as in EDA. These two values are used to calculate `outputSize` which is fed to `PluginError` to produce an appropriate warning banner when it is zero.

In addition we have relaxed `io-ts` validation to allow nulls for binSlider and binSpec when there is an empty response from the back end (but no 204 or 500). This happens when there is a subset, but the plot variables are absent from that subset.


### old PR notes

The error message(s) indicates type errors of backend response. I think that null returns of binSlider/binSpec in Lineplot Viz means empty data return, thus relevant types are loose to accommodate null values. After this change, the error message is the same with what we could see at Scatterplot Viz

![lineplot error message02](https://github.com/VEuPathDB/web-monorepo/assets/12802305/348d6517-bc03-4ed7-875c-7a844814ceb2)
