### PR TITLE
Use maxSelectedCount to test if multiPick, and do not include branches if not multiPick

### DIFF
--- a/packages/libs/wdk-client/src/Views/Question/Params/TreeBoxEnumParam.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/Params/TreeBoxEnumParam.tsx
@@ -253,6 +253,8 @@ export function useDefaultCheckboxTreeProps(
   tree: TreeBoxVocabNode,
   selectedLeaves: string[]
 ): CheckboxTreeProps<TreeBoxVocabNode> {
+  const multiPick =
+    isMultiPick(props.parameter) && props.parameter.maxSelectedCount > 1;
   const handleExpansionChange = useCallback(
     (expandedList: string[]) => {
       props.dispatch(setExpandedList({ ...props.context, expandedList }));
@@ -261,7 +263,9 @@ export function useDefaultCheckboxTreeProps(
   );
   const handleSelectionChange = useCallback(
     (ids: string[]) => {
-      const idsWithBranches = ids.concat(deriveSelectedBranches(tree, ids));
+      const idsWithBranches = multiPick
+        ? ids.concat(deriveSelectedBranches(tree, ids))
+        : ids;
       props.onChange(idsWithBranches);
     },
     [props.onChange, tree]
@@ -275,7 +279,7 @@ export function useDefaultCheckboxTreeProps(
 
   return {
     isSelectable: true,
-    isMultiPick: isMultiPick(props.parameter),
+    isMultiPick: multiPick,
     linksPosition: LinksPosition.Top,
     showRoot: false,
     shouldExpandDescendantsWithOneChild: false,


### PR DESCRIPTION
This PR fixes an issue where "single pick" treebox params are including branch leaves in the selection.

The following changes were made:
1. Use `parameter.maxSelectedCount` help determine if a parameter is multiPick. This is only does for UI purpose, as the format of the param value varies based on if it's multiPick.
2. If a treeBox parameter is not multiPick, do not include branch leaves in the value. It's not clear why we include the branch nodes when all children are selected, but we can investigate that at a later time.