### PR TITLE
Fix search links for WGCNA network nodes

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlation.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlation.tsx
@@ -99,12 +99,18 @@ export const plugin: ComputationPlugin = {
           const variable = variables.find((v) => v.id === variableId);
           if (variable == null) return [];
 
+          // E.g., "qa."
+          const urlPrefix = window.location.host.replace(
+            /(plasmodb|hostdb)\.org/,
+            ''
+          );
+
           const href = parasiteCollection?.memberVariableIds.includes(
             variable.id
           )
-            ? `https://qa.plasmodb.org/plasmo/app/search/transcript/GenesByRNASeqpfal3D7_Lee_Gambian_ebi_rnaSeq_RSRCWGCNAModules?param.wgcnaParam=${variable.displayName.toLowerCase()}&autoRun=1`
+            ? `//${urlPrefix}plasmodb.org/plasmo/app/search/transcript/GenesByRNASeqpfal3D7_Lee_Gambian_ebi_rnaSeq_RSRCWGCNAModules?param.wgcnaParam=${variable.displayName.toLowerCase()}&autoRun=1`
             : hostCollection?.memberVariableIds.includes(variable.id)
-            ? `https://qa.hostdb.org/hostdb/app/search/transcript/GenesByRNASeqhsapREF_Lee_Gambian_ebi_rnaSeq_RSRCWGCNAModules?param.wgcnaParam=${variable.displayName.toLowerCase()}&autoRun=1`
+            ? `//${urlPrefix}hostdb.org/hostdb/app/search/transcript/GenesByRNASeqhsapREF_Lee_Gambian_ebi_rnaSeq_RSRCWGCNAModules?param.wgcnaParam=${variable.displayName.toLowerCase()}&autoRun=1`
             : undefined;
           if (href == null) return [];
           return [


### PR DESCRIPTION
Closes #1078

This PR makes it so the WDK search links in WGCNA EDA correlation viz use the correct url prefix. The url prefix is derived from the host website (not to be confused with HostDB website). This means the links will likely not work on dev sites, unless the same dev site prefix exists for both plasmodb and hostdb.

In the future, this could be driven by configuration values.

_**The production site needs to be patched with this change.**_