### PR TITLE
Open help menu details by default, remove new images

### DIFF
--- a/packages/libs/web-common/src/components/homepage/Header.tsx
+++ b/packages/libs/web-common/src/components/homepage/Header.tsx
@@ -91,6 +91,7 @@ interface ExternalLinkMenuItem<T> extends HeaderMenuItemBase<T> {
 interface SubmenuItem<T> extends HeaderMenuItemBase<T> {
   type: 'subMenu';
   items: HeaderMenuItem<T>[];
+  openByDefault?: boolean;
 }
 
 interface CustomMenuItem<T> extends HeaderMenuItemBase<T> {
@@ -379,7 +380,7 @@ const HeaderMenuItemContent = ({
           </DeferredDiv>
         </div>
       ) : item.type === 'subMenu' ? (
-        <details>
+        <details open={!!item.openByDefault}>
           <summary>
             <span>{item.display}</span>
           </summary>

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -535,7 +535,6 @@ const useHeaderMenuItems = (
               display: (
                 <>
                   MapVEu &mdash; Interactive maps{' '}
-                  <img alt="NEW" src={newImage} />{' '}
                   <Loading
                     style={{
                       display: 'inline-block',
@@ -551,22 +550,12 @@ const useHeaderMenuItems = (
           : mapMenuItems.length === 1
           ? {
               ...mapMenuItems[0],
-              display: (
-                <>
-                  MapVEu &mdash; {mapMenuItems[0].display}{' '}
-                  <img alt="NEW" src={newImage} />
-                </>
-              ),
+              display: <>MapVEu &mdash; {mapMenuItems[0].display} </>,
             }
           : {
               key: 'maps-alpha',
               type: 'subMenu',
-              display: (
-                <>
-                  MapVEu &mdash; Interactive maps{' '}
-                  <img alt="NEW" src={newImage} />
-                </>
-              ),
+              display: <>MapVEu &mdash; Interactive maps </>,
               items: mapMenuItems,
             },
         {
@@ -601,12 +590,7 @@ const useHeaderMenuItems = (
         },
         {
           key: 'srt',
-          display: (
-            <>
-              Sequence retrieval{' '}
-              {projectId === EuPathDB ? '' : <img alt="NEW" src={newImage} />}
-            </>
-          ),
+          display: 'Sequence retrieval',
           type: 'reactRoute',
           url: '/fasta-tool',
         },
@@ -1023,6 +1007,7 @@ const useHeaderMenuItems = (
           key: 'learning',
           display: 'Learn how to use VEuPathDB',
           type: 'subMenu',
+          openByDefault: true,
           items: [
             {
               key: 'faqs',


### PR DESCRIPTION
Resolves https://redmine.apidb.org/issues/53433 and removes "new" images from `Sequence retrieval` and `MapVEu` menu items.