### PR TITLE
change order of babel presets

### DIFF
--- a/packages/libs/components/.storybook/main.js
+++ b/packages/libs/components/.storybook/main.js
@@ -16,7 +16,7 @@ module.exports = {
   babel: async (options) => {
     return {
       ...options,
-      presets: [...options.presets, '@emotion/babel-preset-css-prop'],
+      presets: ['@emotion/babel-preset-css-prop', ...options.presets],
       // See https://stackoverflow.com/questions/70406632/typescript-parameter-properties-not-working-with-storybook-rollup-in-developm
       plugins: options.plugins.filter(
         (x) =>


### PR DESCRIPTION
This PR fixes an issue with storybook stories in `@veupathdb/components`.

Several map stories, and all network stories, have been failing with a `React is not defined` error. I believe it is related to adding the `@emotion/babel-preset-css-prop` to the end of the list of babel presets. The `@babel/preset-react` automatically adds `import React from 'react'` to modules. If `@emotion/babel-preset-css-prop` introduces a reference to `React` to a module, this would explain the error, since `@babel/preset-react` has already run. 

Moving it to the beginning fixes the issue.