### PR TITLE
Revert "Only show Management Dashboard button for user datasets"

### DIFF
--- a/packages/libs/eda/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/packages/libs/eda/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -77,8 +77,7 @@ export function EDAWorkspaceHeading({
           </H3>
         )}
         <div>
-          {studyMetadata.isUserStudy &&
-            !permissionsValue.loading &&
+          {!permissionsValue.loading &&
             shouldOfferLinkToDashboard(
               permissionsValue.permissions,
               studyRecord.id[0].value


### PR DESCRIPTION
Reverts VEuPathDB/web-monorepo#1003

This logic is not correct. If anything, we only want to show the button if a study has any access restrictions.