### PR TITLE
fix bugs on some EDA viz buttons

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -195,7 +195,7 @@ function ConfiguredVisualizations(props: Props) {
                             analysisState.deleteVisualization(
                               viz.visualizationId
                             );
-                            /* 
+                            /*
                               Here we're deleting the computation in the event we delete
                               the computation's last remaining visualization.
                             */
@@ -331,7 +331,7 @@ export function NewVisualizationPicker(props: NewVisualizationPickerProps) {
       {includeHeader && (
         <>
           <div className={cx('-PickerActions')}>
-            <Link replace to={`../${computationId}`}>
+            <Link replace to={'../visualizations'}>
               <i className="fa fa-close"></i>
             </Link>
           </div>
@@ -393,7 +393,9 @@ export function NewVisualizationPicker(props: NewVisualizationPickerProps) {
                 <div>
                   {vizOverview.displayName
                     ?.split(/(, )/g)
-                    .map((str) => (str === ', ' ? <br /> : str))}
+                    .map((str, index) =>
+                      str === ', ' ? <br key={index} /> : str
+                    )}
                 </div>
                 {vizPlugin == null && <i>(Coming soon!)</i>}
                 {vizPlugin != null && disabled && (
@@ -576,7 +578,7 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
                   onClick={() => {
                     if (viz == null) return;
                     analysisState.deleteVisualization(viz.visualizationId);
-                    /* 
+                    /*
                       Here we're deleting the computation in the event we delete
                       the computation's last remaining visualization.
                     */
@@ -625,7 +627,7 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
             <Tooltip title="Minimize visualization">
               <Link
                 to={{
-                  pathname: `../${baseUrl ? '' : computationId}`, // Should go to ../visualizations unless in single app mode
+                  pathname: `${baseUrl ? baseUrl : '../' + computationId}`, // Should go to ../visualizations unless in single app
                   state: { scrollToTop: false },
                 }}
               >


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/829.

Although this would work ok, I have a question, @dmfalke. For the second Lin/pathname at Minimize Visualization, I have no idea what the role of computationId is in there. I tried both ClinEpi and Microbiome site to check the value of computationId in there, but it is not that meaningful value for the behavior of the "Minimize Viz": either pass-through or a random word (mbio). So, I think that it can be simply used as the following. What do you think?

`pathname: '../visualizations',`