### PR TITLE
fixing broken visx stories - Network & Volcano

### DIFF
--- a/packages/libs/components/src/plots/BipartiteNetwork.tsx
+++ b/packages/libs/components/src/plots/BipartiteNetwork.tsx
@@ -1,9 +1,4 @@
-import { BipartiteNetworkData, NodeData } from '../types/plots/network';
-import { partition } from 'lodash';
-import { LabelPosition, Link, NodeWithLabel } from './Network';
-import { Graph } from '@visx/network';
-import { Text } from '@visx/text';
-import {
+import React, {
   CSSProperties,
   ReactNode,
   Ref,
@@ -12,6 +7,11 @@ import {
   useRef,
   useCallback,
 } from 'react';
+import { BipartiteNetworkData, NodeData } from '../types/plots/network';
+import { partition } from 'lodash';
+import { LabelPosition, Link, NodeWithLabel } from './Network';
+import { Graph } from '@visx/network';
+import { Text } from '@visx/text';
 import Spinner from '../components/Spinner';
 import { ToImgopts } from 'plotly.js';
 import { gray } from '@veupathdb/coreui/lib/definitions/colors';

--- a/packages/libs/components/src/plots/ExportPlotToImageButton.tsx
+++ b/packages/libs/components/src/plots/ExportPlotToImageButton.tsx
@@ -50,11 +50,6 @@ export function ExportPlotToImageButton(props: Props) {
             value: 'svg',
           } as const,
           {
-            // display: (
-            //   <>
-            //     PNG &nbsp; <em>(large plots may fail)</em>
-            //   </>
-            // ),
             display: (
               <>
                 PNG &nbsp; <em>(large plots may fail)</em>

--- a/packages/libs/components/src/plots/ExportPlotToImageButton.tsx
+++ b/packages/libs/components/src/plots/ExportPlotToImageButton.tsx
@@ -1,6 +1,6 @@
+import React, { CSSProperties, useState } from 'react';
 import { Image } from '@material-ui/icons';
-import { colors, SingleSelect, Warning } from '@veupathdb/coreui';
-import { CSSProperties, useState } from 'react';
+import { colors, SingleSelect } from '@veupathdb/coreui';
 
 interface ToImageOpts {
   height: number;
@@ -50,6 +50,11 @@ export function ExportPlotToImageButton(props: Props) {
             value: 'svg',
           } as const,
           {
+            // display: (
+            //   <>
+            //     PNG &nbsp; <em>(large plots may fail)</em>
+            //   </>
+            // ),
             display: (
               <>
                 PNG &nbsp; <em>(large plots may fail)</em>

--- a/packages/libs/components/src/plots/Network.tsx
+++ b/packages/libs/components/src/plots/Network.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { DefaultNode } from '@visx/network';
 import { Text } from '@visx/text';
 import { LinkData, NodeData } from '../types/plots/network';

--- a/packages/libs/components/src/plots/VolcanoPlot.tsx
+++ b/packages/libs/components/src/plots/VolcanoPlot.tsx
@@ -1,10 +1,11 @@
-import {
+import React, {
   CSSProperties,
   forwardRef,
   Ref,
   useCallback,
   useImperativeHandle,
   useRef,
+  useContext,
 } from 'react';
 import {
   VolcanoPlotData,
@@ -34,7 +35,6 @@ import {
   plotToImage,
 } from './visxVEuPathDB';
 import { Polygon } from '@visx/shape';
-import { useContext } from 'react';
 import { PatternLines } from '@visx/visx';
 import Spinner from '../components/Spinner';
 // For screenshotting
@@ -274,7 +274,7 @@ function VolcanoPlot(props: VolcanoPlotProps, ref: Ref<HTMLDivElement>) {
           ref={plotRef} // Set ref here. Also tried setting innerRef of Group but that didnt work with domToImage
           style={{ width: '100%', height: '100%' }}
         >
-          {/* The XYChart takes care of laying out the chart elements (children) appropriately. 
+          {/* The XYChart takes care of laying out the chart elements (children) appropriately.
           It uses modularized React.context layers for data, events, etc. The following all becomes an svg,
           so use caution when ordering the children (ex. draw axes before data).  */}
           <XYChart

--- a/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
+++ b/packages/libs/components/src/stories/plots/BipartiteNetwork.stories.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useRef, CSSProperties, ReactNode } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  CSSProperties,
+  ReactNode,
+} from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import {
   NodeData,

--- a/packages/libs/components/src/stories/plots/VolcanoPlot.stories.tsx
+++ b/packages/libs/components/src/stories/plots/VolcanoPlot.stories.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import VolcanoPlot, {
   StatisticsFloors,
   VolcanoPlotProps,

--- a/packages/libs/components/src/stories/plots/VolcanoPlotRef.stories.tsx
+++ b/packages/libs/components/src/stories/plots/VolcanoPlotRef.stories.tsx
@@ -1,6 +1,4 @@
-import { useEffect } from 'react';
-import { useState } from 'react';
-import { useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Story } from '@storybook/react/types-6-0';
 import VolcanoPlot, { VolcanoPlotProps } from '../../plots/VolcanoPlot';
 import { range } from 'lodash';


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/920

It turned out that as Ann thought, it was correct that `import React from 'react';` was needed. I tracked down all error messages carefully, and added the part for all relevant files.

If I understand correctly, Dave has set up auto inclusion of those react import for web-monorepo (babel and/or webpack config), but I think that storybook did not have such configuration, which requires to have the react import in that case.

I checked all sub-plots and all seem to work correctly without complaints :)