### PR TITLE
Add group description to show-hide group

### DIFF
--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.scss
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.scss
@@ -18,7 +18,7 @@
 
   &ShowHideGroup {
     border: 1px solid #eaeaea;
-    background-color: #f0f0f0;
+    background-color: #f5f5f5;
     margin-top: 0.5em;
 
     &Toggle {

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
@@ -31,7 +31,6 @@ import { Tabs } from '../../Components';
 
 import '../../Views/Question/DefaultQuestionForm.scss';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
-import { type } from 'os';
 import { BetaIcon } from '../../Core/Style/Icons/BetaIcon';
 
 type TextboxChangeHandler = (
@@ -382,6 +381,15 @@ function ShowHideGroup(props: GroupProps) {
         {group.displayName}
       </button>
       <div className={cx('ShowHideGroupContent')}>
+        {isVisible && group.description && (
+          <Banner
+            banner={{
+              type: 'normal',
+              hideIcon: true,
+              message: safeHtml(group.description, null, 'div'),
+            }}
+          />
+        )}
         {isVisible ? props.children : null}
       </div>
     </div>
@@ -440,12 +448,12 @@ function ParameterHeading(props: {
   const { parameter, paramDependencyUpdating } = props;
   return (
     <div className={cx('ParameterHeading')}>
-      <h3>
+      <h4>
         <HelpIcon>{safeHtml(parameter.help)}</HelpIcon> {parameter.displayName}
         {paramDependencyUpdating && (
           <IconAlt fa="circle-o-notch" className="fa-spin fa-fw" />
         )}
-      </h3>
+      </h4>
     </div>
   );
 }


### PR DESCRIPTION
This PR adds a group description to the show-hide WDK parameter group section. It also includes some styling changes: use `h4` for parameter names, and lighten the background of the show-hide section.

The styling could probably use some work, but I thought this would be a good starting point.

---
### Screenshots

**Before**
![Screenshot 2024-03-14 at 12-25-50 Search for ESTs by Extent of Gene Overlap](https://github.com/VEuPathDB/web-monorepo/assets/365139/9e861f74-1406-47a9-9e75-cedde28cdc55)

---

**After**
![Screenshot 2024-03-14 at 12-17-15 Search for ESTs by Extent of Gene Overlap](https://github.com/VEuPathDB/web-monorepo/assets/365139/6ee23958-6b3a-4ed8-820b-ac8df73750d2)
![Screenshot 2024-03-14 at 12-17-41 Search for ESTs by Extent of Gene Overlap](https://github.com/VEuPathDB/web-monorepo/assets/365139/a210fecc-310b-488e-a9e3-fa0a7b611bdb)



closes #930