### PR TITLE
Use real links

### DIFF
--- a/packages/libs/components/src/plots/BipartiteNetwork.tsx
+++ b/packages/libs/components/src/plots/BipartiteNetwork.tsx
@@ -20,7 +20,6 @@ import { ToImgopts } from 'plotly.js';
 import { gray } from '@veupathdb/coreui/lib/definitions/colors';
 import { ExportPlotToImageButton } from './ExportPlotToImageButton';
 import { plotToImage } from './visxVEuPathDB';
-import { Menu } from '@veupathdb/coreui/lib/components/inputs/Menu';
 import { GlyphTriangle } from '@visx/visx';
 
 import './BipartiteNetwork.css';
@@ -267,20 +266,35 @@ function BipartiteNetwork(
               background: 'white',
             }}
           >
-            <Menu
-              items={activeNode.actions.map((nodeAction) => ({
-                display: nodeAction.label,
-                value: nodeAction,
-              }))}
-              onSelect={(action) => {
-                if (action.href) {
-                  window.location.assign(action.href);
-                } else if (action.onClick) {
-                  action.onClick();
-                }
-                setActiveNodeId(undefined);
-              }}
-            />
+            {activeNode.actions.map((action) => (
+              <div>
+                {action.href ? (
+                  <a
+                    style={{
+                      display: 'inline-block',
+                      lineHeight: '1.25em',
+                      padding: '0.5em 1em',
+                    }}
+                    href={action.href}
+                  >
+                    {action.label}
+                  </a>
+                ) : (
+                  <button
+                    style={{
+                      display: 'inline-block',
+                      lineHeight: '1.25em',
+                      padding: '0.5em 1em',
+                    }}
+                    onClick={action.onClick}
+                    type="button"
+                    className="link"
+                  >
+                    {action.label}
+                  </button>
+                )}
+              </div>
+            ))}
           </div>
         )}
         <div


### PR DESCRIPTION
Using real links allows users to open the link in a new tab with ctrl-click or right-click, etc.

closes #1007