### PR TITLE
Clear errorMessage when a new ontology summary is loaded

### DIFF
--- a/packages/libs/wdk-client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
+++ b/packages/libs/wdk-client/src/Views/Question/Params/FilterParamNew/FilterParamObserver.ts
@@ -508,24 +508,39 @@ function getOntologyTermSummary(
         })
       ),
       from(
-        getSummaries.then((summaries) =>
-          updateFieldState({
-            searchName,
-            parameter,
-            paramValues,
-            field: ontologyTerm,
-            fieldState: {
-              loading: false,
-              invalid: false,
-              sort,
-              leafSummaries: sortMultiFieldSummary(
-                summaries,
-                parameter.ontology,
-                sort
-              ),
-              searchTerm: '',
-            },
-          })
+        getSummaries.then(
+          (summaries) =>
+            updateFieldState({
+              searchName,
+              parameter,
+              paramValues,
+              field: ontologyTerm,
+              fieldState: {
+                loading: false,
+                invalid: false,
+                errorMessage: undefined,
+                sort,
+                leafSummaries: sortMultiFieldSummary(
+                  summaries,
+                  parameter.ontology,
+                  sort
+                ),
+                searchTerm: '',
+              },
+            }),
+          () =>
+            updateFieldState({
+              searchName,
+              parameter,
+              paramValues,
+              field: ontologyTerm,
+              fieldState: {
+                invalid: false,
+                loading: false,
+                errorMessage:
+                  'Unable to load summary for "' + ontologyTerm + '".',
+              },
+            })
         )
       )
     );
@@ -581,6 +596,7 @@ function updateOntologyTermSummary(
             ? {
                 invalid: false,
                 loading: false,
+                errorMessage: undefined,
                 sort,
                 currentPage: 1,
                 rowsPerPage: 100,
@@ -593,6 +609,7 @@ function updateOntologyTermSummary(
             : {
                 invalid: false,
                 loading: false,
+                errorMessage: undefined,
                 summary: summary,
               };
 


### PR DESCRIPTION
Fixes #888 

This PR clears any error message related to fetching an ontology summary.