### PR TITLE
Make adjustments to record not found UI

### DIFF
--- a/packages/libs/wdk-client/src/Controllers/RecordController.tsx
+++ b/packages/libs/wdk-client/src/Controllers/RecordController.tsx
@@ -34,6 +34,7 @@ import {
 } from '../Views/Records/RecordUtils';
 import { RootState } from '../Core/State/Types';
 import { preorderSeq } from '../Utils/TreeUtils';
+import { RecordNotFoundPage } from '../Views/Records/RecordNotFoundPage';
 
 const ActionCreators = {
   ...UserActionCreators,
@@ -145,27 +146,8 @@ class RecordController extends PageController<Props> {
   }
 
   renderDataNotFound() {
-    const [sourceID, projectID] = this.props.ownProps.primaryKey.split('/');
-    const recordClass = this.props.ownProps.recordClass;
-    return (
-      <div>
-        <h1>
-          No {recordClass} with an ID of {sourceID} found in {projectID}
-        </h1>
-        <p>
-          The ID may have changed. Please use our site search feature to find
-          matches for <strong>{sourceID}</strong>.
-        </p>
-        <p>
-          <a
-            target={'_blank'}
-            href="https://static-content.veupathdb.org/documents/SiteSearch.pdf"
-          >
-            Learn more about our site search feature here.
-          </a>
-        </p>
-      </div>
-    );
+    const sourceID = this.props.ownProps.primaryKey.split('/')[0];
+    return <RecordNotFoundPage sourceID={sourceID} />;
   }
 
   getTitle() {

--- a/packages/libs/wdk-client/src/Views/Records/RecordNotFound.css
+++ b/packages/libs/wdk-client/src/Views/Records/RecordNotFound.css
@@ -1,0 +1,8 @@
+.wdk-RecordNotFoundHeader {
+  padding: 0.5em 0 0 0;
+}
+
+.wdk-RecordNotFoundParagraph {
+  margin: 0.5em 0;
+  font-size: 1.2em;
+}

--- a/packages/libs/wdk-client/src/Views/Records/RecordNotFoundPage.tsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordNotFoundPage.tsx
@@ -1,0 +1,29 @@
+import { useLocation } from 'react-router';
+import './RecordNotFound.css';
+
+type Props = {
+  sourceID: string;
+};
+
+export function RecordNotFoundPage({ sourceID }: Props) {
+  const location = useLocation();
+  const searchUrl = window.location.href.replace(
+    location.pathname,
+    `/search?q=${sourceID}`
+  );
+  return (
+    <div>
+      <h1 className="wdk-RecordNotFoundHeader">
+        No results for <strong>{sourceID}</strong>
+      </h1>
+      <p className="wdk-RecordNotFoundParagraph">
+        The ID may have changed. Please use our site search feature to find
+        matches for{' '}
+        <a href={searchUrl}>
+          <strong>{sourceID}</strong>
+        </a>
+        .
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Responds to feedback [here](https://github.com/VEuPathDB/web-monorepo/pull/944#issuecomment-2030331134) and in a slack thread. Screenshots below show how the UIs compare between no record and empty search results.

**No record found**
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/4d1b28d1-bdc2-4fb9-97b2-d7c758171e59)

**No search results**
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/7a773940-f8e4-4787-8c61-5f48f3d236d7)
