### PR TITLE
Eda genomics map menu items

### DIFF
--- a/packages/libs/eda/src/lib/core/utils/study-records.ts
+++ b/packages/libs/eda/src/lib/core/utils/study-records.ts
@@ -18,6 +18,7 @@ interface WdkStudyRecordsOptions {
   attributes?: AnswerJsonFormatConfig['attributes'];
   tables?: AnswerJsonFormatConfig['tables'];
   searchName?: string;
+  hasMap?: boolean;
 }
 
 const DEFAULT_STUDY_ATTRIBUTES = ['dataset_id'];
@@ -64,7 +65,10 @@ export async function getWdkStudyRecords(
       }
     ),
   ]);
-  const studyIds = new Set(edaStudies.map((s) => s.id));
+  const filteredStudies = options?.hasMap
+    ? edaStudies.filter((study) => study.hasMap)
+    : edaStudies;
+  const studyIds = new Set(filteredStudies.map((s) => s.id));
   return answer.records.filter((record) => {
     const datasetId = getStudyId(record);
     if (datasetId == null) {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -49,6 +49,7 @@ import {
 import {
   useUserDatasetsWorkspace,
   edaServiceUrl,
+  showUnreleasedData,
 } from '@veupathdb/web-common/lib/config';
 import { useAnnouncementsState } from '@veupathdb/web-common/lib/hooks/announcements';
 import { useCommunitySiteRootUrl } from '@veupathdb/web-common/lib/hooks/staticData';
@@ -1192,17 +1193,26 @@ function useMapMenuItems(question?: Question) {
     if (question == null || studyAccessApi == null) return;
     getWdkStudyRecords(
       { studyAccessApi, subsettingClient, wdkService },
-      { searchName: question.urlSegment }
+      {
+        searchName: question.urlSegment,
+        attributes: ['is_public'],
+        hasMap: true,
+      }
     ).then(
       (records) => {
-        const menuItems = records.map(
-          (record): HeaderMenuItemEntry => ({
-            key: `map-${record.id[0].value}`,
-            display: record.displayName,
-            type: 'reactRoute',
-            url: `/workspace/maps/${record.id[0].value}/new`,
-          })
-        );
+        const menuItems = records
+          .filter(
+            (record) =>
+              record.attributes.is_public === 'true' || showUnreleasedData
+          )
+          .map(
+            (record): HeaderMenuItemEntry => ({
+              key: `map-${record.id[0].value}`,
+              display: record.displayName,
+              type: 'reactRoute',
+              url: `/workspace/maps/${record.id[0].value}/new`,
+            })
+          );
         setMapMenuItems(menuItems);
       },
       (error) => {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -1196,7 +1196,7 @@ function useMapMenuItems(question?: Question) {
       {
         searchName: question.urlSegment,
         attributes: ['is_public'],
-        hasMap: true,
+        // hasMap: true,
       }
     ).then(
       (records) => {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -64,13 +64,15 @@ import { Props as PageProps } from '@veupathdb/wdk-client/lib/Components/Layout/
 import { PageDescription } from './PageDescription';
 import { makeVpdbClassNameHelper } from './Utils';
 
-import './VEuPathDBHomePage.scss';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import SubsettingClient from '@veupathdb/eda/lib/core/api/SubsettingClient';
 import { WdkDependenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
 import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
 import { Question } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
-import { Warning } from '@veupathdb/coreui';
+import { Tooltip, Warning } from '@veupathdb/coreui';
+import { Build } from '@material-ui/icons';
+
+import './VEuPathDBHomePage.scss';
 
 const vpdbCx = makeVpdbClassNameHelper('');
 
@@ -1208,7 +1210,16 @@ function useMapMenuItems(question?: Question) {
           .map(
             (record): HeaderMenuItemEntry => ({
               key: `map-${record.id[0].value}`,
-              display: record.displayName,
+              display:
+                record.attributes.is_public === 'true' ? (
+                  record.displayName
+                ) : (
+                  <Tooltip title="This dataset is under development and will not appear on live sites.">
+                    <div style={{ display: 'inline' }}>
+                      {record.displayName} <Build fontSize="small" />
+                    </div>
+                  </Tooltip>
+                ),
               type: 'reactRoute',
               url: `/workspace/maps/${record.id[0].value}/new`,
             })

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -70,7 +70,6 @@ import { WdkDependenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDepen
 import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
 import { Question } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { Tooltip, Warning } from '@veupathdb/coreui';
-import { Build } from '@material-ui/icons';
 
 import './VEuPathDBHomePage.scss';
 
@@ -1216,7 +1215,7 @@ function useMapMenuItems(question?: Question) {
                 ) : (
                   <Tooltip title="This dataset is under development and will not appear on live sites.">
                     <div style={{ display: 'inline' }}>
-                      {record.displayName} <Build fontSize="small" />
+                      &#128679; {record.displayName}
                     </div>
                   </Tooltip>
                 ),
@@ -1224,7 +1223,15 @@ function useMapMenuItems(question?: Question) {
               url: `/workspace/maps/${record.id[0].value}/new`,
             })
           );
-        setMapMenuItems(menuItems);
+        if (menuItems.length > 0) setMapMenuItems(menuItems);
+        else
+          setMapMenuItems([
+            {
+              key: 'map-empty',
+              type: 'custom',
+              display: 'No map datasets found',
+            },
+          ]);
       },
       (error) => {
         console.error(error);

--- a/packages/sites/genomics-site/webpack.config.local.mjs
+++ b/packages/sites/genomics-site/webpack.config.local.mjs
@@ -52,6 +52,7 @@ export default configure({
         edaServiceUrl: process.env.EDA_SERVICE_ENDPOINT,
         edaSingleAppMode: process.env.EDA_SINGLE_APP_MODE,
         vdiServiceUrl: process.env.VDI_SERVICE_ENDPOINT,
+        showUnreleasedData: process.env.SHOW_UNRELEASED_DATA === 'true',
 })
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Hides datasets with `is_public=false` from mapveu menu

Depends on https://github.com/VEuPathDB/EbrcModelCommon/pull/47

Those w/ `is_public=false` will have an icon on sites with `showUnreleasedData=true`:

![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/ad9db90b-9e61-490d-9372-08faab3b789a)
