### PR TITLE
More external link handling

### DIFF
--- a/packages/libs/wdk-client/src/Views/User/Password/ChangePasswordLink.jsx
+++ b/packages/libs/wdk-client/src/Views/User/Password/ChangePasswordLink.jsx
@@ -16,7 +16,11 @@ const ChangePasswordLink = (props) => {
     let url = props.changePasswordUrl
       .replace('{{returnUrl}}', encodeURIComponent(window.location))
       .replace('{{suggestedUsername}}', encodeURIComponent(props.userEmail));
-    return <a href={url}>{props.children}</a>;
+    return (
+      <a href={url} target="_self">
+        {props.children}
+      </a>
+    );
   } else {
     // use default WDK change password page
     return <Link to={`/user/profile/password`}>{props.children}</Link>;

--- a/packages/libs/web-common/src/externalLinkHandler.ts
+++ b/packages/libs/web-common/src/externalLinkHandler.ts
@@ -1,32 +1,5 @@
 import { Seq } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
 import { rootElement } from './config';
-/**
- * This module adds a mutation observer that will add a target="_blank"
- * attribute to anchor elements with a href for an external site.
- */
-// addEventListener('DOMContentLoaded', function execute() {
-//   const target = document.querySelector(rootElement);
-//   if (window.MutationObserver == null || target == null) return;
-
-//   const observer = new MutationObserver(function callback(mutations, observer) {
-//     Seq.from(mutations)
-//       .map(mutation => mutation.target)
-//       .filter((node): node is HTMLElement => node instanceof HTMLElement)
-//       .flatMap(node => node.querySelectorAll('a'))
-//       .filter(a => !!a.href && !a.target)
-//       .forEach(a => {
-//         const url = new URL(a.href);
-//         if (url.origin !== location.origin) {
-//           a.target = "_blank";
-//           a.rel = "noreferrer";
-//         }
-//       });
-//   });
-//   observer.observe(target, {
-//     subtree: true,
-//     childList: true,
-//   });
-// });
 
 /**
  * Add click event listener to add target and rel for external links
@@ -38,7 +11,7 @@ addEventListener('click', (event) => {
     !event.target.target
   ) {
     const url = new URL(event.target.href);
-    if (url.origin !== location.origin) {
+    if (url.origin !== location.origin || !event.target.target) {
       event.target.target = '_blank';
       event.target.rel = 'noreffer';
     }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -410,7 +410,6 @@ const useHeaderMenuItems = (
           tooltip: 'Instantaneous, collaborative, genome annotation editor',
           type: 'reactRoute',
           url: makeStaticPageRoute(`/apollo_help.html`),
-          target: '_blank',
           metadata: {
             include: [
               AmoebaDB,
@@ -435,7 +434,6 @@ const useHeaderMenuItems = (
           display: 'BLAST (multi-query capable)',
           type: 'reactRoute',
           url: '/workspace/blast/new',
-          target: '_blank',
         },
         {
           key: 'companion',
@@ -444,7 +442,6 @@ const useHeaderMenuItems = (
           tooltip:
             'Annotate your sequence and determine orthology, phylogeny & synteny',
           url: 'https://companion.ac.uk/',
-          target: '_blank',
           metadata: {
             exclude: [VectorBase],
           },
@@ -456,7 +453,6 @@ const useHeaderMenuItems = (
           tooltip:
             'CRISPR GuideXpress at DRSC/TRiP Functional Genomics Resources',
           url: 'https://www.flyrnai.org/tools/fly2mosquito/web/',
-          target: '_blank',
           metadata: {
             include: [VectorBase],
           },
@@ -467,7 +463,6 @@ const useHeaderMenuItems = (
           type: 'externalLink',
           tooltip: 'Eukaryotic Pathogen CRISPR guide RNA/DNA Design Tool',
           url: 'http://grna.ctegd.uga.edu',
-          target: '_blank',
           metadata: {
             exclude: [VectorBase],
           },
@@ -489,14 +484,12 @@ const useHeaderMenuItems = (
           display: 'Galaxy',
           type: 'reactRoute',
           url: '/galaxy-orientation',
-          target: '_blank',
         },
         {
           key: 'jbrowse',
           display: 'Genome browser',
           type: 'reactRoute',
           url: '/jbrowse?data=/a/service/jbrowse/tracks/default',
-          target: '_blank',
           metadata: {
             exclude: [EuPathDB],
           },
@@ -507,7 +500,6 @@ const useHeaderMenuItems = (
           tooltip: 'Free to use pictures of vectors',
           type: 'reactRoute',
           url: makeStaticPageRoute('/VectorBase/imageGallery.html'),
-          target: '_blank',
           metadata: {
             include: [VectorBase],
           },
@@ -519,7 +511,6 @@ const useHeaderMenuItems = (
             'Your online resource for CRISPR Cas9 T7 RNA Polymerase gene editing in kinetoplastids',
           type: 'externalLink',
           url: 'http://www.leishgedit.net',
-          target: '_blank',
           metadata: {
             include: [TriTrypDB],
           },
@@ -530,7 +521,6 @@ const useHeaderMenuItems = (
           tooltip: 'Population Biology map',
           type: 'externalLink',
           url: '/popbio-map/web/',
-          target: '_blank',
           metadata: {
             include: [VectorBase],
           },
@@ -541,7 +531,6 @@ const useHeaderMenuItems = (
           tooltip: 'Population Biology map',
           type: 'externalLink',
           url: 'https://vectorbase.org/popbio-map/web/',
-          target: '_blank',
           metadata: {
             include: [EuPathDB, UniDB],
           },
@@ -601,14 +590,12 @@ const useHeaderMenuItems = (
           display: 'NCBI Primer3',
           type: 'externalLink',
           url: 'https://www.ncbi.nlm.nih.gov/tools/primer-blast/',
-          target: '_blank',
         },
         {
           key: 'plasmoap',
           display: 'PlasmoAP',
           type: 'reactRoute',
           url: '/plasmoap',
-          target: '_blank',
           metadata: {
             include: [PlasmoDB],
           },
@@ -618,7 +605,6 @@ const useHeaderMenuItems = (
           display: 'PATS',
           type: 'externalLink',
           url: 'http://modlabcadd.ethz.ch/software/pats/',
-          target: '_blank',
           metadata: {
             include: [ PlasmoDB ]
           }
@@ -628,21 +614,18 @@ const useHeaderMenuItems = (
           display: 'PubMed and Entrez',
           type: 'externalLink',
           url: `/pubcrawler/${displayName}`,
-          target: '_blank',
         },
         {
           key: 'srt',
           display: 'Sequence retrieval',
           type: 'reactRoute',
           url: '/fasta-tool',
-          target: '_blank',
         },
         {
           key: 'webservices',
           display: 'Web services',
           type: 'reactRoute',
           url: makeStaticPageRoute(`/content/${displayName}/webServices.html`),
-          target: '_blank',
         },
       ],
     },
@@ -787,98 +770,84 @@ const useHeaderMenuItems = (
               display: 'VEuPathDB',
               type: 'externalLink',
               url: 'https://veupathdb.org',
-              target: '_blank',
             },
             {
               key: 'amoebadb',
               display: 'AmoebaDB',
               type: 'externalLink',
               url: 'https://amoebadb.org',
-              target: '_blank',
             },
             {
               key: 'cryptodb',
               display: 'CryptoDB',
               type: 'externalLink',
               url: 'https://cryptodb.org',
-              target: '_blank',
             },
             {
               key: 'fungidb',
               display: 'FungiDB',
               type: 'externalLink',
               url: 'https://fungidb.org',
-              target: '_blank',
             },
             {
               key: 'giardiadb',
               display: 'GiardiaDB',
               type: 'externalLink',
               url: 'https://giardiadb.org',
-              target: '_blank',
             },
             {
               key: 'hostdb',
               display: 'HostDB',
               type: 'externalLink',
               url: 'https://hostdb.org',
-              target: '_blank',
             },
             {
               key: 'microsporidiadb',
               display: 'MicrosporidiaDB',
               type: 'externalLink',
               url: 'https://microsporidiadb.org',
-              target: '_blank',
             },
             {
               key: 'piroplasmadb',
               display: 'PiroplasmaDB',
               type: 'externalLink',
               url: 'https://piroplasmadb.org',
-              target: '_blank',
             },
             {
               key: 'plasmodb',
               display: 'PlasmoDB',
               type: 'externalLink',
               url: 'https://plasmodb.org',
-              target: '_blank',
             },
             {
               key: 'toxodb',
               display: 'ToxoDB',
               type: 'externalLink',
               url: 'https://toxodb.org',
-              target: '_blank',
             },
             {
               key: 'trichdb',
               display: 'TrichDB',
               type: 'externalLink',
               url: 'https://trichdb.org',
-              target: '_blank',
             },
             {
               key: 'tritrypdb',
               display: 'TriTrypDB',
               type: 'externalLink',
               url: 'https://tritrypdb.org',
-              target: '_blank',
             },
             {
               key: 'vectorbase',
               display: 'VectorBase',
               type: 'externalLink',
               url: 'https://vectorbase.org',
-              target: '_blank',
             },
             {
               key: 'orthomcl',
               display: 'OrthoMCL',
               type: 'externalLink',
               url: 'https://orthomcl.org',
-              target: '_blank',
             },
           ],
         },
@@ -923,7 +892,6 @@ const useHeaderMenuItems = (
               display: 'Publications that use our resources',
               type: 'externalLink',
               url: 'https://scholar.google.com/scholar?hl=en&as_sdt=0,39&q=OrthoMCL+OR+PlasmoDB+OR+ToxoDB+OR+CryptoDB+OR+TrichDB+OR+GiardiaDB+OR+TriTrypDB+OR+AmoebaDB+OR+MicrosporidiaDB+OR+%22FungiDB%22+OR+PiroplasmaDB+OR+%22vectorbase%22+OR+veupathdb+OR+ApiDB+OR+EuPathDB+-encrypt+-cryptography+-hymenoptera&scisbd=1',
-              target: '_blank',
             },
           ],
         },
@@ -1043,7 +1011,6 @@ const useHeaderMenuItems = (
               display: 'Website usage statistics',
               type: 'externalLink',
               url: '/awstats/awstats.pl',
-              target: '_blank',
               metadata: {
                 exclude: [EuPathDB],
               },
@@ -1053,7 +1020,6 @@ const useHeaderMenuItems = (
               display: 'All websites usage statistics',
               type: 'externalLink',
               url: '/awstats/awstats.pl?config=All_EBRC_Combined',
-              target: '_blank',
               metadata: {
                 include: [EuPathDB],
               },
@@ -1099,7 +1065,6 @@ const useHeaderMenuItems = (
       display: 'Contact Us',
       type: 'reactRoute',
       url: '/contact-us',
-      target: '_blank',
     },
   ];
 


### PR DESCRIPTION
This PR removes the target attribute from tools. If a link already has a target attribute, then its behavior will not change. This allows us to force external links to open in the same browser.