### PR TITLE
Add member type to legends, subtitles, and collection logic

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/Utils.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Utils.ts
@@ -94,7 +94,9 @@ export function isTaxonomicVariableCollection(
 ): boolean {
   return (
     isNotAbsoluteAbundanceVariableCollection(variableCollection) &&
-    variableCollection.normalizationMethod === 'sumToUnity'
+    (variableCollection.member
+      ? variableCollection.member === 'taxon'
+      : variableCollection.normalizationMethod === 'sumToUnity') // if we have a member annotation, use that. Old datasets may not have this annotation, hence the fall back normalizationMethod check.
   );
 }
 
@@ -107,7 +109,11 @@ export function isTaxonomicVariableCollection(
 export function isFunctionalCollection(
   variableCollection: CollectionVariableTreeNode
 ): boolean {
-  return variableCollection.normalizationMethod === 'RPK'; // reads per kilobase
+  // Use the member annotation if available. Otherwise, use the fallback normalizationMethod annotation.
+  return variableCollection.member
+    ? variableCollection.member === 'pathway' ||
+        variableCollection.member === 'gene'
+    : variableCollection.normalizationMethod === 'RPK'; // reads per kilobase
 }
 
 /**

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -56,7 +56,6 @@ export const plugin: ComputationPlugin = {
         if (AbundanceConfig.is(config) && config.rankingMethod) {
           return (
             <>
-              <br />
               <span>
                 Ranked abundance: X-axis variables with {config.rankingMethod} =
                 0 removed. Showing up to the top ten variables.

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -55,12 +55,10 @@ export const plugin: ComputationPlugin = {
       getPlotSubtitle(config) {
         if (AbundanceConfig.is(config) && config.rankingMethod) {
           return (
-            <>
-              <span>
-                Ranked abundance: X-axis variables with {config.rankingMethod} =
-                0 removed. Showing up to the top ten variables.
-              </span>
-            </>
+            <span>
+              Ranked abundance: X-axis variables with {config.rankingMethod} = 0
+              removed. Showing up to the top ten variables.
+            </span>
           );
         }
       },
@@ -83,13 +81,10 @@ export const plugin: ComputationPlugin = {
       getPlotSubtitle(config) {
         if (AbundanceConfig.is(config)) {
           return (
-            <>
-              <br />
-              <span>
-                Ranked abundance: Overlay variables with {config.rankingMethod}{' '}
-                = 0 removed. Showing up to the top eight variables.
-              </span>
-            </>
+            <span>
+              Ranked abundance: Overlay variables with {config.rankingMethod} =
+              0 removed. Showing up to the top eight variables.
+            </span>
           );
         }
       },

--- a/packages/libs/eda/src/lib/core/components/visualizations/OutputEntityTitle.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/OutputEntityTitle.tsx
@@ -6,26 +6,40 @@ import { makeEntityDisplayName } from '../../utils/study-metadata';
 import { ReactNode } from 'react';
 
 interface Props {
+  /** StudyEntity. Will use the display name of the entity for the title */
   entity?: StudyEntity;
+  /** If present, use in the title in place of the entity display name */
+  entityDisplayNameOverride?: string;
+  /** Value to be used in the title. Usually the number of points in the plot */
   outputSize?: number;
+  /** Optional subtitle to show below the title */
   subtitle?: ReactNode;
 }
 
 const cx = makeClassNameHelper('OutputEntityTitle');
 const cxSubtitle = makeClassNameHelper('OutputEntitySubtitle');
 
-export function OutputEntityTitle({ entity, outputSize, subtitle }: Props) {
+export function OutputEntityTitle({
+  entity,
+  entityDisplayNameOverride,
+  outputSize,
+  subtitle,
+}: Props) {
   return (
     <p className={cx()}>
       {outputSize != null && <>{outputSize.toLocaleString()} </>}
-      <span className={cx('-EntityName', entity == null && 'unselected')}>
-        {entity != null
-          ? makeEntityDisplayName(
-              entity,
-              outputSize == null || outputSize !== 1
-            )
-          : 'No entity selected'}
-      </span>
+      {entityDisplayNameOverride != null ? (
+        <span className={cx('-EntityName')}> {entityDisplayNameOverride} </span>
+      ) : (
+        <span className={cx('-EntityName', entity == null && 'unselected')}>
+          {entity != null
+            ? makeEntityDisplayName(
+                entity,
+                outputSize == null || outputSize !== 1
+              )
+            : 'No entity selected'}
+        </span>
+      )}
       {subtitle && (
         <div className={cxSubtitle()} style={{ color: gray[700] }}>
           {subtitle}

--- a/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
+++ b/packages/libs/eda/src/lib/core/components/visualizations/Visualizations.scss
@@ -439,7 +439,7 @@ $data-table-thick-border: 2px solid #262626;
 .OutputEntitySubtitle {
   font-style: italic;
   font-size: 0.9em;
-  margin-top: -10px;
+  margin-top: 0.4em;
 }
 
 // R-square table for Scatter plot's Best fit option

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -14,6 +14,7 @@ import { usePromise } from '../../../hooks/promise';
 import { useUpdateThumbnailEffect } from '../../../hooks/thumbnails';
 import {
   useDataClient,
+  useFindEntityAndVariableCollection,
   useStudyEntities,
   useStudyMetadata,
 } from '../../../hooks/workspace';
@@ -46,7 +47,7 @@ import { yellow } from '@material-ui/core/colors';
 import PlotLegend from '@veupathdb/components/lib/components/plotControls/PlotLegend';
 import { significanceColors } from '@veupathdb/components/lib/types/plots';
 import { NumberOrDateRange, NumberRange } from '../../../types/general';
-import { max, min } from 'lodash';
+import { capitalize, max, min } from 'lodash';
 
 // plot controls
 import SliderWidget, {
@@ -697,10 +698,16 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
     </div>
   );
 
+  // If available, grab the annotated display name to describe the points
+  const findEntityAndVariableCollection = useFindEntityAndVariableCollection();
+  const pointsDisplayName = findEntityAndVariableCollection(
+    computationConfiguration.collectionVariable
+  )?.variableCollection.memberPlural;
+
   const legendNode = finalData && countsData && (
     <PlotLegend
       type="list"
-      legendTitle="Legend"
+      legendTitle={capitalize(pointsDisplayName) ?? 'Legend'}
       legendItems={[
         {
           label: `Inconclusive (${

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -700,14 +700,15 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
 
   // If available, grab the annotated display name to describe the points
   const findEntityAndVariableCollection = useFindEntityAndVariableCollection();
-  const pointsDisplayName = findEntityAndVariableCollection(
-    computationConfiguration.collectionVariable
-  )?.variableCollection.memberPlural;
+  const pointsDisplayName = capitalize(
+    findEntityAndVariableCollection(computationConfiguration.collectionVariable)
+      ?.variableCollection.memberPlural
+  );
 
   const legendNode = finalData && countsData && (
     <PlotLegend
       type="list"
-      legendTitle={capitalize(pointsDisplayName) ?? 'Legend'}
+      legendTitle={pointsDisplayName ?? 'Legend'}
       legendItems={[
         {
           label: `Inconclusive (${
@@ -775,7 +776,13 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
         outputSize={finalData?.statistics.length}
       />
 
-      {!hideInputsAndControls && <OutputEntityTitle subtitle={plotSubtitle} />}
+      {!hideInputsAndControls && (
+        <OutputEntityTitle
+          subtitle={plotSubtitle}
+          entityDisplayNameOverride={pointsDisplayName}
+          outputSize={finalData?.statistics.length}
+        />
+      )}
       <LayoutComponent
         isFaceted={false}
         legendNode={legendNode}

--- a/packages/libs/eda/src/lib/core/types/study.ts
+++ b/packages/libs/eda/src/lib/core/types/study.ts
@@ -230,6 +230,8 @@ export const CollectionVariableTreeNode = t.intersection([
     isProportion: t.boolean,
     normalizationMethod: t.string,
     distributionDefaults: NumberDistributionDefaults,
+    member: t.string,
+    memberPlural: t.string,
   }),
 ]);
 


### PR DESCRIPTION
Resolves #382 and #898 and [comment](https://github.com/VEuPathDB/web-monorepo/issues/393#issuecomment-1658447748) 

First we added `member` and `memberPlural` as annotations for `CollectionVariableTreeNode`. Then we used those annotations to clarify collection filters, and add better info to the volcano visualization. One side effect was that to better position the subtitle for the `OutputEntityTitle`, I moved the `<br>` inside the component and modified the css.

<img width="1030" alt="Screen Shot 2024-04-19 at 11 55 02 AM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/7f3f6881-acaf-40ef-801f-040ee9657351">