### PR TITLE
Genomic segments: Fix styling of input labels and add banner for SRT

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/controllers/FastaConfigController.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/controllers/FastaConfigController.tsx
@@ -50,8 +50,7 @@ const submissionMetadata: SubmissionMetadata = {
 const genomicSegmentsBanner = (
   <Banner
     banner={{
-      type: 'warning',
-      // hideIcon: true,
+      type: 'info',
       message: (
         <div>
           To download partial genomic sequences (aka genomic segments) please
@@ -59,7 +58,7 @@ const genomicSegmentsBanner = (
           <Link to={{ pathname: '/search/genomic-segment/DynSpansBySourceId' }}>
             Genomic Segments based on Genomic Location
           </Link>{' '}
-          search page
+          search page.
         </div>
       ),
     }}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/DynSpansBySourceId.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/DynSpansBySourceId.scss
@@ -14,13 +14,14 @@
       justify-content: flex-end;
       border-bottom: unset;
 
-      h2 {
+      h3 {
         display: flex;
         flex-direction: row-reverse;
         align-items: center;
         font-size: 0.75rem;
         margin: 0.75em;
         padding: unset;
+        gap: 1ex;
 
         .HelpTrigger {
           margin-left: 0.5em;


### PR DESCRIPTION
This PR fixes a styling issue:

**Before**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/e53f17d8-6ba9-4609-925b-54ea6624dfcc)

**After**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/de5a3b81-c585-4118-a920-b1bb31651840)


It also adds a banner to SRT:

![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/732ff85d-2ba5-45db-bcd4-e95dc2f84afd)

![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/0301c534-944f-420b-ab81-284566b642af)

