### PR TITLE
External links - Remove errant condition

### DIFF
--- a/packages/libs/web-common/src/externalLinkHandler.ts
+++ b/packages/libs/web-common/src/externalLinkHandler.ts
@@ -11,7 +11,7 @@ addEventListener('click', (event) => {
     !event.target.target
   ) {
     const url = new URL(event.target.href);
-    if (url.origin !== location.origin || !event.target.target) {
+    if (url.origin !== location.origin) {
       event.target.target = '_blank';
       event.target.rel = 'noreffer';
     }


### PR DESCRIPTION
This PR fixes an issue where some links would open in a new tab. This is due to an errant condition.