### PR TITLE
possibly address barplot x-axis with a mix of number strings and text strings

### DIFF
--- a/packages/libs/components/src/plots/Barplot.tsx
+++ b/packages/libs/components/src/plots/Barplot.tsx
@@ -168,6 +168,7 @@ const Barplot = makePlotlyPlotComponent(
       range: data.series.length ? undefined : [0, 10],
       tickfont: data.series.length ? {} : { color: 'transparent' },
       showticklabels: showIndependentAxisTickLabel,
+      type: 'category',
     };
 
     // truncation


### PR DESCRIPTION
This will possibly address https://github.com/VEuPathDB/web-monorepo/issues/1101. I have looked at the current implementation of Barplot Viz but couldn't find specific issue why it was caused. Then, tested with some mock-up data that consists of a mixture of number strings and text strings like the screenshot, Surprisingly, it seems like bar chart at Plotly treats those specific case as number strings only, by excluding text strings. 

That being said, I found an option that the x-axis (technically independent axis) can always be treated as categorical values, by setting type: 'category'. From my tests (using codesandbox.io), it accepts such mixed strings correctly. 

So, @bobular it would be great if you can test this PR with the user dataset you mentioned.