### PR TITLE
Wdk service cache fix

### DIFF
--- a/packages/libs/wdk-client/src/Service/ServiceBase.ts
+++ b/packages/libs/wdk-client/src/Service/ServiceBase.ts
@@ -351,7 +351,13 @@ export const ServiceBase = (serviceUrl: string) => {
       .then((storeConfig) => {
         if (storeConfig == null) {
           return fetch(serviceUrl)
-            .then((response) => response.json())
+            .then((response) => {
+              if (!response.ok) {
+                console.error(`Fetching ${serviceUrl} failed for _initializeStore: ${response.statusText}`);
+                throw new Error("Failed to initialize service");
+              }
+              return response.json()
+            })
             .then((serviceConfig: ServiceConfig) => {
               return _store
                 .setItem('/__config', serviceConfig)

--- a/packages/libs/wdk-client/src/Service/ServiceBase.ts
+++ b/packages/libs/wdk-client/src/Service/ServiceBase.ts
@@ -350,14 +350,19 @@ export const ServiceBase = (serviceUrl: string) => {
       .getItem<ServiceConfig>('/__config')
       .then((storeConfig) => {
         if (storeConfig == null) {
-          return _fetchJson<ServiceConfig>('GET', '/').then((serviceConfig) => {
-            return _store.setItem('/__config', serviceConfig);
-          });
+          return fetch(serviceUrl)
+            .then((response) => response.json())
+            .then((serviceConfig: ServiceConfig) => {
+              return _store
+                .setItem('/__config', serviceConfig)
+                .then(() => serviceConfig);
+            });
         }
         return storeConfig;
       })
       .then((config) => {
         _version = config.startupTime;
+        return _version;
       });
   });
 

--- a/packages/libs/wdk-client/src/Service/ServiceBase.ts
+++ b/packages/libs/wdk-client/src/Service/ServiceBase.ts
@@ -350,13 +350,15 @@ export const ServiceBase = (serviceUrl: string) => {
       .getItem<ServiceConfig>('/__config')
       .then((storeConfig) => {
         if (storeConfig == null) {
-          return fetch(serviceUrl)
+          return fetchWithRetry(1, serviceUrl)
             .then((response) => {
               if (!response.ok) {
-                console.error(`Fetching ${serviceUrl} failed for _initializeStore: ${response.statusText}`);
-                throw new Error("Failed to initialize service");
+                console.error(
+                  `Fetching ${serviceUrl} failed for _initializeStore: ${response.statusText}`
+                );
+                throw new Error('Failed to initialize service');
               }
-              return response.json()
+              return response.json();
             })
             .then((serviceConfig: ServiceConfig) => {
               return _store

--- a/packages/libs/wdk-client/src/Service/ServiceBase.ts
+++ b/packages/libs/wdk-client/src/Service/ServiceBase.ts
@@ -234,7 +234,7 @@ export const ServiceBase = (serviceUrl: string) => {
     return submitErrorIfNot500(error, extra);
   }
 
-  function _fetchJson<T>(
+  async function _fetchJson<T>(
     method: string,
     url: string,
     body?: string,
@@ -244,7 +244,7 @@ export const ServiceBase = (serviceUrl: string) => {
       'Content-Type': 'application/json',
       traceid: makeTraceid(),
     });
-    if (_version) headers.append(CLIENT_WDK_VERSION_HEADER, String(_version));
+    headers.append(CLIENT_WDK_VERSION_HEADER, String(await _initializeStore()));
     return fetchWithRetry(1, isBaseUrl ? url : serviceUrl + url, {
       headers,
       method: method.toUpperCase(),

--- a/packages/libs/wdk-client/src/Service/ServiceBase.ts
+++ b/packages/libs/wdk-client/src/Service/ServiceBase.ts
@@ -285,14 +285,14 @@ export const ServiceBase = (serviceUrl: string) => {
               _isInvalidating = true;
               _store
                 .clear()
-                .then(() =>
-                  hasRequestBeenMade
-                    ? alert(
-                        'Reload page',
-                        'This page is no longer valid and will be reloaded.'
-                      )
-                    : undefined
-                )
+                .then(() => {
+                  if (hasRequestBeenMade) {
+                    return alert(
+                      'Reload page',
+                      'This page is no longer valid and will be reloaded.'
+                    );
+                  }
+                })
                 .then(() => {
                   window.location.reload();
                 });


### PR DESCRIPTION
This PR fixes an issue where the reload dialog would appear on an initial page load.

The issue is due to some requests being made before the WdkService `startupTime` property is initialized (as the variable `_version`) on the client. Such requests would set `_hasRequestBeenMade` to `true`, but the request would not include the header `x-client-wdk-timestamp`.

The fix is to always call `_initializeStore` before any requests are made. This took a little refactoring to avoid an infinite loop.