### PR TITLE
Don't send little filters to `useDistributionOverlayConfig` and `useLegendData`

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/BarMarkerMapType.tsx
@@ -161,9 +161,17 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
     enabled: configuration.selectedCountsOption === 'visible',
   });
 
-  const previewMarkerData = useMarkerData({
+  const overlayConfigQueryResult = useDistributionOverlayConfig({
     studyId,
     filters,
+    binningMethod,
+    overlayVariableDescriptor: selectedVariable,
+    selectedValues,
+  });
+
+  const previewMarkerData = useMarkerData({
+    studyId,
+    filters, // no extra little filters; should reflect whole map and all time
     studyEntities,
     geoConfigs,
     selectedVariable,
@@ -171,6 +179,7 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
     binningMethod,
     dependentAxisLogScale,
     valueSpec: selectedPlotMode,
+    overlayConfigQueryResult,
   });
 
   const continuousMarkerPreview = useMemo(() => {
@@ -367,6 +376,14 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     markerDataFilterFuncs
   );
 
+  const overlayConfigQueryResult = useDistributionOverlayConfig({
+    studyId,
+    filters,
+    binningMethod,
+    overlayVariableDescriptor: selectedVariable,
+    selectedValues,
+  });
+
   const markerData = useMarkerData({
     studyEntities,
     studyId,
@@ -378,6 +395,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     binningMethod,
     dependentAxisLogScale,
     valueSpec: selectedPlotMode,
+    overlayConfigQueryResult,
   });
 
   const handleSelectedMarkerSnackbars = useSelectedMarkerSnackbars(
@@ -449,6 +467,15 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
   const { selectedMarkers, legendPanelConfig, visualizationPanelConfig } =
     configuration;
 
+  const { binningMethod, selectedVariable, selectedValues } = configuration;
+  const overlayConfigQueryResult = useDistributionOverlayConfig({
+    studyId,
+    filters,
+    binningMethod,
+    overlayVariableDescriptor: selectedVariable,
+    selectedValues,
+  });
+
   const markerData = useMarkerData({
     studyEntities,
     studyId,
@@ -459,6 +486,7 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
     dependentAxisLogScale: configuration.dependentAxisLogScale,
     selectedValues: configuration.selectedValues,
     valueSpec: configuration.selectedPlotMode,
+    overlayConfigQueryResult,
   });
 
   const legendItems = markerData.legendItems;

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/plugins/DonutMarkerMapType.tsx
@@ -139,15 +139,24 @@ function ConfigPanelComponent(props: MapTypeConfigPanelProps) {
     enabled: configuration.selectedCountsOption === 'visible',
   });
 
-  const previewMarkerResult = useMarkerData({
+  const overlayConfigQueryResult = useDistributionOverlayConfig({
     studyId,
     filters,
+    binningMethod,
+    overlayVariableDescriptor: selectedVariable,
+    selectedValues,
+  });
+
+  const previewMarkerResult = useMarkerData({
+    studyId,
+    filters, // no extra little filters; should reflect whole map and all time
     studyEntities,
     geoConfigs,
     selectedVariable: configuration.selectedVariable,
     binningMethod: configuration.binningMethod,
     selectedValues: configuration.selectedValues,
     valueSpec: 'count',
+    overlayConfigQueryResult,
   });
 
   const continuousMarkerPreview = useMemo(() => {
@@ -328,6 +337,14 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     markerDataFilterFuncs
   );
 
+  const overlayConfigQueryResult = useDistributionOverlayConfig({
+    studyId,
+    filters,
+    binningMethod,
+    overlayVariableDescriptor: selectedVariable,
+    selectedValues,
+  });
+
   const markerDataResponse = useMarkerData({
     studyId,
     filters: filtersForMarkerData,
@@ -338,6 +355,7 @@ function MapLayerComponent(props: MapTypeMapLayerProps) {
     selectedValues,
     binningMethod,
     valueSpec: 'count',
+    overlayConfigQueryResult,
   });
 
   const handleSelectedMarkerSnackbars = useSelectedMarkerSnackbars(
@@ -435,6 +453,14 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
     substudyFilterFuncs
   );
 
+  const overlayConfigQueryResult = useDistributionOverlayConfig({
+    studyId,
+    filters,
+    binningMethod,
+    overlayVariableDescriptor: selectedVariable,
+    selectedValues,
+  });
+
   const data = useMarkerData({
     studyId,
     filters,
@@ -444,6 +470,7 @@ function MapOverlayComponent(props: MapTypeMapLayerProps) {
     selectedVariable,
     selectedValues,
     valueSpec: 'count',
+    overlayConfigQueryResult,
   });
 
   const plugins = useStandaloneVizPlugins({

--- a/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/mapTypes/shared.tsx
@@ -16,7 +16,7 @@ import {
 import { BoundsViewport } from '@veupathdb/components/lib/map/Types';
 import { findEntityAndVariable } from '../../../core/utils/study-metadata';
 import { leastAncestralEntity } from '../../../core/utils/data-element-constraints';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import {
   DefaultOverlayConfigProps,
   getDefaultOverlayConfig,
@@ -213,19 +213,19 @@ export interface DistributionMarkerDataProps {
   selectedValues: string[] | undefined;
   binningMethod: DefaultOverlayConfigProps['binningMethod'];
   valueSpec: StandaloneMapMarkersRequestParams['config']['valueSpec'];
+  overlayConfigQueryResult: UseQueryResult<OverlayConfig | undefined>;
 }
 
 export function useDistributionMarkerData(props: DistributionMarkerDataProps) {
   const {
     boundsZoomLevel,
     selectedVariable,
-    binningMethod,
     geoConfigs,
     studyId,
     filters,
     studyEntities,
-    selectedValues,
     valueSpec,
+    overlayConfigQueryResult,
   } = props;
 
   const dataClient = useDataClient();
@@ -243,13 +243,7 @@ export function useDistributionMarkerData(props: DistributionMarkerDataProps) {
     boundsZoomLevel
   );
 
-  const overlayConfigResult = useDistributionOverlayConfig({
-    studyId,
-    filters,
-    binningMethod,
-    overlayVariableDescriptor: selectedVariable,
-    selectedValues,
-  });
+  const overlayConfig = overlayConfigQueryResult.data;
 
   const requestParams: StandaloneMapMarkersRequestParams = {
     studyId,
@@ -258,13 +252,12 @@ export function useDistributionMarkerData(props: DistributionMarkerDataProps) {
       geoAggregateVariable,
       latitudeVariable,
       longitudeVariable,
-      overlayConfig: overlayConfigResult.data,
+      overlayConfig,
       outputEntityId,
       valueSpec,
       viewport,
     },
   };
-  const overlayConfig = overlayConfigResult.data;
 
   const markerQuery = useQuery({
     keepPreviousData: true,
@@ -322,14 +315,14 @@ export function useDistributionMarkerData(props: DistributionMarkerDataProps) {
         boundsZoomLevel,
       };
     },
-    enabled: overlayConfig != null && !overlayConfigResult.isFetching,
+    enabled: overlayConfig != null && !overlayConfigQueryResult.isFetching,
   });
 
   return {
     ...markerQuery,
-    error: overlayConfigResult.error ?? markerQuery.error,
-    isFetching: overlayConfigResult.isFetching || markerQuery.isFetching,
-    isPreviousData: overlayConfigResult.error
+    error: overlayConfigQueryResult.error ?? markerQuery.error,
+    isFetching: overlayConfigQueryResult.isFetching || markerQuery.isFetching,
+    isPreviousData: overlayConfigQueryResult.error
       ? false
       : markerQuery.isPreviousData,
   };


### PR DESCRIPTION
Fixes #896 

The problem for both donut/bar and bubble markers was that `useMarkerData` was calling either `useDistributionOverlayConfig` or `useLegendData` internally using the `filters` that was passed to it. Problem was that we were sending filters plus "little filters for marker data" (aka viewport and timeslider).  This meant that the `overlayConfig` (or `legendData`) needed for the marker requests (and/or processing) was not the same as has been used for the legend (which didn't use any little filters).

As explained in #896 this was most obvious when showing the timeslider variable on the markers. The legend and markers were telling completely different stories.

Now the code is slightly more verbose because `useDistributionOverlayConfig` or `useLegendData` are called outside `useMarkerData` and the result is passed into it.

The alternative was to change the `useMarkerData` props so there was an additional `allFilters` prop (or similar). I thought this approach was cleaner in the long run.  