### PR TITLE
Fix bug with grid rows and breakpoints

### DIFF
--- a/packages/libs/web-common/src/styles/default-layout.scss
+++ b/packages/libs/web-common/src/styles/default-layout.scss
@@ -36,7 +36,7 @@ body.vpdb-Body {
     grid-template-rows: $expanded-header-height auto 1fr auto;
 
     @media screen and (max-width: $hamburger-width) {
-      grid-template-rows: auto auto 1fr auto !important;
+      grid-template-rows: auto auto 1fr auto;
     }
 
     grid-template-columns: 100%;

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.scss
@@ -194,18 +194,3 @@ body.vpdb-Body .ExternalContentController a[name]::before {
 body.vpdb-Body .wdk-RecordSidebarContainer {
   top: 2em;
 }
-
-body.vpdb-Body .vpdb-RootContainer {
-  @media screen and (max-width: $mobile-width) {
-    grid-template-areas:
-      'header'
-      'subheader'
-      'banner'
-      'nav'
-      'content'
-      'side'
-      'footer';
-
-    grid-template-rows: auto auto auto auto 1fr auto auto;
-  }
-}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/styles/home-page-layout.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/styles/home-page-layout.scss
@@ -10,6 +10,10 @@ body.vpdb-Body .vpdb-RootContainer {
 
   grid-template-rows: 11em auto auto 1fr auto;
 
+  @media screen and (max-width: $hamburger-width) {
+    grid-template-rows: auto auto auto 1fr auto;
+  }
+
   &__home {
     grid-template-areas:
       'header header header'
@@ -31,6 +35,19 @@ body.vpdb-Body .vpdb-RootContainer {
         'nav content content'
         'nav side side'
         'footer footer footer';
+    }
+
+    @media screen and (max-width: $mobile-width) {
+      grid-template-areas:
+        'header'
+        'subheader'
+        'banner'
+        'nav'
+        'content'
+        'side'
+        'footer';
+
+      grid-template-rows: auto auto auto auto 1fr auto auto;
     }
   }
 


### PR DESCRIPTION
Our breakpoints targeting the grid layout are off. On the live site, notice how changing between the workspace tabs for all datasets to new upload jumps the page:

https://github.com/VEuPathDB/web-monorepo/assets/69446567/8a14a6f6-a6ba-4718-954e-770d605356dd

I reverted an old change I made to `default-layout` that added the `!important` attribute. It was a hack that masked other problems. Somehow it seems Ortho is using just the default layout grid, even on the homepage, without issue.

As for genomics, I made specific changes to breakpoint logic that fixes the original issue that the `!important` attribute aimed to fix, which was the "ghost" effect of the hamburger menu rendering without the site header's background behind it, and it fixed the jumping effect that prompted this investigation. I also moved a breakpoint that is intended to target the homepage grid areas but was actually being applied sitewide.
