### PR TITLE
add timelinehisto viz icon

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/selectorIcons/HistogramTimelineSVG.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/selectorIcons/HistogramTimelineSVG.tsx
@@ -1,0 +1,75 @@
+import { MonotoneSvgProps } from './types';
+
+export default function HistogramTimelineSVG({
+  primaryColor,
+}: MonotoneSvgProps) {
+  return (
+    // <!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+    <svg
+      version="1.1"
+      id="Layer_1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      x="0px"
+      y="0px"
+      viewBox="0 0 500 500"
+      xmlSpace="preserve"
+    >
+      <style type="text/css">
+        {/* <!-- svg classes --> */}
+        .bar&#123;fill-rule:evenodd;clip-rule:evenodd;&#125;
+        .arrow&#123;stroke-width:0px;&#125;
+      </style>
+      <g style={{ fill: primaryColor }}>
+        <polygon
+          className="arrow"
+          points="113.4 423 367.1 419 367.1 427.1 113.4 423"
+        />
+        <polygon
+          className="arrow"
+          points="362.7 390.2 362.7 455.8 395.5 423 362.7 390.2"
+        />
+        <polygon
+          id="uuid-92570449-7d3d-49f8-a1d6-3bc4535d4be0"
+          className="bar"
+          points="50 363 50 345.1 94 345.1 94 363 50 363"
+        />
+        <polygon
+          id="uuid-11bfcbee-6a7c-490a-87af-60438b8a6444"
+          className="bar"
+          points="100.9 363 100.9 327.2 144.9 327.2 144.9 363 100.9 363"
+        />
+        <polygon
+          id="uuid-7b9a14c4-5027-40af-988e-d1ff5406ef05"
+          className="bar"
+          points="151.7 363 151.7 288.2 195.7 288.2 195.7 363 151.7 363"
+        />
+        <polygon
+          id="uuid-eab4d69a-006e-48b4-8211-da2b5163e585"
+          className="bar"
+          points="202.6 363 202.6 222.7 246.6 222.7 246.6 363 202.6 363"
+        />
+        <polygon
+          id="uuid-0db6f034-af2e-4475-831c-56289205bedc"
+          className="bar"
+          points="253.4 363 253.4 134.5 297.4 134.5 297.4 363 253.4 363"
+        />
+        <polygon
+          id="uuid-39c4269a-20dd-42d4-a3a7-dfea7c8d7428"
+          className="bar"
+          points="304.3 363 304.3 52.7 348.3 52.7 348.3 363 304.3 363"
+        />
+        <polygon
+          id="uuid-73e385b0-7fc5-477a-a165-f655caa7551a"
+          className="bar"
+          points="355.1 363 355.1 195.3 399.1 195.3 399.1 363 355.1 363"
+        />
+        <polygon
+          id="uuid-6459c3bb-aeef-4b63-bc33-18bfee092dc5"
+          className="bar"
+          points="406 363 406 242.5 450 242.5 450 363 406 363"
+        />
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
Resolves #1025 

New viz icon added! Here's an example of how it will look next to all the other icons:

<img width="610" alt="Screen Shot 2024-04-22 at 7 37 15 AM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/80c2b8c0-de16-4819-9907-266fb8dcd301">
