### PR TITLE
add remove or replace parentheticals utils

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/RunComputeButton.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/RunComputeButton.tsx
@@ -3,6 +3,7 @@ import { FilledButton } from '@veupathdb/coreui';
 import { ComputationAppOverview } from '../../types/visualization';
 import { Tooltip } from '@veupathdb/components/lib/components/widgets/Tooltip';
 import { JobStatus } from './ComputeJobStatusHook';
+import { removeParentheticals } from '../../utils/string-formatters';
 
 interface Props {
   computationAppOverview: ComputationAppOverview;
@@ -28,9 +29,8 @@ export function RunComputeButton(props: Props) {
       <FilledButton
         themeRole="primary"
         // Remove any parentheticals from the button text
-        text={`Generate ${computationAppOverview.displayName.replace(
-          / *\([^)]*\) */g,
-          ''
+        text={`Generate ${removeParentheticals(
+          computationAppOverview.displayName
         )} results`}
         textTransform="none"
         onPress={createJob}

--- a/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/VisualizationsContainer.tsx
@@ -44,6 +44,7 @@ import { JobStatus } from '../computations/ComputeJobStatusHook';
 import { ComputationStepContainer } from '../computations/ComputationStepContainer';
 import { ComputationPlugin } from '../computations/Types';
 import { PlotContainerStyleOverrides } from './VisualizationTypes';
+import { removeParentheticals } from '../../utils/string-formatters';
 
 const cx = makeClassNameHelper('VisualizationsContainer');
 
@@ -688,9 +689,8 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
                   computationStepInfo={{
                     stepNumber: 2,
                     // Remove parentheticals from Step 2 tite.
-                    stepTitle: `Generate ${computationAppOverview.displayName.replace(
-                      / *\([^)]*\) */g,
-                      ''
+                    stepTitle: `Generate ${removeParentheticals(
+                      computationAppOverview.displayName
                     )} results`,
                   }}
                   isStepDisabled={!isComputationConfigurationValid}
@@ -710,9 +710,8 @@ export function FullScreenVisualization(props: FullScreenVisualizationProps) {
               computationStepInfo={{
                 stepNumber: 3,
                 // Remove parentheticals from Step 3 title
-                stepTitle: `Use ${computationAppOverview.displayName.replace(
-                  / *\([^)]*\) */g,
-                  ''
+                stepTitle: `Use ${removeParentheticals(
+                  computationAppOverview.displayName
                 )} results in visualization`,
               }}
               isStepDisabled={computeJobStatus !== 'complete'}

--- a/packages/libs/eda/src/lib/core/utils/string-formatters.ts
+++ b/packages/libs/eda/src/lib/core/utils/string-formatters.ts
@@ -1,0 +1,19 @@
+/**
+ * Removes parentheses, their contents, and surrounding whitespace.
+ * For example, "Hello (world)." becomes "Hello.".
+ */
+export function removeParentheticals(stringWithParentheses: string): string {
+  return stringWithParentheses.replace(/ *\([^)]*\) */g, '');
+}
+
+/**
+ * Replace parentheticals and surrounding whitespace with a string.
+ * For example, "Hello (world)" becomes "Hello{new string}".
+ * Useful for replacing parentheticals within a sentence.
+ */
+export function replaceParentheticals(
+  stringWithParentheses: string,
+  newString: string
+): string {
+  return stringWithParentheses.replace(/ *\([^)]*\) */g, newString);
+}


### PR DESCRIPTION
Discussed in #878 , we repeated ourselves _three_ times!!! It's function time!


This PR adds `removeParentheticals` and `replaceParentheticals` to our util functions. The former just strips out the parentheticals and surrounding whitespace from a string. The latter replaces that parenthetical+white space with a new string. This latter one isn't used yet but it seemed an obvious extension so I thought I might as well go ahead and add it.

