### PR TITLE
set default binWidth as undefined for HistogramViz and Lineplot Viz

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -1548,9 +1548,6 @@ function getRequestParams(
     xAxisVariable,
   } = config;
 
-  //DKDK
-  console.log('binWidth, binWidthTimeUnit =', binWidth, binWidthTimeUnit);
-
   const binSpec: Pick<HistogramRequestParams['config'], 'binSpec'> = binWidth
     ? {
         binSpec: {

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -1540,12 +1540,7 @@ function getRequestParams(
   ) => HistogramRequestParams
 ): HistogramRequestParams {
   const {
-    binWidth = NumberVariable.is(variable) || DateVariable.is(variable)
-      ? config.independentAxisValueSpec === 'Full'
-        ? variable.distributionDefaults.binWidthOverride ??
-          variable.distributionDefaults.binWidth
-        : undefined
-      : undefined,
+    binWidth = undefined,
     binWidthTimeUnit = variable?.type === 'date'
       ? variable.distributionDefaults.binUnits
       : undefined,

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/HistogramVisualization.tsx
@@ -1540,15 +1540,16 @@ function getRequestParams(
   ) => HistogramRequestParams
 ): HistogramRequestParams {
   const {
-    binWidth = undefined,
-    binWidthTimeUnit = variable?.type === 'date'
-      ? variable.distributionDefaults.binUnits
-      : undefined,
+    binWidth,
+    binWidthTimeUnit,
     valueSpec,
     overlayVariable,
     facetVariable,
     xAxisVariable,
   } = config;
+
+  //DKDK
+  console.log('binWidth, binWidthTimeUnit =', binWidth, binWidthTimeUnit);
 
   const binSpec: Pick<HistogramRequestParams['config'], 'binSpec'> = binWidth
     ? {

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -2098,10 +2098,8 @@ function getRequestParams(
     facetVariable,
     valueSpecConfig,
     showMissingness,
-    binWidth = undefined,
-    binWidthTimeUnit = xAxisVariableMetadata?.type === 'date'
-      ? xAxisVariableMetadata.distributionDefaults.binUnits
-      : undefined,
+    binWidth,
+    binWidthTimeUnit,
     useBinning,
     numeratorValues,
     denominatorValues,

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/LineplotVisualization.tsx
@@ -2098,11 +2098,7 @@ function getRequestParams(
     facetVariable,
     valueSpecConfig,
     showMissingness,
-    binWidth = NumberVariable.is(xAxisVariableMetadata) ||
-    DateVariable.is(xAxisVariableMetadata)
-      ? xAxisVariableMetadata.distributionDefaults.binWidthOverride ??
-        xAxisVariableMetadata.distributionDefaults.binWidth
-      : undefined,
+    binWidth = undefined,
     binWidthTimeUnit = xAxisVariableMetadata?.type === 'date'
       ? xAxisVariableMetadata.distributionDefaults.binUnits
       : undefined,


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/961. Implementation didn't take too much time but tests did 😅. Changed both HistogramViz and Lineplot Viz: time series worked just fine after changing Lineplot Viz. 

One note is that backend did return incorrect binWidthRange for the example case in the ticket (please see the screenshot below), { min: 0.1, max: 0 }. @d-callan? 

![histogram_binWidthRange01](https://github.com/VEuPathDB/web-monorepo/assets/12802305/c7d922b5-b2ee-4104-a556-63d9f5bcd337)



Here are some screenshots with this PR:
![histogram_binWidthRange00](https://github.com/VEuPathDB/web-monorepo/assets/12802305/7fac5813-16f0-4f07-8c10-e81166ae76f1)

![hisgotram_binWidthRange02](https://github.com/VEuPathDB/web-monorepo/assets/12802305/e9e30414-7112-431b-ae7b-564082b32fe1)

![lineplot_binWidthRange00](https://github.com/VEuPathDB/web-monorepo/assets/12802305/46b6678a-0353-47c2-8599-ce4c40839b42)
