### PR TITLE
Data table followup work

### DIFF
--- a/packages/libs/coreui/src/components/Mesa/Ui/DataRow.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/DataRow.jsx
@@ -79,12 +79,11 @@ class DataRow extends React.PureComponent {
       typeof eventHandlers.onRowSelect === 'function' &&
       typeof eventHandlers.onRowDeselect === 'function';
 
-    const hasExpansionColumn = [
-      childRow,
-      eventHandlers.onExpandedRowsChange,
-      uiState.expandedRows,
-      getRowId,
-    ].every((prop) => prop != null);
+    const hasExpansionColumn =
+      childRow != null &&
+      eventHandlers?.onExpandedRowsChange != null &&
+      uiState?.expandedRows != null &&
+      getRowId != null;
 
     const showChildRow =
       hasExpansionColumn && uiState.expandedRows.includes(getRowId(row));

--- a/packages/libs/coreui/src/components/Mesa/Ui/HeadingRow.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/HeadingRow.jsx
@@ -32,12 +32,11 @@ class HeadingRow extends React.PureComponent {
       onRowDeselect,
     ].every((fn) => typeof fn === 'function');
 
-    const hasExpansionColumn = [
-      childRow,
-      expandedRows,
-      onExpandedRowsChange,
-      getRowId,
-    ].every((prop) => prop != null);
+    const hasExpansionColumn =
+      childRow != null &&
+      onExpandedRowsChange != null &&
+      expandedRows != null &&
+      getRowId != null;
 
     const rowCount = columns.reduce((count, column) => {
       const thisCount = Array.isArray(column.renderHeading)

--- a/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
@@ -239,12 +239,14 @@ class RecordTable extends Component {
       uiState: {
         sort: this.state.sort,
         expandedRows,
+        filteredRowCount: mesaReadyRows.length - filteredRows.length,
       },
       options: {
         toolbar: true,
         childRow: childRow ? this.wrappedChildRow : undefined,
         className: 'wdk-DataTableContainer',
         getRowId: getSortIndex,
+        showCount: mesaReadyRows.length > 1,
       },
     };
 

--- a/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
@@ -92,9 +92,6 @@ class RecordTable extends Component {
     const content =
       typeof ChildRow === 'string' ? (
         safeHtml(ChildRow)
-      ) : // Q: Is this necessary? Is ChildRow ever a typeof function that isn't actually a PureWrapper class?
-      typeof ChildRow === 'function' && ChildRow.name !== 'PureWrapper' ? (
-        ChildRow({ rowIndex, rowData })
       ) : (
         <ChildRow rowIndex={rowIndex} rowData={rowData} />
       );

--- a/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
@@ -21,9 +21,6 @@ import { ErrorBoundary } from '../../../Controllers';
 import { stripHTML } from '../../../Utils/DomUtils';
 import './RecordTable.css';
 
-// TODO: handle in model
-const COLUMNS_TO_OVERRIDE_SORT = ['thumbnail', 'clustalInput'];
-
 // NOTE: This is very hacky because the model is not reliably providing column or sort types
 const mapSortType = (val) => {
   if (!isNaN(parseFloat(val)) && isFinite(val)) {
@@ -153,9 +150,7 @@ class RecordTable extends Component {
           ...remainingProperties,
           key: name,
           name: displayName,
-          sortable: COLUMNS_TO_OVERRIDE_SORT.includes(name)
-            ? false
-            : isSortable,
+          sortable: isSortable,
           type: type ?? 'html',
           helpText: help,
           sortType,

--- a/packages/libs/web-common/src/styles/client.scss
+++ b/packages/libs/web-common/src/styles/client.scss
@@ -2,6 +2,8 @@
 @import './AllSites.scss';
 @import './question-wizard.css';
 
+$expand-child-row-toggle-width: 3em;
+
 body,
 h1,
 h2,
@@ -112,11 +114,15 @@ tr._childIsExpanded
 }
 
 .wdk-DataTableCellExpand {
-  width: 3em;
+  width: $expand-child-row-toggle-width;
   padding: 0;
   border: none;
   line-height: 2;
   background: transparent !important;
+}
+
+.wdk-DataTableCell.wdk-DataTableCell__childRowToggle {
+  width: $expand-child-row-toggle-width;
 }
 
 th > .wdk-DataTableCellExpand {

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -142,7 +142,7 @@ const transformPfamsAttributeFields = curry(
   (isGraphic: boolean, attributeFields: AttributeField[]): AttributeField[] => {
     const renamedAttributeFields = attributeFields.map((attributeField) =>
       attributeField.name === ACCESSION_ATTRIBUTE_NAME
-        ? { ...attributeField, displayName: 'Accession' }
+        ? { ...attributeField, displayName: 'Accession', type: 'link' }
         : attributeField
     );
 
@@ -187,6 +187,7 @@ const makeProteinDomainLocationAttributeFields =
     {
       name: SOURCE_ID_ATTRIBUTE_NAME,
       displayName: 'Accession',
+      type: 'link',
     },
     {
       name: TAXON_ATTRIBUTE_NAME,
@@ -219,6 +220,7 @@ const makeProteinDomainArchitectureAttributeFields =
     {
       name: SOURCE_ID_ATTRIBUTE_NAME,
       displayName: 'Accession',
+      type: 'link',
     },
     {
       name: TAXON_ATTRIBUTE_NAME,

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
@@ -85,6 +85,7 @@ const makePfamDomainsAttributeFields = transformAttributeFieldsUsingSpecs([
   {
     name: DOMAIN_ACCESSION_ATTRIBUTE_NAME,
     displayName: 'Accession',
+    type: 'link',
   },
   {
     name: DOMAIN_SYMBOL_ATTRIBUTE_NAME,


### PR DESCRIPTION
Works to resolve issues found in https://github.com/VEuPathDB/web-monorepo/issues/921

Specifically, this branch does the following:
- fix Bob's discovery re: "eventHandlers undefined" issue in his orthotree branch
- fix ortho's accession column issues w/ links (previously thought this would be handled in the model by adding `type="link"` somewhere, but is client-side instead)
- fix issue with the `wrappedChildRow` logic breaking w/ classes only in production bundle (removed faulty function check)
- pass props to Mesa to enable row counts
- define column width for childRow toggle columns