### PR TITLE
reset button position for histogram filter

### DIFF
--- a/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
@@ -661,7 +661,7 @@ function HistogramPlotWithControls({
             }}
           >
             <LabelledGroup label="X-axis controls"> </LabelledGroup>
-            <div style={{ marginLeft: '-2.6em', width: '50%' }}>
+            <div style={{ marginLeft: '-1em', width: '50%' }}>
               <ResetButtonCoreUI
                 size={'medium'}
                 text={''}
@@ -743,7 +743,7 @@ function HistogramPlotWithControls({
             }}
           >
             <LabelledGroup label="Y-axis controls"> </LabelledGroup>
-            <div style={{ marginLeft: '-2.6em', width: '50%' }}>
+            <div style={{ marginLeft: '-1em', width: '50%' }}>
               <ResetButtonCoreUI
                 size={'medium'}
                 text={''}


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/853. As Dave said, marginLeft: -1em looks similar to the Live site's position