### PR TITLE
Add support for max file size

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
@@ -44,6 +44,7 @@ interface Props<T extends string = string> {
   clearBadUpload: () => void;
   submitForm: (newUserDataset: FormSubmission, redirectTo?: string) => void;
   supportedFileUploadTypes: string[];
+  maxSizeBytes?: number;
 }
 
 type DataUploadMode = 'file' | 'url' | 'strategy' | 'step';
@@ -93,6 +94,7 @@ function UploadForm({
   clearBadUpload,
   submitForm,
   supportedFileUploadTypes,
+  maxSizeBytes,
 }: Props) {
   const strategyOptionsByStrategyId = useMemo(
     () => keyBy(strategyOptions, (option) => option.strategyId),
@@ -248,6 +250,7 @@ function UploadForm({
         .join(',')}
       required={dataUploadMode === 'file'}
       disabled={dataUploadMode !== 'file' || useFixedUploadMethod}
+      maxSizeBytes={maxSizeBytes}
       onChange={(file) => {
         const fileWithSpacedRemovedFromName =
           file && new File([file], file?.name.replace(/\s+/g, '_'), file);

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetNewUploadController.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetNewUploadController.tsx
@@ -119,6 +119,9 @@ export default function UserDatasetUploadController({
           datasetUploadType.formConfig.uploadMethodConfig.result
         }
         supportedFileUploadTypes={supportedFileUploadTypes}
+        maxSizeBytes={
+          datasetUploadType.formConfig.uploadMethodConfig.file?.maxSizeBytes
+        }
       />
     </div>
   );

--- a/packages/libs/user-datasets/src/lib/Utils/types.ts
+++ b/packages/libs/user-datasets/src/lib/Utils/types.ts
@@ -91,6 +91,7 @@ export interface DatasetUploadTypeConfigEntry<T extends string> {
 
 export interface FileUploadConfig {
   render?: (props: { fieldNode: ReactNode }) => ReactNode;
+  maxSizeBytes?: number;
 }
 
 export interface UrlUploadConfig {

--- a/packages/libs/user-datasets/src/lib/Utils/upload-config.tsx
+++ b/packages/libs/user-datasets/src/lib/Utils/upload-config.tsx
@@ -14,8 +14,8 @@ export const uploadTypeConfig: DatasetUploadTypeConfig<ImplementedUploadTypes> =
           <p className="formInfo">
             We accept any file in the{' '}
             <a href="http://biom-format.org">BIOM format</a>, either JSON-based
-            (BIOM 1.0) or HDF5 (BIOM 2.0+). The maximum allowed file size is
-            1GB.
+            (BIOM 1.0) or HDF5 (BIOM 2.0+). The maximum allowed file size is 10
+            MB.
             <br />
             <br />
             If possible, try including taxonomic information and rich sample

--- a/packages/libs/user-datasets/src/lib/Utils/upload-config.tsx
+++ b/packages/libs/user-datasets/src/lib/Utils/upload-config.tsx
@@ -24,7 +24,19 @@ export const uploadTypeConfig: DatasetUploadTypeConfig<ImplementedUploadTypes> =
             level, using our filtering and visualisation tools.
           </p>
         ),
-        uploadMethodConfig: {},
+        uploadMethodConfig: {
+          file: {
+            maxSizeBytes: 1e7, // 10 megabytes
+            render: ({ fieldNode }) => (
+              <>
+                {fieldNode}
+                <div style={{ marginTop: '0.25em' }}>
+                  File must be 10MB or smaller.
+                </div>
+              </>
+            ),
+          },
+        },
       },
     },
     'gene-list': {

--- a/packages/libs/user-datasets/src/lib/Utils/upload-config.tsx
+++ b/packages/libs/user-datasets/src/lib/Utils/upload-config.tsx
@@ -31,7 +31,7 @@ export const uploadTypeConfig: DatasetUploadTypeConfig<ImplementedUploadTypes> =
               <>
                 {fieldNode}
                 <div style={{ marginTop: '0.25em' }}>
-                  File must be 10MB or smaller.
+                  File must be 10 MB or smaller.
                 </div>
               </>
             ),

--- a/packages/libs/wdk-client/src/Components/InputControls/FileInput.tsx
+++ b/packages/libs/wdk-client/src/Components/InputControls/FileInput.tsx
@@ -4,23 +4,33 @@
  * field, not the event causing the change.
  */
 
-import React from 'react';
-
 import { Omit } from '../../Core/CommonTypes';
 import { wrappable } from '../../Utils/ComponentUtils';
+import { bytesToHuman } from '../../Utils/Converters';
 
 type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 type InputWithoutOnChange = Omit<InputProps, 'onChange'>;
 type Props = InputWithoutOnChange & {
   onChange: (value: File | null) => void;
+  maxSizeBytes?: number;
 };
 
 const FileInput = function (originalProps: Props) {
-  const { onChange, ...props } = originalProps;
+  const { onChange, maxSizeBytes, ...props } = originalProps;
   const changeHandler = function (
     event: React.ChangeEvent<HTMLInputElement>
   ): void {
-    onChange(event.target.files && event.target.files[0]);
+    const file = event.target.files?.[0];
+    if (file && maxSizeBytes && file.size > maxSizeBytes) {
+      alert(
+        `The file is too large. It must be no larger than ${bytesToHuman(
+          maxSizeBytes
+        )}.`
+      );
+      event.target.value = '';
+    } else {
+      onChange(event.target.files && event.target.files[0]);
+    }
   };
   return <input type="file" {...props} onChange={changeHandler} />;
 };

--- a/packages/libs/wdk-client/src/Utils/Converters.ts
+++ b/packages/libs/wdk-client/src/Utils/Converters.ts
@@ -1,7 +1,7 @@
 const scales = ['B', 'K', 'M', 'G'];
 
 export function bytesToHuman(size: number, scale = 0): string {
-  return size < 1024 || scale === scales.length - 1
+  return size < 1000 || scale === scales.length - 1
     ? `${size.toFixed(2)} ${scales[scale]}`
-    : bytesToHuman(size / 1024, scale + 1);
+    : bytesToHuman(size / 1000, scale + 1);
 }

--- a/packages/libs/wdk-client/src/Utils/Converters.ts
+++ b/packages/libs/wdk-client/src/Utils/Converters.ts
@@ -1,7 +1,16 @@
-const scales = ['B', 'K', 'M', 'G'];
+const scales = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
 
-export function bytesToHuman(size: number, scale = 0): string {
+/**
+ * Convert bytes to a human readable string
+ */
+export function bytesToHuman(numBytes: number) {
+  return recurse(numBytes);
+}
+
+function recurse(size: number, scale = 0): string {
   return size < 1000 || scale === scales.length - 1
-    ? `${size.toFixed(2)} ${scales[scale]}`
-    : bytesToHuman(size / 1000, scale + 1);
+    ? `${size.toLocaleString(undefined, { maximumFractionDigits: 2 })} ${
+        scales[scale]
+      }`
+    : recurse(size / 1000, scale + 1);
 }


### PR DESCRIPTION
fixes #915 

This does not affect files upload via URL, do large files can still make it to the installer.

Here is a screencast with the new feature:

[Screencast from 2024-03-08 12-26-14.webm](https://github.com/VEuPathDB/web-monorepo/assets/365139/7e41ea98-232f-4f9d-b8b2-d2c048ad246c)
