### PR TITLE
Make "### Studies" a link and remove button from tooltip

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/MapTypeHeaderStudyDetails.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/MapTypeHeaderStudyDetails.tsx
@@ -125,9 +125,6 @@ export function MapTypeHeaderStudyDetails(props: Props) {
           {studyEntityCount.data.count === 1
             ? studyEntity.displayName
             : studyEntity.displayNamePlural}{' '}
-          <button type="button" onClick={() => onShowStudies(true)}>
-            Show list
-          </button>
         </p>
       )}
     </div>
@@ -140,7 +137,6 @@ export function MapTypeHeaderStudyDetails(props: Props) {
           padding: '1em',
           fontSize: '1.2em',
           display: 'flex',
-          gap: '1ex',
           alignItems: 'center',
         }}
       >
@@ -151,13 +147,20 @@ export function MapTypeHeaderStudyDetails(props: Props) {
           : outputEntity.displayNamePlural}
         {onShowStudies && studyEntity && (
           <>
-            {' '}
-            from {format(studyEntityCount.data.count)}{' '}
-            {studyEntityCount.data.count === 1
-              ? studyEntity.displayName
-              : studyEntity.displayNamePlural}
+            &nbsp;from&nbsp;
+            <button
+              className="link"
+              type="button"
+              onClick={() => onShowStudies(true)}
+            >
+              {format(studyEntityCount.data.count)}{' '}
+              {studyEntityCount.data.count === 1
+                ? studyEntity.displayName
+                : studyEntity.displayNamePlural}
+            </button>
           </>
         )}
+        &nbsp;
         <Tooltip title={tooltipContent} interactive style={{ width: 'auto' }}>
           <Info style={{ color: '#069', height: '.8em', width: '.8em' }} />
         </Tooltip>


### PR DESCRIPTION
This was suggested at a recent map ux meeting. I think it makes sense.

![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/d34a323b-42f2-41ca-b800-fac4dd6f503a)
