### PR TITLE
remove parentheticals from Steps 2-3 in computes

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/RunComputeButton.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/RunComputeButton.tsx
@@ -27,7 +27,11 @@ export function RunComputeButton(props: Props) {
     >
       <FilledButton
         themeRole="primary"
-        text={`Generate ${computationAppOverview.displayName} results`}
+        // Remove any parentheticals from the button text
+        text={`Generate ${computationAppOverview.displayName.replace(
+          / *\([^)]*\) */g,
+          ''
+        )} results`}
         textTransform="none"
         onPress={createJob}
         disabled={!status || !['no-such-job', 'expired'].includes(status)}

--- a/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -687,7 +687,11 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
                 <ComputationStepContainer
                   computationStepInfo={{
                     stepNumber: 2,
-                    stepTitle: `Generate ${computationAppOverview.displayName} results`,
+                    // Remove parentheticals from Step 2 tite.
+                    stepTitle: `Generate ${computationAppOverview.displayName.replace(
+                      / *\([^)]*\) */g,
+                      ''
+                    )} results`,
                   }}
                   isStepDisabled={!isComputationConfigurationValid}
                 >
@@ -705,7 +709,11 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
             <ComputationStepContainer
               computationStepInfo={{
                 stepNumber: 3,
-                stepTitle: `Use ${computationAppOverview.displayName} results in visualization`,
+                // Remove parentheticals from Step 3 title
+                stepTitle: `Use ${computationAppOverview.displayName.replace(
+                  / *\([^)]*\) */g,
+                  ''
+                )} results in visualization`,
               }}
               isStepDisabled={computeJobStatus !== 'complete'}
             >


### PR DESCRIPTION
We've have a run around with the correlation app names. We finally agreed on calling them both "Correlation" and using parentheticals to distinguish between the two. That seemed really nice on the new visualization page and on the thumbnail page but today i realized the actual viz page looks like this with parentheses all over the place. Yuck!

<img width="724" alt="Screen Shot 2024-02-19 at 3 55 50 PM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/9d9ffdf7-f107-4308-9a06-b3091c822780">

This PR removes parentheses and the text they contain from the Generate Results button and the titles of Steps 2 and 3.

<img width="771" alt="Screen Shot 2024-02-19 at 3 56 43 PM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/2b20b00c-f289-42ba-97b9-fbc978b30f8c">


Would really love to get this in for b67 if anyone is around!
