### PR TITLE
Intercept nulls in another place and refactor

### DIFF
--- a/packages/libs/eda/src/lib/core/api/DataClient/index.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/index.ts
@@ -59,17 +59,7 @@ export default class DataClient extends FetchClientWithCredentials {
         method: 'POST',
         path: `/apps/${computationName}/visualizations/${visualizationName}`,
         body: params,
-        transformResponse(body) {
-          if (body == null) {
-            throw new NoDataError(
-              'The visualization cannot be made because no data remains after filtering.',
-              'No data',
-              204,
-              uuid()
-            );
-          }
-          return ioTransformer(decoder)(body);
-        },
+        transformResponse: nullResponseInterceptor(decoder),
       })
     );
   }
@@ -236,10 +226,27 @@ export default class DataClient extends FetchClientWithCredentials {
         method: 'POST',
         path: `/filter-aware-metadata/continuous-variable`,
         body: params,
-        transformResponse: ioTransformer(ContinousVariableMetadataResponse),
+        transformResponse: nullResponseInterceptor(
+          ContinousVariableMetadataResponse
+        ),
       })
     );
   }
+}
+
+// intercept a null body response and throw a '204' internally
+function nullResponseInterceptor<T>(decoder: Decoder<unknown, T>) {
+  return function (body: unknown) {
+    if (body == null) {
+      throw new NoDataError(
+        'The visualization cannot be made because no data remains after filtering.',
+        'No data',
+        204,
+        uuid()
+      );
+    }
+    return ioTransformer(decoder)(body);
+  };
 }
 
 export * from './types';


### PR DESCRIPTION
Fixes #866 

This fixes one of the runtime exceptions when the back end `eda-service/filter-aware-metadata/continuous-variable` returns null and a 204.  However, it really makes a difference where you make the timeslider filter.

Here is where it causes a 204 and is now fixed in this PR.  In a comment below I'll demonstrate a 500 that probably needs fixing on the back end.

![image](https://github.com/VEuPathDB/web-monorepo/assets/308639/4b98a57a-3323-480f-a6f6-06366c3d3f73)
