### PR TITLE
Pass noop dismissSubmenus callback to sub-submenus

### DIFF
--- a/packages/libs/web-common/src/components/homepage/Header.tsx
+++ b/packages/libs/web-common/src/components/homepage/Header.tsx
@@ -374,7 +374,7 @@ const HeaderMenuItemContent = ({
               focusType={focusType}
               setSelectedItems={setSelectedItems}
               setFocusType={setFocusType}
-              dismissSubmenus={dismissSubmenus}
+              dismissSubmenus={() => null}
             />
           </DeferredDiv>
         </div>


### PR DESCRIPTION
Resolves issue where submenus are disappearing unless a click event occurs.

From slack:
- https://epvb.slack.com/archives/C01DS6HBY3Z/p1713193639600269
- https://epvb.slack.com/archives/GBDR4LDNC/p1712673496607519

NOTE: this issue is occurring on live sites