### PR TITLE
Markers automatically use the most appropriate geoEntity when there are multiple to choose from

### DIFF
--- a/packages/libs/eda/src/lib/core/utils/geoVariables.ts
+++ b/packages/libs/eda/src/lib/core/utils/geoVariables.ts
@@ -1,5 +1,6 @@
 import { GeoConfig } from '../types/geoConfig';
 import { StudyEntity } from '../types/study';
+import { findLast } from 'lodash';
 
 /**
  * Given an entity note in the study tree, check to see if it has the following variables
@@ -44,4 +45,46 @@ export function entityToGeoConfig(
     }
   }
   return undefined;
+}
+
+/**
+ * Given the geoConfigs (one per entity with geo variables) and an entity ID,
+ * return the geoConfig/entity that is furthest from the root that is the parent of the provided entity ID.
+ *
+ * Assumes `geoConfigs` is in root to leaf order.
+ */
+export function findLeastAncestralGeoConfig(
+  geoConfigs: GeoConfig[],
+  entityId: string
+): GeoConfig {
+  return (
+    findLast(geoConfigs, ({ entity }) =>
+      entityHasChildEntityWithId(entity, entityId)
+    ) ?? geoConfigs[0]
+  );
+}
+
+// Check if the specified entity or any of its descendants has the given entityId.
+function entityHasChildEntityWithId(
+  entity: StudyEntity,
+  entityId: string
+): boolean {
+  return (
+    entity.id === entityId ||
+    (entity.children?.some((child) =>
+      entityHasChildEntityWithId(child, entityId)
+    ) ??
+      false)
+  );
+}
+
+// simple convenience function
+// defaults to root-most geoConfig for safety.
+export function getGeoConfig(
+  geoConfigs: GeoConfig[],
+  entityId?: string
+): GeoConfig {
+  return (
+    geoConfigs.find(({ entity: { id } }) => id === entityId) ?? geoConfigs[0]
+  );
 }

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -80,6 +80,7 @@ import { Page } from '@veupathdb/wdk-client/lib/Components';
 import { AnalysisError } from '../../core/components/AnalysisError';
 import useSnackbar from '@veupathdb/coreui/lib/components/notifications/useSnackbar';
 import SettingsButton from '@veupathdb/coreui/lib/components/containers/DraggablePanel/SettingsButton';
+import { getGeoConfig } from './mapTypes/shared';
 
 enum MapSideNavItemLabels {
   Download = 'Download',
@@ -231,7 +232,6 @@ function MapAnalysisImpl(props: ImplProps) {
   const dataClient = useDataClient();
   const downloadClient = useDownloadClient();
   const subsettingClient = useSubsettingClient();
-  const geoConfig = geoConfigs[0];
   const history = useHistory();
 
   // FIXME use the sharingUrl prop to construct this
@@ -244,6 +244,11 @@ function MapAnalysisImpl(props: ImplProps) {
 
   const activeMarkerConfiguration = markerConfigurations.find(
     (markerConfig) => markerConfig.type === activeMarkerConfigurationType
+  );
+
+  const geoConfig = getGeoConfig(
+    geoConfigs,
+    activeMarkerConfiguration?.geoEntityId
   );
 
   const updateMarkerConfigurations = useCallback(

--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -80,7 +80,7 @@ import { Page } from '@veupathdb/wdk-client/lib/Components';
 import { AnalysisError } from '../../core/components/AnalysisError';
 import useSnackbar from '@veupathdb/coreui/lib/components/notifications/useSnackbar';
 import SettingsButton from '@veupathdb/coreui/lib/components/containers/DraggablePanel/SettingsButton';
-import { getGeoConfig } from './mapTypes/shared';
+import { getGeoConfig } from '../../core/utils/geoVariables';
 
 enum MapSideNavItemLabels {
   Download = 'Download',

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
@@ -27,6 +27,8 @@ import {
 } from '../appState';
 import { gray } from '@veupathdb/coreui/lib/definitions/colors';
 import { SharedMarkerConfigurations } from '../mapTypes/shared';
+import { GeoConfig } from '../../../core/types/geoConfig';
+import { findLeastAncestralGeoConfig } from '../../../core/utils/geoVariables';
 
 interface MarkerConfiguration<T extends string> {
   type: T;
@@ -65,6 +67,7 @@ interface Props
    * Only defined and used in categorical table if selectedCountsOption is 'visible'
    */
   allVisibleCategoricalValues: AllValuesDefinition[] | undefined;
+  geoConfigs: GeoConfig[];
 }
 
 // TODO: generalize this and PieMarkerConfigMenu into MarkerConfigurationMenu. Lots of code repetition...
@@ -84,6 +87,7 @@ export function BarPlotMarkerConfigurationMenu({
   continuousMarkerPreview,
   allFilteredCategoricalValues,
   allVisibleCategoricalValues,
+  geoConfigs,
 }: Props) {
   /**
    * Used to track the CategoricalMarkerConfigurationTable's selection state, which allows users to
@@ -154,12 +158,19 @@ export function BarPlotMarkerConfigurationMenu({
       return;
     }
 
+    const geoConfig = findLeastAncestralGeoConfig(
+      geoConfigs,
+      selection.overlayVariable.entityId
+    );
+
     onChange({
       ...configuration,
       selectedVariable: selection.overlayVariable,
       selectedValues: undefined,
+      geoEntityId: geoConfig.entity.id,
     });
   }
+
   function handlePlotModeSelection(option: string) {
     onChange({
       ...configuration,

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BubbleMarkerConfigurationMenu.tsx
@@ -16,6 +16,8 @@ import { DataElementConstraint } from '../../../core/types/visualization'; // TO
 import { SharedMarkerConfigurations } from '../mapTypes/shared';
 import { invalidProportionText } from '../utils/defaultOverlayConfig';
 import { BubbleLegendPositionConfig, PanelConfig } from '../appState';
+import { GeoConfig } from '../../../core/types/geoConfig';
+import { findLeastAncestralGeoConfig } from '../../../core/utils/geoVariables';
 
 type AggregatorOption = typeof aggregatorOptions[number];
 const aggregatorOptions = ['mean', 'median'] as const;
@@ -47,6 +49,7 @@ interface Props
   configuration: BubbleMarkerConfiguration;
   overlayConfiguration: BubbleOverlayConfig | undefined;
   isValidProportion: boolean | undefined; // undefined when not categorical mode
+  geoConfigs: GeoConfig[];
 }
 
 export function BubbleMarkerConfigurationMenu({
@@ -58,6 +61,7 @@ export function BubbleMarkerConfigurationMenu({
   toggleStarredVariable,
   constraints,
   isValidProportion,
+  geoConfigs,
 }: Props) {
   function handleInputVariablesOnChange(selection: VariablesByInputName) {
     if (!selection.overlayVariable) {
@@ -67,11 +71,17 @@ export function BubbleMarkerConfigurationMenu({
       return;
     }
 
+    const geoConfig = findLeastAncestralGeoConfig(
+      geoConfigs,
+      selection.overlayVariable.entityId
+    );
+
     onChange({
       ...configuration,
       selectedVariable: selection.overlayVariable,
       numeratorValues: undefined,
       denominatorValues: undefined,
+      geoEntityId: geoConfig.entity.id,
     });
   }
 

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
@@ -24,11 +24,9 @@ import {
   SelectedCountsOption,
   SelectedValues,
 } from '../appState';
-import {
-  SharedMarkerConfigurations,
-  findLeastAncestralGeoConfig,
-} from '../mapTypes/shared';
+import { SharedMarkerConfigurations } from '../mapTypes/shared';
 import { GeoConfig } from '../../../core/types/geoConfig';
+import { findLeastAncestralGeoConfig } from '../../../core/utils/geoVariables';
 
 interface MarkerConfiguration<T extends string> {
   type: T;

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
@@ -24,7 +24,11 @@ import {
   SelectedCountsOption,
   SelectedValues,
 } from '../appState';
-import { SharedMarkerConfigurations } from '../mapTypes/shared';
+import {
+  SharedMarkerConfigurations,
+  findLeastAncestralGeoConfig,
+} from '../mapTypes/shared';
+import { GeoConfig } from '../../../core/types/geoConfig';
 
 interface MarkerConfiguration<T extends string> {
   type: T;
@@ -61,6 +65,7 @@ interface Props
    * Only defined and used in categorical table if selectedCountsOption is 'visible'
    */
   allVisibleCategoricalValues: AllValuesDefinition[] | undefined;
+  geoConfigs: GeoConfig[];
 }
 
 // TODO: generalize this and BarPlotMarkerConfigMenu into MarkerConfigurationMenu. Lots of code repetition...
@@ -80,6 +85,7 @@ export function PieMarkerConfigurationMenu({
   continuousMarkerPreview,
   allFilteredCategoricalValues,
   allVisibleCategoricalValues,
+  geoConfigs,
 }: Props) {
   /**
    * Used to track the CategoricalMarkerConfigurationTable's selection state, which allows users to
@@ -149,12 +155,23 @@ export function PieMarkerConfigurationMenu({
       return;
     }
 
+    // With each variable change we set the geo entity for the user to the least ancestral
+    // entity on the path from root to the chosen variable.
+    // However, we could make this choosable via the UI in the future.
+    // (That's one reason why we're storing it in appState.)
+    const geoConfig = findLeastAncestralGeoConfig(
+      geoConfigs,
+      selection.overlayVariable.entityId
+    );
+
     onChange({
       ...configuration,
       selectedVariable: selection.overlayVariable,
       selectedValues: undefined,
+      geoEntityId: geoConfig.entity.id,
     });
   }
+
   function handleBinningMethodSelection(option: string) {
     onChange({
       ...configuration,

--- a/packages/libs/eda/src/lib/map/analysis/appState.ts
+++ b/packages/libs/eda/src/lib/map/analysis/appState.ts
@@ -99,6 +99,7 @@ export const MarkerConfiguration = t.intersection([
   }),
   t.partial({
     activeVisualizationId: t.string,
+    geoEntityId: t.string,
   }),
   t.union([
     t.intersection([

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -260,6 +260,7 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
         analysisState.analysis?.descriptor.starredVariables ?? []
       }
       toggleStarredVariable={toggleStarredVariable}
+      geoConfigs={geoConfigs}
     />
   );
 

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BubbleMarkerMapType.tsx
@@ -145,6 +145,7 @@ function BubbleMapConfigurationPanel(props: MapTypeConfigPanelProps) {
       toggleStarredVariable={toggleStarredVariable}
       constraints={markerVariableConstraints}
       isValidProportion={isValidProportion}
+      geoConfigs={geoConfigs}
     />
   );
 

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -221,6 +221,7 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
         analysisState.analysis?.descriptor.starredVariables ?? []
       }
       toggleStarredVariable={toggleStarredVariable}
+      geoConfigs={geoConfigs}
     />
   );
 

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -44,7 +44,10 @@ import {
   PanelConfig,
   PanelPositionConfig,
 } from '../appState';
-import { findLast } from 'lodash';
+import {
+  findLeastAncestralGeoConfig,
+  getGeoConfig,
+} from '../../../core/utils/geoVariables';
 
 export const defaultAnimation = {
   method: 'geohash',
@@ -791,48 +794,4 @@ export function getLegendErrorMessage(error: unknown) {
  */
 export function EntitySubtitleForViz({ subtitle }: { subtitle: string }) {
   return <div style={{ marginTop: 8, fontStyle: 'italic' }}>({subtitle})</div>;
-}
-
-// multiple geoEntity functions
-
-/**
- * Given the geoConfigs (one per entity with geo variables) and an entity ID,
- * return the entity that is furthest from the root that is the parent of the provided entity ID.
- *
- * Assumes `geoConfigs` is in root to leaf order.
- */
-export function findLeastAncestralGeoConfig(
-  geoConfigs: GeoConfig[],
-  entityId: string
-): GeoConfig {
-  return (
-    findLast(geoConfigs, ({ entity }) =>
-      entityHasChildEntityWithId(entity, entityId)
-    ) ?? geoConfigs[0]
-  );
-}
-
-// Check if the specified entity or any of its descendants has the given entityId.
-function entityHasChildEntityWithId(
-  entity: StudyEntity,
-  entityId: string
-): boolean {
-  return (
-    entity.id === entityId ||
-    (entity.children?.some((child) =>
-      entityHasChildEntityWithId(child, entityId)
-    ) ??
-      false)
-  );
-}
-
-// simple convenience function
-// defaults to root-most geoConfig for safety.
-export function getGeoConfig(
-  geoConfigs: GeoConfig[],
-  entityId?: string
-): GeoConfig {
-  return (
-    geoConfigs.find(({ entity: { id } }) => id === entityId) ?? geoConfigs[0]
-  );
 }


### PR DESCRIPTION
Fixes #1024 

This only affects the Transmission Zero Field Trials prototype dataset at the moment (qa restricted clinepi) because this is the only study where more than one entity has geo variables.

Luckily a lot of the code was already passing around `geoConfigs` rather than `geoConfigs[0]` so there wasn't a huge amount of upheaval.

I have implemented this as if there was a drop-down for the user to choose the geoEntity they wanted, but instead have chosen the least ancestral entity for them automatically. So this is why this "choice" is stored in appState. We can add UI later if needed.

- [x] Donut mode
- [x] Bar mode
- [x] Bubble mode