### PR TITLE
Update param UI to reflect visibleHelpPosition set to 'right'

### DIFF
--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -41,12 +41,13 @@ export type BannerProps = {
   showMoreLinkColor?: string;
   // is showMoreLink bold?
   isShowMoreLinkBold?: boolean;
-  // banner margin, padding, text font size
+  // banner margin, padding, text font size, width
   spacing?: {
     margin?: CSSProperties['margin'];
     padding?: CSSProperties['padding'];
   };
   fontSize?: CSSProperties['fontSize'];
+  width?: CSSProperties['width'];
   // implementing Banner timeout
   showBanner?: boolean;
   setShowBanner?: (newValue: boolean) => void;
@@ -119,6 +120,7 @@ export default function Banner(props: BannerComponentProps) {
     additionalMessage,
     spacing,
     fontSize,
+    width,
     showBanner = true,
     setShowBanner,
     autoHideDuration,
@@ -186,7 +188,7 @@ export default function Banner(props: BannerComponentProps) {
             box-sizing: border-box;
             border-radius: ${CollapsibleContent != null ? '0' : '7px'};
             margin: ${spacing?.margin != null ? spacing.margin : '10px 0'};
-            width: 100%;
+            width: ${width ?? '100%'};
             padding: ${spacing?.padding != null ? spacing.padding : '10px'};
             align-items: center;
             font-family: 'Roboto', 'Helvetica Neue', Helvetica, 'Segoe UI',

--- a/packages/libs/wdk-client/src/Service/Decoders/QuestionDecoders.ts
+++ b/packages/libs/wdk-client/src/Service/Decoders/QuestionDecoders.ts
@@ -64,7 +64,8 @@ const paramSharedDecoder =
     ),
     Decode.combine(
       Decode.field('allowEmptyValue', Decode.boolean),
-      Decode.field('visibleHelp', Decode.optional(Decode.string))
+      Decode.field('visibleHelp', Decode.optional(Decode.string)),
+      Decode.field('visibleHelpPosition', Decode.optional(Decode.string))
     )
   );
 

--- a/packages/libs/wdk-client/src/Utils/WdkModel.ts
+++ b/packages/libs/wdk-client/src/Utils/WdkModel.ts
@@ -60,6 +60,7 @@ interface ParameterBase extends NamedModelEntity {
   dependentParams: string[];
   allowEmptyValue: boolean;
   visibleHelp?: string;
+  visibleHelpPosition?: string;
 }
 
 export interface StringParam extends ParameterBase {

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.scss
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.scss
@@ -74,7 +74,6 @@
     &_Right {
       grid-column: 2;
       grid-row: 1;
-      border-left: 1px solid #ccc;
     }
   }
 

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.scss
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.scss
@@ -42,6 +42,15 @@
     padding-bottom: 0.5rem;
   }
 
+  &ParameterControlContainer {
+    &_VisibleHelpRight {
+      display: grid;
+      align-items: center;
+      grid-template-columns: auto auto;
+      grid-template-rows: auto;
+    }
+  }
+
   &ParameterHeading {
     h2 {
       font-size: 1.6em;
@@ -55,6 +64,18 @@
 
   &ParameterControl {
     padding: 1.3rem;
+    .ControlLeft {
+      grid-column: 1;
+      grid-row: 1;
+    }
+  }
+
+  &VisibleHelpContainer {
+    &_Right {
+      grid-column: 2;
+      grid-row: 1;
+      border-left: 1px solid #ccc;
+    }
   }
 
   &VisibleHelp {

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
@@ -434,18 +434,54 @@ export function ParameterList(props: ParameterListProps) {
                 !!paramDependenciesUpdating[parameter.name]
               }
             />
-            {parameter.visibleHelp !== undefined && (
-              <Banner
-                banner={{
-                  // 'normal' renders a banner w/ gray background
-                  type: 'normal',
-                  message: safeHtml(parameter.visibleHelp, null, 'div'),
-                  hideIcon: true,
-                }}
-              />
-            )}
-            <div className={cx('ParameterControl')}>
-              {parameterElements[parameter.name]}
+            <div
+              className={cx(
+                'ParameterControlContainer' +
+                  (parameter.visibleHelp
+                    ? parameter.visibleHelpPosition &&
+                      parameter.visibleHelpPosition === 'right'
+                      ? '_VisibleHelpRight'
+                      : ''
+                    : '')
+              )}
+            >
+              {parameter.visibleHelp !== undefined && (
+                <div
+                  className={
+                    parameter.visibleHelpPosition &&
+                    parameter.visibleHelpPosition === 'right'
+                      ? cx('VisibleHelpContainer_Right')
+                      : ''
+                  }
+                >
+                  <Banner
+                    banner={{
+                      // 'normal' renders a banner w/ gray background
+                      type: 'normal',
+                      message: safeHtml(parameter.visibleHelp, null, 'div'),
+                      hideIcon: true,
+                      spacing:
+                        parameter.visibleHelpPosition &&
+                        parameter.visibleHelpPosition === 'right'
+                          ? { margin: '10px' }
+                          : { margin: '10px 0' },
+                    }}
+                  />
+                </div>
+              )}
+              <div
+                className={
+                  cx('ParameterControl') +
+                  (parameter.visibleHelp
+                    ? parameter.visibleHelpPosition &&
+                      parameter.visibleHelpPosition === 'right'
+                      ? ' ControlLeft'
+                      : ''
+                    : '')
+                }
+              >
+                {parameterElements[parameter.name]}
+              </div>
             </div>
           </React.Fragment>
         ))}

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
@@ -465,6 +465,7 @@ export function ParameterList(props: ParameterListProps) {
                         parameter.visibleHelpPosition === 'right'
                           ? { margin: '10px' }
                           : { margin: '10px 0' },
+                      width: 'auto',
                     }}
                   />
                 </div>


### PR DESCRIPTION
Depends on the second commit in https://github.com/VEuPathDB/WDK/pull/86 that adds `visibleHelpPosition` as an optional attribute to params.

A `visibleHelpPosition: 'right'` would display as shown:
![image](https://github.com/VEuPathDB/web-monorepo/assets/69446567/3160125b-d0d9-4887-8ab5-b8ad66184ba4)
