### PR TITLE
Disable histogram timeline for b68 release

### DIFF
--- a/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
+++ b/packages/libs/eda/src/lib/map/analysis/hooks/standaloneVizPlugins.ts
@@ -158,12 +158,12 @@ export function useStandaloneVizPlugins({
             vizWithOptions(histogramVisualization),
             histogramRequest
           ),
-          timeline: vizWithCustomizedGetRequest(
-            vizWithOptions(
-              histogramVisualization.withSelectorIcon(HistogramTimelineSVG)
-            ),
-            histogramRequest
-          ),
+          //         timeline: vizWithCustomizedGetRequest(
+          //           vizWithOptions(
+          //             histogramVisualization.withSelectorIcon(HistogramTimelineSVG)
+          //           ),
+          //           histogramRequest
+          //         ),
           boxplot: vizWithCustomizedGetRequest(
             vizWithOptions(boxplotVisualization),
             boxplotRequest


### PR DESCRIPTION
Fixes https://github.com/VEuPathDB/EdaNewIssues/issues/784


Is it worth changing `StartPage` to either remove or improve the greyed out icon?

NO. There is a back end fix to go with this. https://github.com/VEuPathDB/service-eda/pull/31 


![image](https://github.com/VEuPathDB/web-monorepo/assets/308639/28980571-f173-4c83-a460-9b195a1caad7)
