### PR TITLE
Update verbiage about genome-scale downloads

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/controllers/FastaConfigController.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/controllers/FastaConfigController.tsx
@@ -93,8 +93,9 @@ export default function FastaConfigController() {
         supply.
       </p>
       <p>
-        (If instead you would like to download sequences in bulk, please visit
-        our file download section.)
+        (If instead you would like to download sequences in genome-scale files,
+        please visit our{' '}
+        <Link to={{ pathname: '/downloads' }}>file download section</Link>.)
       </p>
       <WorkspaceNavigation
         heading={null}


### PR DESCRIPTION
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/f80e74a6-375b-4bd7-b2da-2046fde2fba9)
