### PR TITLE
modifying correlation inputs

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
@@ -42,6 +42,11 @@
       }
     }
   }
+
+  &-DescriptionContainer {
+    font-weight: normal !important;
+    text-transform: none;
+  }
 }
 
 .ConfigDescriptionContainer {

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import {
   FeaturePrefilterThresholds,
   useFindEntityAndVariableCollection,
@@ -166,6 +167,21 @@ export function CorrelationAssayAssayConfiguration(
     visualizationId
   );
 
+  // set initial prefilterThresholds
+  useEffect(() => {
+    changeConfigHandler('prefilterThresholds', {
+      proportionNonZero:
+        configuration.prefilterThresholds?.proportionNonZero ??
+        DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+      variance:
+        configuration.prefilterThresholds?.variance ??
+        DEFAULT_VARIANCE_THRESHOLD,
+      standardDeviation:
+        configuration.prefilterThresholds?.standardDeviation ??
+        DEFAULT_STANDARD_DEVIATION_THRESHOLD,
+    });
+  }, []);
+
   return (
     <ComputationStepContainer
       computationStepInfo={{
@@ -212,21 +228,28 @@ export function CorrelationAssayAssayConfiguration(
             </div>
           </div>
           <div className={cx('-CorrelationOuterConfigContainer')}>
-            <H6>Prefilters</H6>
+            <H6>Prefilter Data</H6>
             <div className={cx('-InputContainer')}>
-              <span>Proportion non-zero</span>
+              <span>
+                Prevalence: Keep if abundance is non-zero in at least{' '}
+              </span>
               <NumberInput
                 minValue={0}
-                maxValue={1}
-                step={0.01}
+                maxValue={100}
+                step={1}
                 value={
-                  configuration.prefilterThresholds?.proportionNonZero ??
-                  DEFAULT_PROPORTION_NON_ZERO_THRESHOLD
+                  // display with % value
+                  configuration.prefilterThresholds?.proportionNonZero != null
+                    ? configuration.prefilterThresholds?.proportionNonZero * 100
+                    : DEFAULT_PROPORTION_NON_ZERO_THRESHOLD * 100
                 }
                 onValueChange={(newValue) => {
                   changeConfigHandler('prefilterThresholds', {
                     proportionNonZero:
-                      Number(newValue) ?? DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+                      // save as decimal point, not %
+                      newValue != null
+                        ? Number((newValue as number) / 100)
+                        : DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
                     variance:
                       configuration.prefilterThresholds?.variance ??
                       DEFAULT_VARIANCE_THRESHOLD,
@@ -235,48 +258,9 @@ export function CorrelationAssayAssayConfiguration(
                       DEFAULT_STANDARD_DEVIATION_THRESHOLD,
                   });
                 }}
+                containerStyles={{ width: '5.5em' }}
               />
-              <span>Variance</span>
-              <NumberInput
-                minValue={0}
-                step={1}
-                value={
-                  configuration.prefilterThresholds?.variance ??
-                  DEFAULT_VARIANCE_THRESHOLD
-                }
-                onValueChange={(newValue) => {
-                  changeConfigHandler('prefilterThresholds', {
-                    proportionNonZero:
-                      configuration.prefilterThresholds?.proportionNonZero ??
-                      DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
-                    variance: Number(newValue) ?? DEFAULT_VARIANCE_THRESHOLD,
-                    standardDeviation:
-                      configuration.prefilterThresholds?.standardDeviation ??
-                      DEFAULT_STANDARD_DEVIATION_THRESHOLD,
-                  });
-                }}
-              />
-              <span>Standard deviation</span>
-              <NumberInput
-                minValue={0}
-                step={1}
-                value={
-                  configuration.prefilterThresholds?.standardDeviation ??
-                  DEFAULT_STANDARD_DEVIATION_THRESHOLD
-                }
-                onValueChange={(newValue) => {
-                  changeConfigHandler('prefilterThresholds', {
-                    proportionNonZero:
-                      configuration.prefilterThresholds?.proportionNonZero ??
-                      DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
-                    variance:
-                      configuration.prefilterThresholds?.variance ??
-                      DEFAULT_VARIANCE_THRESHOLD,
-                    standardDeviation:
-                      Number(newValue) ?? DEFAULT_STANDARD_DEVIATION_THRESHOLD,
-                  });
-                }}
-              />
+              <span>% of samples</span>
             </div>
           </div>
         </div>

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayAssay.tsx
@@ -230,8 +230,9 @@ export function CorrelationAssayAssayConfiguration(
           <div className={cx('-CorrelationOuterConfigContainer')}>
             <H6>Prefilter Data</H6>
             <div className={cx('-InputContainer')}>
-              <span>
-                Prevalence: Keep if abundance is non-zero in at least{' '}
+              <span>Prevalence: </span>
+              <span className={cx('-DescriptionContainer')}>
+                Keep if abundance is non-zero in at least{' '}
               </span>
               <NumberInput
                 minValue={0}
@@ -260,7 +261,7 @@ export function CorrelationAssayAssayConfiguration(
                 }}
                 containerStyles={{ width: '5.5em' }}
               />
-              <span>% of samples</span>
+              <span className={cx('-DescriptionContainer')}>% of samples</span>
             </div>
           </div>
         </div>

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import {
   VariableTreeNode,
   FeaturePrefilterThresholds,
@@ -145,6 +146,21 @@ export function CorrelationAssayMetadataConfiguration(
     visualizationId
   );
 
+  // set initial prefilterThresholds
+  useEffect(() => {
+    changeConfigHandler('prefilterThresholds', {
+      proportionNonZero:
+        configuration.prefilterThresholds?.proportionNonZero ??
+        DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+      variance:
+        configuration.prefilterThresholds?.variance ??
+        DEFAULT_VARIANCE_THRESHOLD,
+      standardDeviation:
+        configuration.prefilterThresholds?.standardDeviation ??
+        DEFAULT_STANDARD_DEVIATION_THRESHOLD,
+    });
+  }, []);
+
   return (
     <ComputationStepContainer
       computationStepInfo={{
@@ -184,21 +200,28 @@ export function CorrelationAssayMetadataConfiguration(
           </div>
         </div>
         <div className={cx('-CorrelationOuterConfigContainer')}>
-          <H6>Prefilters</H6>
+          <H6>Prefilter Data</H6>
           <div className={cx('-InputContainer')}>
-            <span>Proportion non-zero</span>
+            <span>
+              Prevalence: Keep taxa if abundance is non-zero in at least{' '}
+            </span>
             <NumberInput
               minValue={0}
-              maxValue={1}
-              step={0.01}
+              maxValue={100}
+              step={1}
               value={
-                configuration.prefilterThresholds?.proportionNonZero ??
-                DEFAULT_PROPORTION_NON_ZERO_THRESHOLD
+                // display with % value
+                configuration.prefilterThresholds?.proportionNonZero != null
+                  ? configuration.prefilterThresholds?.proportionNonZero * 100
+                  : DEFAULT_PROPORTION_NON_ZERO_THRESHOLD * 100
               }
               onValueChange={(newValue) => {
                 changeConfigHandler('prefilterThresholds', {
                   proportionNonZero:
-                    Number(newValue) ?? DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
+                    // save as decimal point, not %
+                    newValue != null
+                      ? Number((newValue as number) / 100)
+                      : DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
                   variance:
                     configuration.prefilterThresholds?.variance ??
                     DEFAULT_VARIANCE_THRESHOLD,
@@ -207,48 +230,9 @@ export function CorrelationAssayMetadataConfiguration(
                     DEFAULT_STANDARD_DEVIATION_THRESHOLD,
                 });
               }}
+              containerStyles={{ width: '5.5em' }}
             />
-            <span>Variance</span>
-            <NumberInput
-              minValue={0}
-              step={1}
-              value={
-                configuration.prefilterThresholds?.variance ??
-                DEFAULT_VARIANCE_THRESHOLD
-              }
-              onValueChange={(newValue) => {
-                changeConfigHandler('prefilterThresholds', {
-                  proportionNonZero:
-                    configuration.prefilterThresholds?.proportionNonZero ??
-                    DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
-                  variance: Number(newValue) ?? DEFAULT_VARIANCE_THRESHOLD,
-                  standardDeviation:
-                    configuration.prefilterThresholds?.standardDeviation ??
-                    DEFAULT_STANDARD_DEVIATION_THRESHOLD,
-                });
-              }}
-            />
-            <span>Standard deviation</span>
-            <NumberInput
-              minValue={0}
-              step={1}
-              value={
-                configuration.prefilterThresholds?.standardDeviation ??
-                DEFAULT_STANDARD_DEVIATION_THRESHOLD
-              }
-              onValueChange={(newValue) => {
-                changeConfigHandler('prefilterThresholds', {
-                  proportionNonZero:
-                    configuration.prefilterThresholds?.proportionNonZero ??
-                    DEFAULT_PROPORTION_NON_ZERO_THRESHOLD,
-                  variance:
-                    configuration.prefilterThresholds?.variance ??
-                    DEFAULT_VARIANCE_THRESHOLD,
-                  standardDeviation:
-                    Number(newValue) ?? DEFAULT_STANDARD_DEVIATION_THRESHOLD,
-                });
-              }}
-            />
+            <span>% of samples</span>
           </div>
         </div>
       </div>

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlationAssayMetadata.tsx
@@ -202,8 +202,9 @@ export function CorrelationAssayMetadataConfiguration(
         <div className={cx('-CorrelationOuterConfigContainer')}>
           <H6>Prefilter Data</H6>
           <div className={cx('-InputContainer')}>
-            <span>
-              Prevalence: Keep taxa if abundance is non-zero in at least{' '}
+            <span>Prevalence: </span>
+            <span className={cx('-DescriptionContainer')}>
+              Keep taxa if abundance is non-zero in at least{' '}
             </span>
             <NumberInput
               minValue={0}
@@ -232,7 +233,7 @@ export function CorrelationAssayMetadataConfiguration(
               }}
               containerStyles={{ width: '5.5em' }}
             />
-            <span>% of samples</span>
+            <span className={cx('-DescriptionContainer')}>% of samples</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/832.

For the last item to fix a bug or change behavior, honestly, I could not fully understand how the computation worked, but I managed to make it fix anyway 😅 

Some screenshots after changing:

![832 mbio correlation01](https://github.com/VEuPathDB/web-monorepo/assets/12802305/b591f496-7bbe-4208-8f1c-6a26844b2e68)


![832 mbio correlation02](https://github.com/VEuPathDB/web-monorepo/assets/12802305/563cab33-ea91-4af4-b92b-c6f53f7894e9)

