### PR TITLE
Include `isStudyExplorerWorkspace`  for standlone study page

### DIFF
--- a/packages/libs/eda/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/packages/libs/eda/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -48,7 +48,8 @@ export function EDAWorkspaceHeading({
 
   const permissionsValue = usePermissions();
 
-  const studyAccess = getStudyAccess(studyRecord);
+  // Default to `public`, if attribute is not defined
+  const studyAccess = getStudyAccess(studyRecord) ?? 'public';
 
   const showButtons =
     !permissionsValue.loading &&
@@ -82,7 +83,7 @@ export function EDAWorkspaceHeading({
         <div>
           {!permissionsValue.loading &&
             !studyMetadata.isUserStudy &&
-            studyAccess?.toLowerCase() !== 'public' &&
+            studyAccess.toLowerCase() !== 'public' &&
             shouldOfferLinkToDashboard(
               permissionsValue.permissions,
               studyRecord.id[0].value

--- a/packages/libs/eda/src/lib/workspace/StandaloneStudyPage.tsx
+++ b/packages/libs/eda/src/lib/workspace/StandaloneStudyPage.tsx
@@ -8,6 +8,7 @@ import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
 interface Props {
   studyId: string;
   showUnreleasedData: boolean;
+  isStudyExplorerWorkspace?: boolean;
 }
 
 /**
@@ -15,7 +16,11 @@ interface Props {
  * @param props
  */
 export function StandaloneStudyPage(props: Props) {
-  const { studyId, showUnreleasedData } = props;
+  const {
+    studyId,
+    showUnreleasedData,
+    isStudyExplorerWorkspace = false,
+  } = props;
   const studyRecord = useStudyRecord();
   const permissionsValue = usePermissions();
   const approvalStatus: ApprovalStatus = permissionsValue.loading
@@ -29,7 +34,9 @@ export function StandaloneStudyPage(props: Props) {
     : 'not-approved';
   return (
     <RestrictedPage approvalStatus={approvalStatus}>
-      <EDAWorkspaceHeading />
+      <EDAWorkspaceHeading
+        isStudyExplorerWorkspace={isStudyExplorerWorkspace}
+      />
       <RecordController recordClass="dataset" primaryKey={studyId} />
     </RestrictedPage>
   );

--- a/packages/libs/eda/src/lib/workspace/WorkspaceRouter.tsx
+++ b/packages/libs/eda/src/lib/workspace/WorkspaceRouter.tsx
@@ -219,10 +219,12 @@ export function WorkspaceRouter({
                 analysisClient={analysisClient}
                 downloadClient={downloadClient}
                 computeClient={computeClient}
+                isStudyExplorerWorkspace={isStudyExplorerWorkspace}
               >
                 <StandaloneStudyPage
                   studyId={props.match.params.studyId}
                   showUnreleasedData={showUnreleasedData}
+                  isStudyExplorerWorkspace={isStudyExplorerWorkspace}
                 />
               </WorkspaceContainer>
             )}


### PR DESCRIPTION
Addresses the issue raised in this slack thread: https://epvb.slack.com/archives/C01DS6HBY3Z/p1714659198160189.

**Before**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/461cf15c-f1cf-4b91-9c76-d811e43e1c0c)


**After**
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/5e55290d-9f2f-45b7-9130-431b8c9e4c49)
