### PR TITLE
Limit site search titles to one line and add title attribute

### DIFF
--- a/packages/libs/web-common/src/components/SiteSearch/SiteSearch.scss
+++ b/packages/libs/web-common/src/components/SiteSearch/SiteSearch.scss
@@ -454,6 +454,9 @@
   &--Result {
     &Link {
       font-size: 1.145em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     &DocumentTypePath {
       color: #3e3e3e;

--- a/packages/libs/web-common/src/components/SiteSearch/SiteSearch.tsx
+++ b/packages/libs/web-common/src/components/SiteSearch/SiteSearch.tsx
@@ -664,7 +664,10 @@ function Hit(props: HitProps) {
           </span>
         )}
         {subTitle && (
-          <div className={cx('--ResultSubTitle')}>
+          <div
+            className={cx('--ResultSubTitle')}
+            title={formatSummaryFieldValue(subTitle)}
+          >
             {formatSummaryFieldValue(subTitle)}
           </div>
         )}


### PR DESCRIPTION
Resolves #919 

<img width="1222" alt="image" src="https://github.com/VEuPathDB/web-monorepo/assets/69446567/564cbcf2-b25a-440c-89d7-bc7c42f79e00">
