### PR TITLE
Add hideIcon prop to Banner and use for visibleHelp attribute banner

### DIFF
--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -54,6 +54,7 @@ export type BannerProps = {
   // fadeout effect when timeout
   fadeoutEffect?: boolean;
   setFadeoutEffect?: (newValue: boolean) => void;
+  hideIcon?: boolean;
 };
 
 export type BannerComponentProps = {
@@ -123,6 +124,7 @@ export default function Banner(props: BannerComponentProps) {
     autoHideDuration,
     fadeoutEffect,
     setFadeoutEffect,
+    hideIcon = false,
   } = banner;
 
   const [isShowMore, setIsShowMore] = useState(false);
@@ -208,20 +210,22 @@ export default function Banner(props: BannerComponentProps) {
                 align-items: center;
               `}
             >
-              <IconComponent
-                css={css`
-                  color: ${intense
-                    ? 'white'
-                    : CollapsibleContent != null
-                    ? '#00008B'
-                    : 'black'};
-                  font-size: 1.4em;
-                  line-height: 1.4em;
-                  width: 30px;
-                  text-align: center;
-                  margin-right: 5px;
-                `}
-              ></IconComponent>
+              {!hideIcon && (
+                <IconComponent
+                  css={css`
+                    color: ${intense
+                      ? 'white'
+                      : CollapsibleContent != null
+                      ? '#00008B'
+                      : 'black'};
+                    font-size: 1.4em;
+                    line-height: 1.4em;
+                    width: 30px;
+                    text-align: center;
+                    margin-right: 5px;
+                  `}
+                />
+              )}
               <span
                 css={css`
                   margin-right: auto;

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
@@ -417,8 +417,10 @@ export function ParameterList(props: ParameterListProps) {
             {parameter.visibleHelp !== undefined && (
               <Banner
                 banner={{
-                  type: 'info',
+                  // 'normal' renders a banner w/ gray background
+                  type: 'normal',
                   message: safeHtml(parameter.visibleHelp, null, 'div'),
+                  hideIcon: true,
                 }}
               />
             )}


### PR DESCRIPTION
Resolves #844 

Still uses `Banner` but I added a `hideIcon` prop and changed the banner type to `normal`, which uses a gray background.

![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/9075fe1e-5f58-429d-bb36-f00281981d2f)
