### PR TITLE
Temporarily spoof the dataElementDependencyOrder for histogram

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MapAnalysis.tsx
@@ -286,7 +286,23 @@ function MapAnalysisImpl(props: ImplProps) {
   const appsPromiseState = usePromise(
     useCallback(async () => {
       const { apps } = await dataClient.getApps();
-      return apps; // return all apps; new viz picker will only show those with client plugins defined
+      return apps.map((app) =>
+        app.name === 'standalone-map-distributions'
+          ? {
+              ...app,
+              visualizations: app.visualizations.map((viz) =>
+                viz.name === 'histogram'
+                  ? {
+                      ...viz,
+                      dataElementDependencyOrder: [
+                        ['xAxisVariable', 'overlayVariable'],
+                      ],
+                    }
+                  : viz
+              ),
+            }
+          : app
+      ); // return all apps; new viz picker will only show those with client plugins defined
     }, [dataClient])
   );
 


### PR DESCRIPTION
This just a test - up for discussion and maybe to help with a demo this+next week.

I've changed the `dataElementDependencyOrder` from
```
{
	"dataElementDependencyOrder": [
		[
			"xAxisVariable"
		],
		[
			"overlayVariable"
		]
	]
}
```
to
```
{
	"dataElementDependencyOrder": [
		[
			"xAxisVariable",
			"overlayVariable"
		]
	]
}
```

So that we can stratify a time-based histogram by species (see below in the Transmission Zero Field Trials prototype). When switching between stratify and no-stratify, the output entity (see the plot title) changes appropriately. So far I can't see any downsides...

![image](https://github.com/VEuPathDB/web-monorepo/assets/308639/8507e9ee-f81b-4a07-b206-188bccc44205)
