### PR TITLE
Handle 204s in DataClient and FetchClient

### DIFF
--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -228,9 +228,10 @@ export default function Banner(props: BannerComponentProps) {
                 `}
               >
                 {/* showMore implementation */}
-                {message}&nbsp;
+                {message}
                 {(additionalMessage != null || CollapsibleContent != null) && (
                   <>
+                    {' '}
                     {isShowMore && additionalMessage}
                     <button
                       css={css`

--- a/packages/libs/eda/src/lib/core/api/DataClient/NoDataError.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/NoDataError.ts
@@ -1,0 +1,11 @@
+export class NoDataError extends Error {
+  name = 'NoDataError';
+  constructor(
+    message: string,
+    public response: string,
+    public status: number,
+    public logMarker: string
+  ) {
+    super(message);
+  }
+}

--- a/packages/libs/eda/src/lib/core/api/DataClient/index.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/index.ts
@@ -62,7 +62,7 @@ export default class DataClient extends FetchClientWithCredentials {
         transformResponse(body) {
           if (body == null) {
             throw new NoDataError(
-              'The visualization cannot be made because the current subset is empty.',
+              'The visualization cannot be made because no data remains after filtering.',
               'No data',
               204,
               uuid()

--- a/packages/libs/eda/src/lib/core/api/DataClient/index.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/index.ts
@@ -1,4 +1,5 @@
 import { TypeOf, Decoder } from 'io-ts';
+import { v4 as uuid } from 'uuid';
 
 import {
   createJsonRequest,
@@ -34,6 +35,7 @@ import {
   StandaloneMapBubblesLegendRequestParams,
   StandaloneMapBubblesLegendResponse,
 } from './types';
+import { NoDataError } from './NoDataError';
 
 export default class DataClient extends FetchClientWithCredentials {
   getApps(): Promise<TypeOf<typeof AppsResponse>> {
@@ -59,11 +61,13 @@ export default class DataClient extends FetchClientWithCredentials {
         body: params,
         transformResponse(body) {
           if (body == null) {
-            throw new Error(
-              'The visualization cannot be made because the current subset is empty.'
+            throw new NoDataError(
+              'The visualization cannot be made because the current subset is empty.',
+              'No data',
+              204,
+              uuid()
             );
           }
-          console.log(body, decoder);
           return ioTransformer(decoder)(body);
         },
       })

--- a/packages/libs/eda/src/lib/core/api/DataClient/index.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/index.ts
@@ -57,7 +57,15 @@ export default class DataClient extends FetchClientWithCredentials {
         method: 'POST',
         path: `/apps/${computationName}/visualizations/${visualizationName}`,
         body: params,
-        transformResponse: ioTransformer(decoder),
+        transformResponse(body) {
+          if (body == null) {
+            throw new Error(
+              'The visualization cannot be made because the current subset is empty.'
+            );
+          }
+          console.log(body, decoder);
+          return ioTransformer(decoder)(body);
+        },
       })
     );
   }

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -2089,8 +2089,14 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         error={data.error}
         outputSize={outputSize}
         customCases={[
-          (errorString) =>
-            errorString.match(/400.+too large/is) ? (
+          (error) => {
+            const errorMessage =
+              error == null
+                ? ''
+                : error instanceof Error
+                ? error.message
+                : String(error);
+            return errorMessage.match(/400.+too large/is) ? (
               <span>
                 Your plot currently has too many points (&gt;
                 {MAXALLOWEDDATAPOINTS.toLocaleString()}) to display in a
@@ -2101,7 +2107,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
                 tab to reduce the number, or consider using a summary plot such
                 as histogram or boxplot.
               </span>
-            ) : undefined,
+            ) : undefined;
+          },
         ]}
       />
 

--- a/packages/libs/eda/src/lib/map/analysis/MapFloatingErrorDiv.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapFloatingErrorDiv.tsx
@@ -4,10 +4,14 @@ import { useMap } from 'react-leaflet';
 import { Link } from 'react-router-dom';
 
 interface MapFloatingErrorDivProps {
-  error: unknown;
+  error?: unknown;
+  children?: React.ReactNode;
 }
 
-export function MapFloatingErrorDiv({ error }: MapFloatingErrorDivProps) {
+export function MapFloatingErrorDiv({
+  error,
+  children,
+}: MapFloatingErrorDivProps) {
   // We're using a portal here so that the user can select the text
   // in the banner. The portal causes the resulting DOM node to be a
   // child of the DOM node that is passed as a second argument to the
@@ -27,26 +31,29 @@ export function MapFloatingErrorDiv({ error }: MapFloatingErrorDivProps) {
         width: '55em',
       }}
     >
-      <Banner
-        banner={{
-          type: 'error',
-          message: (
-            <>
-              We are not able to display the requested data. Try again later, or{' '}
-              <Link to="/contact-us" target="_blank">
-                contact us
-              </Link>{' '}
-              for assistance.
-            </>
-          ),
-          additionalMessage: (
-            <pre style={{ whiteSpace: 'break-spaces' }}>{String(error)}</pre>
-          ),
-          showMoreLinkText: 'See details',
-          showLessLinkText: 'Hide details',
-          isShowMoreLinkBold: true,
-        }}
-      />
+      {children ?? (
+        <Banner
+          banner={{
+            type: 'error',
+            message: (
+              <>
+                We are not able to display the requested data. Try again later,
+                or{' '}
+                <Link to="/contact-us" target="_blank">
+                  contact us
+                </Link>{' '}
+                for assistance.
+              </>
+            ),
+            additionalMessage: (
+              <pre style={{ whiteSpace: 'break-spaces' }}>{String(error)}</pre>
+            ),
+            showMoreLinkText: 'See details',
+            showLessLinkText: 'Hide details',
+            isShowMoreLinkBold: true,
+          }}
+        />
+      )}
     </div>,
     useMap().getContainer().parentElement!
   );

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -38,15 +38,15 @@ import {
   defaultAnimation,
   floaterFilterFuncs,
   isApproxSameViewport,
-  isNoDataError,
   markerDataFilterFuncs,
-  noDataErrorMessage,
   pieOrBarMarkerConfigLittleFilter,
   useCategoricalValues,
   useCommonData,
   useDistributionMarkerData,
   useDistributionOverlayConfig,
   visibleOptionFilterFuncs,
+  getErrorOverlayComponent,
+  getLegendErrorMessage,
 } from '../shared';
 import {
   useFindEntityAndVariable,
@@ -66,7 +66,6 @@ import { BarPlotMarkerIcon } from '../../MarkerConfiguration/icons';
 import { TabbedDisplayProps } from '@veupathdb/coreui/lib/components/grids/TabbedDisplay';
 import MapVizManagement from '../../MapVizManagement';
 import Spinner from '@veupathdb/components/lib/components/Spinner';
-import { MapFloatingErrorDiv } from '../../MapFloatingErrorDiv';
 import { MapTypeHeaderCounts } from '../MapTypeHeaderCounts';
 import { useLittleFilters } from '../../littleFilters';
 import TimeSliderQuickFilter from '../../TimeSliderQuickFilter';
@@ -357,9 +356,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
   });
 
   if (markerData.error && !markerData.isFetching)
-    return isNoDataError(markerData.error) ? null : (
-      <MapFloatingErrorDiv error={markerData.error} />
-    );
+    return getErrorOverlayComponent(markerData.error);
 
   // pass selectedMarkers and its state function
   const markers = markerData.markerProps?.map((markerProps) => (
@@ -429,9 +426,7 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
     selectedOverlayConfig: markerData.overlayConfig,
   });
   const toggleStarredVariable = useToggleStarredVariable(props.analysisState);
-  const noDataError = isNoDataError(markerData.error)
-    ? noDataErrorMessage
-    : undefined;
+  const noDataError = getLegendErrorMessage(markerData.error);
 
   const { filters: filtersForFloaters } = useLittleFilters(
     {

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -42,6 +42,7 @@ import {
   isApproxSameViewport,
   markerDataFilterFuncs,
   useCommonData,
+  getErrorOverlayComponent,
 } from '../shared';
 import {
   MapTypeConfigPanelProps,
@@ -54,7 +55,6 @@ import { useQuery } from '@tanstack/react-query';
 import { BoundsViewport } from '@veupathdb/components/lib/map/Types';
 import { GeoConfig } from '../../../../core/types/geoConfig';
 import Spinner from '@veupathdb/components/lib/components/Spinner';
-import { MapFloatingErrorDiv } from '../../MapFloatingErrorDiv';
 import { MapTypeHeaderCounts } from '../MapTypeHeaderCounts';
 import { useLittleFilters, UseLittleFiltersProps } from '../../littleFilters';
 import TimeSliderQuickFilter from '../../TimeSliderQuickFilter';
@@ -217,7 +217,7 @@ function BubbleMapLayer(props: MapTypeMapLayerProps) {
     filters: filtersForMarkerData,
   });
   if (markersData.error && !markersData.isFetching)
-    return <MapFloatingErrorDiv error={markersData.error} />;
+    return getErrorOverlayComponent(markersData.error);
 
   const markers = markersData.data?.markersData?.map((markerProps) => (
     <BubbleMarker {...markerProps} />

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -37,12 +37,12 @@ import {
   useCommonData,
   useDistributionMarkerData,
   useDistributionOverlayConfig,
-  isNoDataError,
-  noDataErrorMessage,
   visibleOptionFilterFuncs,
   markerDataFilterFuncs,
   floaterFilterFuncs,
   pieOrBarMarkerConfigLittleFilter,
+  getErrorOverlayComponent,
+  getLegendErrorMessage,
 } from '../shared';
 import {
   MapTypeConfigPanelProps,
@@ -59,7 +59,6 @@ import { DonutMarkersIcon } from '../../MarkerConfiguration/icons';
 import { TabbedDisplayProps } from '@veupathdb/coreui/lib/components/grids/TabbedDisplay';
 import MapVizManagement from '../../MapVizManagement';
 import Spinner from '@veupathdb/components/lib/components/Spinner';
-import { MapFloatingErrorDiv } from '../../MapFloatingErrorDiv';
 import { MapTypeHeaderCounts } from '../MapTypeHeaderCounts';
 import { useLittleFilters } from '../../littleFilters';
 import TimeSliderQuickFilter from '../../TimeSliderQuickFilter';
@@ -317,9 +316,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
 
   // no markers and no error div for certain known error strings
   if (markerDataResponse.error && !markerDataResponse.isFetching)
-    return isNoDataError(markerDataResponse.error) ? null : (
-      <MapFloatingErrorDiv error={markerDataResponse.error} />
-    );
+    return getErrorOverlayComponent(markerDataResponse.error);
 
   // pass selectedMarkers and its state function
   const markers = markerDataResponse.markerProps?.map((markerProps) => (
@@ -398,9 +395,7 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
     selectedOverlayConfig: data.overlayConfig,
   });
   const toggleStarredVariable = useToggleStarredVariable(props.analysisState);
-  const noDataError = isNoDataError(data.error)
-    ? noDataErrorMessage
-    : undefined;
+  const noDataError = getLegendErrorMessage(data.error);
 
   return (
     <>

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -34,6 +34,7 @@ import { UseLittleFiltersProps } from '../littleFilters';
 import { filtersFromBoundingBox } from '../../../core/utils/visualization';
 import { MapFloatingErrorDiv } from '../MapFloatingErrorDiv';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
+import { NoDataError } from '../../../core/api/DataClient/NoDataError';
 
 export const defaultAnimation = {
   method: 'geohash',
@@ -553,16 +554,9 @@ const noDataPatterns = [
 ];
 
 export function isNoDataError(error: unknown) {
-  if (error instanceof Error && error.name === 'NoDataError') return true;
+  if (error instanceof NoDataError) return true;
   return noDataPatterns.some((pattern) => String(error).match(pattern));
 }
-
-const noDataErrorMessage = (
-  <div css={{ textAlign: 'center', width: 200 }}>
-    <p>Your filters have removed all data for this variable.</p>
-    <p>Please check your filters or choose another variable.</p>
-  </div>
-);
 
 export function getErrorOverlayComponent(error: unknown) {
   return isNoDataError(error) ? (
@@ -579,6 +573,13 @@ export function getErrorOverlayComponent(error: unknown) {
   );
 }
 
+const noDataLegendMessage = (
+  <div css={{ textAlign: 'center', width: 200 }}>
+    <p>Your filters have removed all data for this variable.</p>
+    <p>Please check your filters or choose another variable.</p>
+  </div>
+);
+
 export function getLegendErrorMessage(error: unknown) {
-  return isNoDataError(error) ? noDataErrorMessage : undefined;
+  return isNoDataError(error) ? noDataLegendMessage : undefined;
 }

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -32,6 +32,8 @@ import { getCategoricalValues } from '../utils/categoricalValues';
 import { Viewport } from '@veupathdb/components/lib/map/MapVEuMap';
 import { UseLittleFiltersProps } from '../littleFilters';
 import { filtersFromBoundingBox } from '../../../core/utils/visualization';
+import { MapFloatingErrorDiv } from '../MapFloatingErrorDiv';
+import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 
 export const defaultAnimation = {
   method: 'geohash',
@@ -547,17 +549,36 @@ export const GLOBAL_VIEWPORT = {
  */
 
 const noDataPatterns = [
-  /did not contain any data/, // comes from map-markers endpoint
   /Could not generate continuous variable metadata/, // comes from continuous-variable-metadata endpoint
 ];
 
 export function isNoDataError(error: unknown) {
+  if (error instanceof Error && error.name === 'NoDataError') return true;
   return noDataPatterns.some((pattern) => String(error).match(pattern));
 }
 
-export const noDataErrorMessage = (
+const noDataErrorMessage = (
   <div css={{ textAlign: 'center', width: 200 }}>
     <p>Your filters have removed all data for this variable.</p>
     <p>Please check your filters or choose another variable.</p>
   </div>
 );
+
+export function getErrorOverlayComponent(error: unknown) {
+  return isNoDataError(error) ? (
+    <MapFloatingErrorDiv>
+      <Banner
+        banner={{
+          type: 'warning',
+          message: error instanceof Error ? error.message : String(error),
+        }}
+      />
+    </MapFloatingErrorDiv>
+  ) : (
+    <MapFloatingErrorDiv error={error} />
+  );
+}
+
+export function getLegendErrorMessage(error: unknown) {
+  return isNoDataError(error) ? noDataErrorMessage : undefined;
+}

--- a/packages/libs/http-utils/src/FetchClient.ts
+++ b/packages/libs/http-utils/src/FetchClient.ts
@@ -125,6 +125,10 @@ export abstract class FetchClient {
 }
 
 async function fetchResponseBody(response: Response) {
+  if (response.status === 204) {
+    return undefined;
+  }
+
   const contentType = response.headers.get('Content-Type');
 
   return contentType == null


### PR DESCRIPTION
Depends on https://github.com/VEuPathDB/EdaDataService/pull/328
Resolves #606  
Resolves #607
Resolves #571

In the map, a "no data" response will render a warning banner. To do so, I tweaked the `MapFloatingErrorDiv` to accept `children` as a means to customize its content. Screenshot below:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/45dd47a2-e33a-4a28-8524-a31478b47254)

I've also added the `Banner` component with `type: warning` to the `PluginError` messaging as shown:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/dfd4729b-2b19-4814-8402-948dc4ce6564)