### PR TITLE
draw highlighted edges atop gray edges

### DIFF
--- a/packages/libs/components/src/plots/BipartiteNetwork.tsx
+++ b/packages/libs/components/src/plots/BipartiteNetwork.tsx
@@ -203,7 +203,7 @@ function BipartiteNetwork(
         // If a link is grayed out, it will be sorted before other links.
         // In theory, it's possible to have a false positive here;
         // but that's okay, because the overlapping colors will be the same.
-        (link) => (link.color === '#eee' ? 1 : -1)
+        (link) => (link.color === '#eee' ? -1 : 1)
       ),
     [data.links, highlightedNodeId, nodesByPartitionWithCoordinates]
   );


### PR DESCRIPTION
I noticed that the gray were sitting above the higlighted edges. Turns out it was a very simple fix!

Voila!

https://github.com/VEuPathDB/web-monorepo/assets/11710234/87f4115d-dee6-4675-be92-ced8fee69115


