### PR TITLE
Condition data access verbiage in download tab wrt projectDisplayName && isUserStudy

### DIFF
--- a/packages/libs/coreui/src/components/buttons/SwissArmyButton/index.tsx
+++ b/packages/libs/coreui/src/components/buttons/SwissArmyButton/index.tsx
@@ -63,7 +63,9 @@ export default function SwissArmyButton({
           fontSize="inherit"
           fill={styleSpec[styleState].textColor}
           css={
-            text && iconPosition === 'left'
+            !text
+              ? { margin: 0 }
+              : iconPosition === 'left'
               ? { marginRight: 10 }
               : { marginLeft: 10 }
           }
@@ -74,7 +76,9 @@ export default function SwissArmyButton({
         fontSize={styleSpec.icon?.fontSize ?? calculatedIconSize}
         fill={styleSpec[styleState].textColor}
         css={
-          text && iconPosition === 'left'
+          !text
+            ? { margin: 0 }
+            : iconPosition === 'left'
             ? { marginRight: 10 }
             : { marginLeft: 10 }
         }

--- a/packages/libs/eda/src/lib/core/types/study.ts
+++ b/packages/libs/eda/src/lib/core/types/study.ts
@@ -285,6 +285,7 @@ export const StudyOverview = t.intersection([
   }),
   t.partial({
     hasMap: t.boolean,
+    isUserStudy: t.boolean,
   }),
 ]);
 

--- a/packages/libs/eda/src/lib/workspace/DownloadTab/CurrentRelease.tsx
+++ b/packages/libs/eda/src/lib/workspace/DownloadTab/CurrentRelease.tsx
@@ -90,7 +90,7 @@ export default function CurrentRelease({
   ];
 
   return (
-    <div id="Current Release Dataset" style={{ marginBottom: 35 }}>
+    <div id="Current Release Dataset">
       <div style={{ marginBottom: 15 }}>
         <H5
           text={`Full Dataset (Release ${release.releaseNumber})`}

--- a/packages/libs/eda/src/lib/workspace/DownloadTab/MySubset.tsx
+++ b/packages/libs/eda/src/lib/workspace/DownloadTab/MySubset.tsx
@@ -45,7 +45,7 @@ export default function MySubset({
   const toggleStarredVariable = useToggleStarredVariable(analysisState);
 
   return (
-    <div key="My Subset" style={{ marginTop: 20, marginBottom: 35 }}>
+    <div key="My Subset">
       {currentEntity ? (
         <SubsetDownloadModal
           displayModal={mySubsetModalOpen}

--- a/packages/libs/eda/src/lib/workspace/DownloadTab/StudyCitation.tsx
+++ b/packages/libs/eda/src/lib/workspace/DownloadTab/StudyCitation.tsx
@@ -64,10 +64,8 @@ export default function StudyCitation({
   };
 
   return (
-    <>
-      <H5 additionalStyles={{ marginBottom: 0, marginTop: 20 }}>
-        Dataset Citation:{' '}
-      </H5>
+    <div>
+      <H5 additionalStyles={{ margin: 0 }}>Dataset Citation: </H5>
       <Paragraph
         color={colors.gray[600]}
         styleOverrides={{ margin: 0 }}
@@ -106,6 +104,6 @@ export default function StudyCitation({
           </div>
         </span>
       </Paragraph>
-    </>
+    </div>
   );
 }

--- a/packages/libs/eda/src/lib/workspace/DownloadTab/index.tsx
+++ b/packages/libs/eda/src/lib/workspace/DownloadTab/index.tsx
@@ -32,6 +32,8 @@ import { showLoginForm } from '@veupathdb/wdk-client/lib/Actions/UserSessionActi
 import { useHistory } from 'react-router';
 import { parsePath } from 'history';
 
+const EDA_USER_DATASET_PREFIX = 'EDAUD';
+
 type DownloadsTabProps = {
   downloadClient: DownloadClient;
   analysisState: AnalysisState;
@@ -54,6 +56,7 @@ export default function DownloadTab({
     filteredCounts
   );
   const datasetId = studyRecord.id[0].value;
+  const isUserStudy = datasetId.split('_')[0] === EDA_USER_DATASET_PREFIX;
   const permission = usePermissions();
   const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
   const projectDisplayName = useWdkService(
@@ -114,20 +117,11 @@ export default function DownloadTab({
       </button>
     );
 
-    return (
-      <span
-        style={{
-          fontWeight: 300,
-          fontSize: '1.4em',
-        }}
-      >
-        {getDataAccessDeclaration(
-          studyAccess,
-          requestElement,
-          user?.isGuest,
-          hasPermission
-        )}
-      </span>
+    return getDataAccessDeclaration(
+      studyAccess,
+      requestElement,
+      user?.isGuest,
+      hasPermission
     );
   }, [user, permission, studyRecord, handleClick]);
 
@@ -232,8 +226,18 @@ export default function DownloadTab({
 
   return (
     <div style={{ display: 'flex', paddingTop: 10 }}>
-      <div key="Column One" style={{ marginRight: 75 }}>
-        {dataAccessDeclaration ?? ''}
+      <div
+        key="Column One"
+        style={{
+          display: 'flex',
+          rowGap: '1.5em',
+          flexDirection: 'column',
+          marginRight: 75,
+        }}
+      >
+        {!isUserStudy &&
+          projectDisplayName === 'ClinEpiDB' &&
+          (dataAccessDeclaration ?? '')}
         {mergedReleaseData[0] && (
           <StudyCitation
             partialCitationData={partialCitationData}

--- a/packages/libs/eda/src/lib/workspace/DownloadTab/index.tsx
+++ b/packages/libs/eda/src/lib/workspace/DownloadTab/index.tsx
@@ -32,8 +32,6 @@ import { showLoginForm } from '@veupathdb/wdk-client/lib/Actions/UserSessionActi
 import { useHistory } from 'react-router';
 import { parsePath } from 'history';
 
-const EDA_USER_DATASET_PREFIX = 'EDAUD';
-
 type DownloadsTabProps = {
   downloadClient: DownloadClient;
   analysisState: AnalysisState;
@@ -56,7 +54,7 @@ export default function DownloadTab({
     filteredCounts
   );
   const datasetId = studyRecord.id[0].value;
-  const isUserStudy = datasetId.split('_')[0] === EDA_USER_DATASET_PREFIX;
+  const { isUserStudy } = studyMetadata;
   const permission = usePermissions();
   const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
   const projectDisplayName = useWdkService(
@@ -235,8 +233,8 @@ export default function DownloadTab({
           marginRight: 75,
         }}
       >
-        {!isUserStudy &&
-          projectDisplayName === 'ClinEpiDB' &&
+        {projectDisplayName === 'ClinEpiDB' &&
+          !isUserStudy &&
           (dataAccessDeclaration ?? '')}
         {mergedReleaseData[0] && (
           <StudyCitation


### PR DESCRIPTION
Resolves #989
Resolves #927

Note that I've amended the logic to only display this verbiage in ClinEpiDB for non-user studies. Otherwise, this verbiage won't display in MicrobiomeDB or genomics sites irrespective of its `isUserStudy` status.

I also took a chance to clean up some of the styling. I didn't like how I handled the spacing via margins so set the container to be flex and used gap instead.

MicrobiomeDB:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/57d7be28-8449-4d23-9f0f-16748f28f493)

User study in ClinEpiDB:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/492046b8-0f94-448e-85f5-d16d9952ef32)

Curated study in ClinEpiDB:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/f0c190ac-ab58-44d6-a1ce-1889e59e52a8)
