### PR TITLE
SAM study details ux followup

### DIFF
--- a/packages/libs/components/src/map/BoundsDriftMarker.tsx
+++ b/packages/libs/components/src/map/BoundsDriftMarker.tsx
@@ -56,9 +56,17 @@ export default function BoundsDriftMarker({
     [bounds.northEast.lat, bounds.northEast.lng],
   ]);
 
+  // This will get placed in the popupPane, so that
+  // it is visible on top of the associated marker.
+  // The `interactive` option is set to false, so
+  // that it does not react to mouse events, which
+  // allows the marker to be clicked, even if the
+  // reactable is above the marker.
   const boundsRectangle = L.rectangle(boundingBox, {
     color: 'gray',
     weight: 1,
+    pane: 'popupPane',
+    interactive: false,
   });
   useEffect(() => {
     /**

--- a/packages/libs/components/src/map/BoundsDriftMarker.tsx
+++ b/packages/libs/components/src/map/BoundsDriftMarker.tsx
@@ -290,8 +290,8 @@ export default function BoundsDriftMarker({
             setSelectedMarkers(
               selectedMarkers.filter((id: string) => id !== props.id)
             );
-          } else if (e.originalEvent.shiftKey) {
-            // add to selection if SHIFT key pressed
+          } else if (e.originalEvent.ctrlKey || e.originalEvent.metaKey) {
+            // add to selection if CTRL or CMD key pressed
             setSelectedMarkers([...(selectedMarkers ?? []), props.id]);
           } else {
             // replace selection
@@ -310,10 +310,10 @@ export default function BoundsDriftMarker({
   );
 
   const handleDoubleClick = (e: LeafletMouseEvent) => {
-    // If SHIFT is pressed, ignore double-click event
+    // If any mofigier key is pressed, ignore double-click event
     // so users can quickly select multiple markers without
     // triggering a zoom
-    if (map && !e.originalEvent.shiftKey) {
+    if (map && !mouseEventHasModifierKey(e.originalEvent)) {
       map.fitBounds(boundingBox);
     }
   };
@@ -358,4 +358,8 @@ export default function BoundsDriftMarker({
       {showPopup && popup}
     </ReactLeafletDriftMarker>
   );
+}
+
+function mouseEventHasModifierKey(event: MouseEvent) {
+  return event.ctrlKey || event.altKey || event.metaKey || event.shiftKey;
 }

--- a/packages/libs/components/src/map/styles/map-styles.css
+++ b/packages/libs/components/src/map/styles/map-styles.css
@@ -104,11 +104,8 @@
   transform: rotate(180deg);
 }
 
-/*  on mouse-over, marker to top and set its opacity such that marker doesn't
-    obscure small grey rectangles (the bounding box) */
 .top-marker {
-  z-index: 3100 !important;
-  opacity: 0.4;
+  z-index: 1;
 }
 
 /* Replace leaflet styles*/

--- a/packages/libs/eda/src/lib/map/analysis/SubStudies.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/SubStudies.tsx
@@ -80,7 +80,7 @@ export function SubStudies(props: Props) {
       onDragComplete={updatePosition}
       onPanelResize={updateDimensions}
       styleOverrides={{
-        zIndex: 10,
+        zIndex: 4,
         height: panelConfig.dimensions.height,
         width: panelConfig.dimensions.width,
         resize: 'both',

--- a/packages/libs/eda/src/lib/map/analysis/appState.ts
+++ b/packages/libs/eda/src/lib/map/analysis/appState.ts
@@ -201,8 +201,11 @@ export function useAppState(
         ? {
             studyDetailsPanelConfig: {
               isVisble: false,
-              position: { x: 650, y: 225 },
-              dimensions: { height: '70vh', width: 1000 },
+              position: {
+                x: Math.max(650, window.innerWidth / 2 - 250),
+                y: Math.max(300, window.innerHeight / 2 - 250),
+              },
+              dimensions: { height: 500, width: 500 },
             },
           }
         : {}),

--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -52,6 +52,8 @@ export function useStandaloneVizPlugins({
     function vizWithOptions(
       visualization: VisualizationPlugin<StandaloneVizOptions>
     ) {
+      const modifierKey =
+        window.navigator.platform.indexOf('Mac') === 0 ? 'Cmd' : 'Ctrl';
       return visualization.withOptions({
         hideFacetInputs: true, // will also enable table-only mode for mosaic
         hideShowMissingnessToggle: true,
@@ -81,7 +83,7 @@ export function useStandaloneVizPlugins({
             ? selectedMarkers.length > 1
               ? EntitySubtitleForViz({ subtitle: 'for selected markers' })
               : EntitySubtitleForViz({
-                  subtitle: 'for selected marker - shift-click to add more',
+                  subtitle: `for selected marker - ${modifierKey}-click to add more`,
                 })
             : EntitySubtitleForViz({
                 subtitle:

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/MapTypeHeaderStudyDetails.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/MapTypeHeaderStudyDetails.tsx
@@ -24,6 +24,10 @@ interface Props {
    * If omitted, do not show studies link
    */
   onShowStudies?: (showStudies: boolean) => void;
+  /**
+   * Indicates if any markers are selected
+   */
+  hasMarkerSelection: boolean;
 }
 
 const { format } = new Intl.NumberFormat('en-us');
@@ -34,6 +38,7 @@ export function MapTypeHeaderStudyDetails(props: Props) {
     includesTimeSliderFilter,
     outputEntityId,
     onShowStudies,
+    hasMarkerSelection,
   } = props;
   const entities = useStudyEntities();
   const studyEntity = entities.find(
@@ -139,6 +144,7 @@ export function MapTypeHeaderStudyDetails(props: Props) {
           alignItems: 'center',
         }}
       >
+        {hasMarkerSelection ? 'Selected: ' : 'Showing: '}
         {totalCountFormatted}{' '}
         {outputEntityCount.data.count === 1
           ? outputEntity.displayName
@@ -147,7 +153,9 @@ export function MapTypeHeaderStudyDetails(props: Props) {
           <>
             {' '}
             from {format(studyEntityCount.data.count)}{' '}
-            {studyEntity.displayNamePlural}
+            {studyEntityCount.data.count === 1
+              ? studyEntity.displayName
+              : studyEntity.displayNamePlural}
           </>
         )}
         <Tooltip title={tooltipContent} interactive style={{ width: 'auto' }}>

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -547,7 +547,7 @@ function MapTypeHeaderDetails(props: MapTypeMapLayerProps) {
     filters,
   } = props;
 
-  const { selectedVariable } =
+  const { selectedVariable, selectedMarkers } =
     props.configuration as BarPlotMarkerConfiguration;
 
   const { filters: filtersForSubStudies } = useLittleFilters(
@@ -565,6 +565,7 @@ function MapTypeHeaderDetails(props: MapTypeMapLayerProps) {
 
   return outputEntityId != null ? (
     <MapTypeHeaderStudyDetails
+      hasMarkerSelection={!!selectedMarkers?.length}
       filtersForVisibleData={filtersForSubStudies}
       includesTimeSliderFilter={timeSliderConfig != null}
       outputEntityId={outputEntityId}

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -454,6 +454,7 @@ function MapTypeHeaderDetails(props: MapTypeMapLayerProps) {
 
   return outputEntityId != null ? (
     <MapTypeHeaderStudyDetails
+      hasMarkerSelection={!!configuration.selectedMarkers?.length}
       filtersForVisibleData={filtersForSubStudies}
       includesTimeSliderFilter={timeSliderConfig != null}
       outputEntityId={outputEntityId}

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -512,7 +512,8 @@ function MapTypeHeaderDetails(props: MapTypeMapLayerProps) {
     geoConfigs,
     filters,
   } = props;
-  const { selectedVariable } = props.configuration as PieMarkerConfiguration;
+  const { selectedVariable, selectedMarkers } =
+    props.configuration as PieMarkerConfiguration;
 
   const { filters: filtersForSubStudies } = useLittleFilters(
     {
@@ -529,6 +530,7 @@ function MapTypeHeaderDetails(props: MapTypeMapLayerProps) {
 
   return outputEntityId != null ? (
     <MapTypeHeaderStudyDetails
+      hasMarkerSelection={!!selectedMarkers?.length}
       filtersForVisibleData={filtersForSubStudies}
       includesTimeSliderFilter={timeSliderConfig != null}
       outputEntityId={outputEntityId}

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -63,6 +63,7 @@ export const MAX_FILTERSET_VALUES = 1000;
 export interface SharedMarkerConfigurations {
   selectedVariable: VariableDescriptor;
   activeVisualizationId?: string;
+  selectedMarkers?: string[];
 }
 
 export function useCommonData(

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -416,7 +416,9 @@ export function useSelectedMarkerSnackbars(
         selectedMarkers != null &&
         selectedMarkers.length === 1
       ) {
-        enqueueSnackbar(`Use shift-click to select multiple markers`, {
+        const modifierKey =
+          window.navigator.platform.indexOf('Mac') === 0 ? 'Cmd' : 'Ctrl';
+        enqueueSnackbar(`Use ${modifierKey}-click to select multiple markers`, {
           variant: 'info',
           anchorOrigin: { vertical: 'top', horizontal: 'center' },
         });

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/types.ts
@@ -43,8 +43,6 @@ export interface MapTypeMapLayerProps {
   // and sent to plugin components that don't need it - we should also address this
   hideVizInputsAndControls: boolean;
   setHideVizInputsAndControls: (hide: boolean) => void;
-  // selectedMarkers and its state function
-  selectedMarkers?: string[];
   setSelectedMarkers?: React.Dispatch<React.SetStateAction<string[]>>;
   setStudyDetailsPanelConfig: (config: PanelConfig) => void;
   setTimeSliderConfig?: (


### PR DESCRIPTION
closes #854

This PR addresses UX feedback:
- Reduce default size of study panel
- Update header verbiage:
  - "Showing: 440,305 samples from 5 studies"
  - "Selected: 1,234 samples from 2 studies"
- Use CTRL-CLICK
- Remove opacity from marker on hover

Note that in addition to removing opacity from markers on hover, I also made the bounding rectangle appear above the marker. This makes that rectangle visible when smaller than the marker, and easier to see in general. The rectangle is also non-interactive, so it does not impede the ability to click on the marker, nor does it interfere with the popup.