### PR TITLE
Consume and display question's new searchVisibleHelp attribute

### DIFF
--- a/packages/libs/wdk-client/src/Service/Decoders/QuestionDecoders.ts
+++ b/packages/libs/wdk-client/src/Service/Decoders/QuestionDecoders.ts
@@ -326,6 +326,7 @@ const questionSharedDecoder = Decode.combine(
     Decode.field('reviseBuild', Decode.optional(Decode.string))
   ),
   Decode.combine(
+    Decode.field('searchVisibleHelp', Decode.optional(Decode.string)),
     Decode.field('urlSegment', Decode.string),
     Decode.field('groups', Decode.arrayOf(paramGroupDecoder)),
     Decode.field('defaultAttributes', Decode.arrayOf(Decode.string)),

--- a/packages/libs/wdk-client/src/Utils/WdkModel.ts
+++ b/packages/libs/wdk-client/src/Utils/WdkModel.ts
@@ -273,6 +273,7 @@ export interface Question extends UrlModelEntity {
   queryName?: string;
   isCacheable: boolean;
   isBeta?: boolean;
+  searchVisibleHelp?: string;
 }
 
 export interface QuestionWithParameters extends Question {

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
@@ -330,12 +330,24 @@ export function DefaultGroup(props: DefaultGroupProps) {
       uiState={uiState}
       onVisibilityChange={onVisibilityChange}
     >
-      <ParameterList
-        parameterMap={question.parametersByName}
-        parameterElements={parameterElements}
-        parameters={group.parameters}
-        paramDependenciesUpdating={paramDependenciesUpdating}
-      />
+      <>
+        {question.searchVisibleHelp !== undefined && (
+          <Banner
+            // 'normal' renders a banner w/ gray background
+            banner={{
+              type: 'normal',
+              message: safeHtml(question.searchVisibleHelp, null, 'div'),
+              hideIcon: true,
+            }}
+          />
+        )}
+        <ParameterList
+          parameterMap={question.parametersByName}
+          parameterElements={parameterElements}
+          parameters={group.parameters}
+          paramDependenciesUpdating={paramDependenciesUpdating}
+        />
+      </>
     </Group>
   );
 }


### PR DESCRIPTION
Depends on https://github.com/VEuPathDB/ApiCommonModel/pull/42 and https://github.com/VEuPathDB/WDK/pull/86

Renders a question-level help banner above the `ParameterList`.

![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/1954c5b1-1187-4318-bc81-60e4507ccba0)
