### PR TITLE
Fix opacity for ci for scatter vs scattergl

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -2668,7 +2668,7 @@ function processInputData(
         // use darker color for smoothed mean's confidence interval
         // when using scatter, fillColor should be rgba() format
         fillcolor:
-          facetVariable != null
+          scatterPlotType === 'scatter'
             ? ColorMath.evaluate(
                 markerColorDark(index) + ' @a 20%'
               ).result.css()


### PR DESCRIPTION
This PR fixes opacity issues related to scatter vs scattergl

**Before**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/ac541046-78cf-40e6-924e-b5120e86069d)

**After**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/75036c89-611d-4e74-a7cf-238f1ad8463c)
