### PR TITLE
styling area selection box

### DIFF
--- a/packages/libs/components/src/map/AreaSelectHack.js
+++ b/packages/libs/components/src/map/AreaSelectHack.js
@@ -237,7 +237,11 @@ L.Map.SelectArea = L.Map.BoxZoom.extend({
     // check if ctrlKey or metaKey is pressed to avoid unnecesary initiation of the area selection
     if (e.ctrlKey || e.metaKey) {
       if (!this._moved) {
-        this._box = L.DomUtil.create('div', 'leaflet-zoom-box', this._pane);
+        this._box = L.DomUtil.create(
+          'div',
+          'leaflet-area-selection-box',
+          this._pane
+        );
         L.DomUtil.setPosition(this._box, this._startLayerPoint);
         this._map.fire(L.Map.SelectArea.AREA_SELECT_START);
       }

--- a/packages/libs/components/src/map/styles/map-styles.css
+++ b/packages/libs/components/src/map/styles/map-styles.css
@@ -131,7 +131,6 @@
   height: 0;
   box-sizing: border-box;
   z-index: 800;
-  /* border: 2px dotted #38f; */
   border: 2px dotted rgba(255, 255, 0, 1);
   background: rgba(255, 255, 255, 0.5);
 }

--- a/packages/libs/components/src/map/styles/map-styles.css
+++ b/packages/libs/components/src/map/styles/map-styles.css
@@ -121,3 +121,17 @@
   box-shadow: -1px -0.5px 0px 6px rgba(255, 255, 0, 1),
     -1px -0.5px 0px 2px rgba(255, 255, 0, 1) inset;
 }
+
+/* area selection for selecting markers */
+.leaflet-area-selection-box {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 0;
+  height: 0;
+  box-sizing: border-box;
+  z-index: 800;
+  /* border: 2px dotted #38f; */
+  border: 2px dotted rgba(255, 255, 0, 1);
+  background: rgba(255, 255, 255, 0.5);
+}

--- a/packages/libs/components/src/map/styles/map-styles.css
+++ b/packages/libs/components/src/map/styles/map-styles.css
@@ -131,6 +131,6 @@
   height: 0;
   box-sizing: border-box;
   z-index: 800;
-  border: 2px dotted rgba(255, 255, 0, 1);
+  border: 6px solid rgba(255, 255, 0, 1);
   background: rgba(255, 255, 255, 0.5);
 }


### PR DESCRIPTION
This was branched out from https://github.com/VEuPathDB/web-monorepo/pull/1041. 

Yellow dot-line are less visible than blue dot-line, perhaps due to the background color of gray (with 50% opacity), but it may be okay? Tried green one, just out of curiosity, and it may have better visibility than yellow (screenshot): but this PR is for yellow. Perhaps you can try to change color at the CSS's border. 

If it is good enough, then I will merge it into the parent PR and then merge the parent PR which was already approved. 

![area selection styling01](https://github.com/VEuPathDB/web-monorepo/assets/12802305/8574d64c-1e4f-4564-856e-236adea3fb5c)


![area selection styling03](https://github.com/VEuPathDB/web-monorepo/assets/12802305/e5293902-d357-4bfc-a800-8a27fdfcc6b5)

