### PR TITLE
Add ability to make user datasets public (aka, community datasets)

### DIFF
--- a/packages/libs/user-datasets/src/lib/Actions/UserDatasetsActions.ts
+++ b/packages/libs/user-datasets/src/lib/Actions/UserDatasetsActions.ts
@@ -632,6 +632,7 @@ function transformVdiResponseToLegacyResponseHelper(
     created,
     status,
     importMessages,
+    visibility,
   } = ud;
   const { quota } = userQuotaMetadata;
   return {
@@ -647,6 +648,7 @@ function transformVdiResponseToLegacyResponseHelper(
       name,
       description: description ?? '',
       summary: summary ?? '',
+      visibility,
     },
     ownerUserId: owner.userId,
     age: Date.now() - Date.parse(created),

--- a/packages/libs/user-datasets/src/lib/Actions/UserDatasetsActions.ts
+++ b/packages/libs/user-datasets/src/lib/Actions/UserDatasetsActions.ts
@@ -12,7 +12,6 @@ import {
   EmptyAction,
   emptyAction,
 } from '@veupathdb/wdk-client/lib/Core/WdkMiddleware';
-import { ServiceError } from '@veupathdb/wdk-client/lib/Service/ServiceError';
 
 import { validateVdiCompatibleThunk } from '../Service';
 
@@ -25,6 +24,7 @@ import {
   UserQuotaMetadata,
   UserDatasetFileListing,
 } from '../Utils/types';
+import { FetchClientError } from '@veupathdb/http-utils';
 
 export type Action =
   | DetailErrorAction
@@ -91,12 +91,12 @@ export const LIST_ERROR_RECEIVED = 'user-dataset/list-error';
 export type ListErrorReceivedAction = {
   type: typeof LIST_ERROR_RECEIVED;
   payload: {
-    error: ServiceError;
+    error: FetchClientError;
   };
 };
 
 export function listErrorReceived(
-  error: ServiceError
+  error: FetchClientError
 ): ListErrorReceivedAction {
   return {
     type: LIST_ERROR_RECEIVED,
@@ -161,11 +161,11 @@ export const DETAIL_ERROR = 'user-datasets/detail-error';
 export type DetailErrorAction = {
   type: typeof DETAIL_ERROR;
   payload: {
-    error: ServiceError;
+    error: FetchClientError;
   };
 };
 
-export function detailError(error: ServiceError): DetailErrorAction {
+export function detailError(error: FetchClientError): DetailErrorAction {
   return {
     type: DETAIL_ERROR,
     payload: {
@@ -217,12 +217,12 @@ export const DETAIL_UPDATE_ERROR = 'user-datasets/detail-update-error';
 export type DetailUpdateErrorAction = {
   type: typeof DETAIL_UPDATE_ERROR;
   payload: {
-    error: ServiceError;
+    error: FetchClientError;
   };
 };
 
 export function detailUpdateError(
-  error: ServiceError
+  error: FetchClientError
 ): DetailUpdateErrorAction {
   return {
     type: DETAIL_UPDATE_ERROR,
@@ -275,12 +275,12 @@ export const DETAIL_REMOVE_ERROR = 'user-datasets/detail-remove-error';
 export type DetailRemoveErrorAction = {
   type: typeof DETAIL_REMOVE_ERROR;
   payload: {
-    error: ServiceError;
+    error: FetchClientError;
   };
 };
 
 export function detailRemoveError(
-  error: ServiceError
+  error: FetchClientError
 ): DetailRemoveErrorAction {
   return {
     type: DETAIL_REMOVE_ERROR,
@@ -485,8 +485,8 @@ export function loadUserDatasetDetailWithoutLoadingIndicator(id: string) {
         };
         return detailReceived(id, transformedResponse, fileListing);
       },
-      (error: ServiceError) =>
-        error.status === 404 ? detailReceived(id) : detailError(error)
+      (error: FetchClientError) =>
+        error.statusCode === 404 ? detailReceived(id) : detailError(error)
     )
   );
 }

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -179,13 +179,13 @@ class UserDatasetDetail extends React.Component {
           meta.visibility === 'public' ? (
             <>
               {' '}
-              <Public className="Community-visible" /> This {dataNoun.singular}{' '}
-              is visible to the community.
+              <Public className="Community-visible" /> This{' '}
+              {dataNoun.singular.toLowerCase()} is visible to the community.
             </>
           ) : (
             <>
-              This {dataNoun.singular} is only visble to you and those you have
-              shared it with.
+              This {dataNoun.singular.toLowerCase()} is only visble to the owner
+              and those they have shared it with.
             </>
           ),
       },

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -618,6 +618,7 @@ class UserDatasetDetail extends React.Component {
       shareSuccessful,
       shareError,
       updateUserDatasetDetail,
+      enablePublicUserDatasets,
     } = this.props;
     const AllDatasetsLink = this.renderAllDatasetsLink;
     if (!userDataset)
@@ -646,6 +647,7 @@ class UserDatasetDetail extends React.Component {
             shareSuccessful={shareSuccessful}
             shareError={shareError}
             updateUserDatasetDetail={updateUserDatasetDetail}
+            enablePublicUserDatasets={enablePublicUserDatasets}
           />
         )}
       </div>

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Public } from '@material-ui/icons';
 
 import Icon from '@veupathdb/wdk-client/lib/Components/Icon/IconAlt';
 import SaveableTextEditor from '@veupathdb/wdk-client/lib/Components/InputControls/SaveableTextEditor';
@@ -149,8 +150,8 @@ class UserDatasetDetail extends React.Component {
 
     return [
       {
-        className: classify('Name'),
         attribute: this.props.detailsPageTitle,
+        className: classify('Name'),
         value: (
           <SaveableTextEditor
             value={meta.name}
@@ -161,7 +162,6 @@ class UserDatasetDetail extends React.Component {
       },
       {
         attribute: 'Status',
-        className: classify('Status'),
         value: (
           <UserDatasetStatus
             linkToDataset={false}
@@ -173,6 +173,36 @@ class UserDatasetDetail extends React.Component {
           />
         ),
       },
+      {
+        attribute: 'Visibility',
+        value:
+          meta.visibility === 'public' ? (
+            <>
+              {' '}
+              <Public className="Community-visible" /> This {dataNoun.singular}{' '}
+              is visible to the community.
+            </>
+          ) : (
+            <>
+              This {dataNoun.singular} is only visble to you and those you have
+              shared it with.
+            </>
+          ),
+      },
+      !isOwner || !sharedWith || !sharedWith.length
+        ? null
+        : {
+            attribute: 'Shared with',
+            value: (
+              <ul>
+                {sharedWith.map((share, index) => (
+                  <li key={`${share.userDisplayName}-${index}`}>
+                    {share.userDisplayName}
+                  </li>
+                ))}
+              </ul>
+            ),
+          },
       {
         attribute: 'Owner',
         value: isOwner ? 'Me' : owner,
@@ -222,20 +252,6 @@ class UserDatasetDetail extends React.Component {
             value: `${normalizePercentage(percentQuotaUsed)}% of ${bytesToHuman(
               quotaSize
             )}`,
-          },
-      !isOwner || !sharedWith || !sharedWith.length
-        ? null
-        : {
-            attribute: 'Shared with',
-            value: (
-              <ul>
-                {sharedWith.map((share, index) => (
-                  <li key={`${share.userDisplayName}-${index}`}>
-                    {share.userDisplayName}
-                  </li>
-                ))}
-              </ul>
-            ),
           },
       !questions || !questions.length || !isInstalled
         ? null
@@ -298,7 +314,9 @@ class UserDatasetDetail extends React.Component {
         {attributes.map(({ attribute, value, className }, index) => (
           <div
             className={
-              classify('AttributeRow') + (className ? ' ' + className : '')
+              classify('AttributeRow') +
+              ' ' +
+              (className ?? classify(attribute))
             }
             key={index}
           >

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -617,6 +617,7 @@ class UserDatasetDetail extends React.Component {
       sharingDatasetPending,
       shareSuccessful,
       shareError,
+      updateUserDatasetDetail,
     } = this.props;
     const AllDatasetsLink = this.renderAllDatasetsLink;
     if (!userDataset)
@@ -644,6 +645,7 @@ class UserDatasetDetail extends React.Component {
             sharingDatasetPending={sharingDatasetPending}
             shareSuccessful={shareSuccessful}
             shareError={shareError}
+            updateUserDatasetDetail={updateUserDatasetDetail}
           />
         )}
       </div>

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -326,7 +326,9 @@ class UserDatasetDetail extends React.Component {
             onPress={this.openSharingModal}
           />
         )}
-        <ThemedDeleteButton buttonText="Delete" onPress={this.handleDelete} />
+        {isOwner ? (
+          <ThemedDeleteButton buttonText="Delete" onPress={this.handleDelete} />
+        ) : null}
       </div>
     );
   }

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
@@ -102,8 +102,8 @@
         flex: 1 1 auto;
       }
     }
-    .UserDatasetDetail-Status {
-      margin-bottom: 1em;
+    .UserDatasetDetail-Owner {
+      margin-top: 1em;
     }
   }
 }

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -73,6 +73,7 @@ interface Props {
   updateProjectFilter: (filterByProject: boolean) => any;
   quotaSize: number;
   dataNoun: DataNoun;
+  enablePublicUserDatasets: boolean;
 }
 
 interface State {
@@ -569,6 +570,7 @@ class UserDatasetList extends React.Component<Props, State> {
       shareSuccessful,
       shareError,
       updateUserDatasetDetail,
+      enablePublicUserDatasets,
     } = this.props;
     const { uiState, selectedRows, searchTerm } = this.state;
 
@@ -625,6 +627,7 @@ class UserDatasetList extends React.Component<Props, State> {
                     shareSuccessful={shareSuccessful}
                     shareError={shareError}
                     updateUserDatasetDetail={updateUserDatasetDetail}
+                    enablePublicUserDatasets={enablePublicUserDatasets}
                   />
                 ) : null}
                 <SearchBox

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -39,6 +39,8 @@ import { DateTime } from '../DateTime';
 
 import { ThemedGrantAccessButton } from '../ThemedGrantAccessButton';
 import { ThemedDeleteButton } from '../ThemedDeleteButton';
+import { Public } from '@material-ui/icons';
+import { Tooltip } from '@veupathdb/coreui';
 
 interface Props {
   baseUrl: string;
@@ -156,6 +158,19 @@ class UserDatasetList extends React.Component<Props, State> {
     return !dataset.sharedWith || !dataset.sharedWith.length
       ? null
       : dataset.sharedWith.map((share) => share.userDisplayName).join(', ');
+  }
+
+  renderCommunityCell(cellProps: MesaDataCellProps) {
+    const dataset: UserDataset = cellProps.row;
+    const isPublic = dataset.meta.visibility === 'public';
+    if (!isPublic) return null;
+    return (
+      <Tooltip
+        title={`This ${this.props.dataNoun.singular} is visible to the community.`}
+      >
+        <Public className="Community-visible" />
+      </Tooltip>
+    );
   }
 
   renderStatusCell(cellProps: MesaDataCellProps) {
@@ -281,6 +296,14 @@ class UserDatasetList extends React.Component<Props, State> {
         name: 'Shared With',
         sortable: true,
         renderCell: this.renderSharedWithCell,
+      },
+      {
+        key: 'visibility',
+        name: 'Community',
+        sortable: true,
+        helpText: `Indicates if the ${this.props.dataNoun.singular} is visible to the community.`,
+        style: { textAlign: 'center' },
+        renderCell: this.renderCommunityCell.bind(this),
       },
       {
         key: 'created',

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -568,6 +568,7 @@ class UserDatasetList extends React.Component<Props, State> {
       sharingDatasetPending,
       shareSuccessful,
       shareError,
+      updateUserDatasetDetail,
     } = this.props;
     const { uiState, selectedRows, searchTerm } = this.state;
 
@@ -623,6 +624,7 @@ class UserDatasetList extends React.Component<Props, State> {
                     sharingDatasetPending={sharingDatasetPending}
                     shareSuccessful={shareSuccessful}
                     shareError={shareError}
+                    updateUserDatasetDetail={updateUserDatasetDetail}
                   />
                 ) : null}
                 <SearchBox

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -297,14 +297,18 @@ class UserDatasetList extends React.Component<Props, State> {
         sortable: true,
         renderCell: this.renderSharedWithCell,
       },
-      {
-        key: 'visibility',
-        name: 'Community',
-        sortable: true,
-        helpText: `Indicates if the ${this.props.dataNoun.singular} is visible to the community.`,
-        style: { textAlign: 'center' },
-        renderCell: this.renderCommunityCell.bind(this),
-      },
+      ...(this.props.enablePublicUserDatasets
+        ? [
+            {
+              key: 'visibility',
+              name: 'Community',
+              sortable: true,
+              helpText: `Indicates if the ${this.props.dataNoun.singular} is visible to the community.`,
+              style: { textAlign: 'center' },
+              renderCell: this.renderCommunityCell.bind(this),
+            },
+          ]
+        : []),
       {
         key: 'created',
         name: 'Created',

--- a/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.jsx
@@ -469,6 +469,15 @@ class UserDatasetSharingModal extends React.Component {
         </div>
       );
     } else {
+      // Determine the value for the community visibility toggle:
+      // If a single user dataset is selected, use its value.
+      // If multiple are selected, and they all have the same value,
+      // use that value; otherwise, use undefined.
+      //
+      // Since the former is a subset of the latter, we can implement
+      // only the latter by:
+      // 1. Get an array of unique visbility values.
+      // 2. If the length of the array is 1, use that value; otherwise use undefined.
       const visibilities = uniq(datasets.map((d) => d.meta.visibility));
       const visibility =
         visibilities.length === 1 ? visibilities[0] : undefined;

--- a/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.jsx
@@ -9,8 +9,10 @@ import {
 import { WdkDependenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
 
 import { isVdiCompatibleWdkService } from '../../Service';
+import { SingleSelect } from '@veupathdb/coreui';
 
 import './UserDatasetSharingModal.scss';
+import { uniq } from 'lodash';
 
 const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
@@ -425,8 +427,14 @@ class UserDatasetSharingModal extends React.Component {
 
   renderViewContent() {
     const { recipients } = this.state;
-    const { datasets, onClose, dataNoun, shareError, shareSuccessful } =
-      this.props;
+    const {
+      datasets,
+      onClose,
+      dataNoun,
+      shareError,
+      shareSuccessful,
+      updateUserDatasetDetail,
+    } = this.props;
     const datasetNoun = this.getDatasetNoun();
 
     const DatasetList = this.renderDatasetList;
@@ -460,6 +468,16 @@ class UserDatasetSharingModal extends React.Component {
         </div>
       );
     } else {
+      const visibilities = uniq(datasets.map((d) => d.meta.visibility));
+      const visibility =
+        visibilities.length === 1 ? visibilities[0] : undefined;
+      const visibilityItems = [
+        { value: 'private', display: 'Private' },
+        { value: 'public', display: 'Public' },
+      ];
+      const selectedVisibilityItem = visibilityItems.find(
+        (item) => item.value === visibility
+      );
       return (
         <div className="UserDataset-SharingModal-FormView">
           <div className="UserDataset-SharingModal-DatasetSection">
@@ -467,6 +485,27 @@ class UserDatasetSharingModal extends React.Component {
               Share {datasetNoun}:
             </h2>
             <DatasetList datasets={datasets} />
+          </div>
+          <div className="UserDataset-SharingModal-VisibilitySection">
+            <h2 className="UserDatasetSharing-SectionName">
+              General visibility:
+            </h2>
+            <SingleSelect
+              buttonDisplayContent={selectedVisibilityItem?.display}
+              value={visibility}
+              items={[
+                { value: 'private', display: 'Private' },
+                { value: 'public', display: 'Public' },
+              ]}
+              onSelect={(value) => {
+                datasets.forEach((dataset) =>
+                  updateUserDatasetDetail(dataset, {
+                    ...dataset.meta,
+                    visibility: value,
+                  })
+                );
+              }}
+            />
           </div>
           <div className="UserDataset-SharingModal-RecipientSection">
             <h2 className="UserDatasetSharing-SectionName">

--- a/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.jsx
@@ -9,7 +9,7 @@ import {
 import { WdkDependenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
 
 import { isVdiCompatibleWdkService } from '../../Service';
-import { SingleSelect } from '@veupathdb/coreui';
+import { Toggle } from '@veupathdb/coreui';
 
 import './UserDatasetSharingModal.scss';
 import { uniq } from 'lodash';
@@ -434,6 +434,7 @@ class UserDatasetSharingModal extends React.Component {
       shareError,
       shareSuccessful,
       updateUserDatasetDetail,
+      enablePublicUserDatasets,
     } = this.props;
     const datasetNoun = this.getDatasetNoun();
 
@@ -471,41 +472,37 @@ class UserDatasetSharingModal extends React.Component {
       const visibilities = uniq(datasets.map((d) => d.meta.visibility));
       const visibility =
         visibilities.length === 1 ? visibilities[0] : undefined;
-      const visibilityItems = [
-        { value: 'private', display: 'Private' },
-        { value: 'public', display: 'Public' },
-      ];
-      const selectedVisibilityItem = visibilityItems.find(
-        (item) => item.value === visibility
-      );
       return (
         <div className="UserDataset-SharingModal-FormView">
+          {enablePublicUserDatasets && (
+            <div className="UserDataset-SharingModal-VisibilitySection">
+              <h2 className="UserDatasetSharing-SectionName">
+                Community visibility:
+              </h2>
+              <div
+                className="UserDatasetSharing-Visibility"
+                style={{ padding: '1em' }}
+              >
+                <Toggle
+                  value={visibility === 'public'}
+                  onChange={(value) => {
+                    datasets.forEach((dataset) => {
+                      updateUserDatasetDetail(dataset, {
+                        ...dataset.meta,
+                        visibility: value ? 'public' : 'private',
+                      });
+                    });
+                  }}
+                  label={`Allow ${datasetNoun} to be visible to all users as a Community ${dataNoun.singular}.`}
+                />
+              </div>
+            </div>
+          )}
           <div className="UserDataset-SharingModal-DatasetSection">
             <h2 className="UserDatasetSharing-SectionName">
               Share {datasetNoun}:
             </h2>
             <DatasetList datasets={datasets} />
-          </div>
-          <div className="UserDataset-SharingModal-VisibilitySection">
-            <h2 className="UserDatasetSharing-SectionName">
-              General visibility:
-            </h2>
-            <SingleSelect
-              buttonDisplayContent={selectedVisibilityItem?.display}
-              value={visibility}
-              items={[
-                { value: 'private', display: 'Private' },
-                { value: 'public', display: 'Public' },
-              ]}
-              onSelect={(value) => {
-                datasets.forEach((dataset) =>
-                  updateUserDatasetDetail(dataset, {
-                    ...dataset.meta,
-                    visibility: value,
-                  })
-                );
-              }}
-            />
           </div>
           <div className="UserDataset-SharingModal-RecipientSection">
             <h2 className="UserDatasetSharing-SectionName">

--- a/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.scss
@@ -81,6 +81,7 @@
     }
   }
 
+  .UserDatasetSharing-Visibility,
   .UserDatasetSharing-Dataset,
   .UserDatasetSharing-Recipient {
     border: 1px solid rgba(0, 0, 0, 0.1);

--- a/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.scss
@@ -41,7 +41,7 @@
 
   .UserDatasetSharing-SectionName {
     margin: 10px 0 -5px;
-    font-weight: 200;
+    font-weight: 400;
   }
 
   fieldset {
@@ -167,7 +167,7 @@
   text-align: center;
   padding: 20px 5px;
   h2 {
-    font-weight: 200;
+    font-weight: 400;
     text-align: center;
   }
   button {

--- a/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
@@ -607,6 +607,7 @@ function validateForm<T extends string = string>(
       datasetType: datasetUploadType.type,
       projects: [projectId],
       dataUploadSelection,
+      visibility: 'private',
     },
   };
 }

--- a/packages/libs/user-datasets/src/lib/Components/UserDatasets.scss
+++ b/packages/libs/user-datasets/src/lib/Components/UserDatasets.scss
@@ -5,7 +5,8 @@
 .UserDataset-SharingModal {
   .success,
   .Community-visible {
-    color: $green;
+    color: $blue;
+    vertical-align: bottom;
   }
   .danger {
     color: $red;

--- a/packages/libs/user-datasets/src/lib/Components/UserDatasets.scss
+++ b/packages/libs/user-datasets/src/lib/Components/UserDatasets.scss
@@ -10,7 +10,7 @@
     color: $red;
   }
   .faded {
-    opacity: 0.5;
+    opacity: 0.85;
   }
 
   input,

--- a/packages/libs/user-datasets/src/lib/Components/UserDatasets.scss
+++ b/packages/libs/user-datasets/src/lib/Components/UserDatasets.scss
@@ -3,7 +3,8 @@
 .UserDatasetList,
 .UserDatasetDetail,
 .UserDataset-SharingModal {
-  .success {
+  .success,
+  .Community-visible {
     color: $green;
   }
   .danger {

--- a/packages/libs/user-datasets/src/lib/Components/UserDatasetsWorkspace.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UserDatasetsWorkspace.tsx
@@ -5,7 +5,6 @@ import { Switch, Redirect } from 'react-router-dom';
 import WorkspaceNavigation from '@veupathdb/wdk-client/lib/Components/Workspace/WorkspaceNavigation';
 import WdkRoute from '@veupathdb/wdk-client/lib/Core/WdkRoute';
 
-import UserDatasetAllUploadsController from '../Controllers/UserDatasetAllUploadsController';
 import UserDatasetListController from '../Controllers/UserDatasetListController';
 import UserDatasetNewUploadController from '../Controllers/UserDatasetNewUploadController';
 
@@ -19,6 +18,7 @@ interface Props {
   workspaceTitle: string;
   helpTabContents?: ReactNode;
   dataNoun: DataNoun;
+  enablePublicUserDatasets: boolean;
 }
 
 function UserDatasetsWorkspace(props: Props) {
@@ -29,6 +29,7 @@ function UserDatasetsWorkspace(props: Props) {
     workspaceTitle,
     helpTabContents,
     dataNoun,
+    enablePublicUserDatasets,
   } = props;
 
   return (
@@ -77,6 +78,7 @@ function UserDatasetsWorkspace(props: Props) {
               helpRoute={helpRoute}
               workspaceTitle={workspaceTitle}
               dataNoun={dataNoun}
+              enablePublicUserDatasets={enablePublicUserDatasets}
             />
           )}
           disclaimerProps={{ toDoWhatMessage: 'To view your datasets' }}

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetDetailController.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetDetailController.tsx
@@ -100,9 +100,20 @@ class UserDatasetDetailController extends PageController<MergedProps> {
   }
 
   isRenderDataLoadError() {
+    const { loadError } = this.props.stateProps;
+    return loadError != null && loadError.statusCode >= 400;
+  }
+
+  isRenderDataNotFound(): boolean {
+    const { loadError } = this.props.stateProps;
+    return loadError != null && loadError.statusCode === 404;
+  }
+
+  isRenderDataPermissionDenied(): boolean {
+    const { loadError } = this.props.stateProps;
     return (
-      this.props.stateProps.loadError != null &&
-      this.props.stateProps.loadError.status >= 500
+      loadError != null &&
+      (loadError.statusCode === 401 || loadError.statusCode === 403)
     );
   }
 

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetDetailController.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetDetailController.tsx
@@ -55,6 +55,7 @@ type OwnProps = {
     ComponentType<UserDatasetDetailProps>
   >;
   dataNoun: DataNoun;
+  enablePublicUserDatasets: boolean;
 };
 type MergedProps = {
   ownProps: OwnProps;
@@ -152,8 +153,14 @@ class UserDatasetDetailController extends PageController<MergedProps> {
   }
 
   renderView() {
-    const { baseUrl, detailsPageTitle, id, workspaceTitle, dataNoun } =
-      this.props.ownProps;
+    const {
+      baseUrl,
+      detailsPageTitle,
+      id,
+      workspaceTitle,
+      dataNoun,
+      enablePublicUserDatasets,
+    } = this.props.ownProps;
     const {
       updateUserDatasetDetail,
       shareUserDatasets,
@@ -209,6 +216,7 @@ class UserDatasetDetailController extends PageController<MergedProps> {
       workspaceTitle,
       detailsPageTitle,
       dataNoun,
+      enablePublicUserDatasets,
     };
 
     const DetailView = this.getDetailView(

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetListController.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetListController.tsx
@@ -52,6 +52,7 @@ interface OwnProps extends RouteComponentProps<{}> {
   helpRoute: string;
   workspaceTitle: string;
   dataNoun: DataNoun;
+  enablePublicUserDatasets: boolean;
 }
 type Props = {
   ownProps: OwnProps;
@@ -126,8 +127,14 @@ class UserDatasetListController extends PageController<Props> {
 
     const { projectId, displayName: projectName } = config;
 
-    const { baseUrl, hasDirectUpload, helpRoute, location, dataNoun } =
-      this.props.ownProps;
+    const {
+      baseUrl,
+      hasDirectUpload,
+      helpRoute,
+      location,
+      dataNoun,
+      enablePublicUserDatasets,
+    } = this.props.ownProps;
 
     const {
       userDatasetList: {
@@ -165,6 +172,7 @@ class UserDatasetListController extends PageController<Props> {
       projectName,
       numOngoingUploads,
       quotaSize,
+      enablePublicUserDatasets,
       userDatasets: userDatasets.map(
         (id) => userDatasetsById[id].resource
       ) as UserDataset[],

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetRouter.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetRouter.tsx
@@ -25,6 +25,7 @@ interface Props<T1 extends string = string, T2 extends string = string> {
     ComponentType<UserDatasetDetailProps>
   >;
   dataNoun: DataNoun;
+  enablePublicUserDatasets?: boolean;
 }
 
 export function UserDatasetRouter<T1 extends string, T2 extends string>({
@@ -36,6 +37,7 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
   helpTabContents,
   detailComponentsByTypeName,
   dataNoun,
+  enablePublicUserDatasets = false,
 }: Props<T1, T2>) {
   const { path, url } = useRouteMatch();
 
@@ -70,6 +72,7 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
               workspaceTitle={workspaceTitle}
               helpTabContents={helpTabContents}
               dataNoun={dataNoun}
+              enablePublicUserDatasets={enablePublicUserDatasets}
             />
           );
         }}
@@ -98,6 +101,7 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
               workspaceTitle={workspaceTitle}
               helpTabContents={helpTabContents}
               dataNoun={dataNoun}
+              enablePublicUserDatasets={enablePublicUserDatasets}
             />
           );
         }}
@@ -154,6 +158,7 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
               workspaceTitle={workspaceTitle}
               helpTabContents={helpTabContents}
               dataNoun={dataNoun}
+              enablePublicUserDatasets={enablePublicUserDatasets}
             />
           );
         }}
@@ -169,6 +174,7 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
               workspaceTitle={workspaceTitle}
               detailComponentsByTypeName={detailComponentsByTypeName}
               dataNoun={dataNoun}
+              enablePublicUserDatasets={enablePublicUserDatasets}
               {...props.match.params}
             />
           );

--- a/packages/libs/user-datasets/src/lib/StoreModules/UserDatasetDetailStoreModule.ts
+++ b/packages/libs/user-datasets/src/lib/StoreModules/UserDatasetDetailStoreModule.ts
@@ -1,4 +1,4 @@
-import { ServiceError } from '@veupathdb/wdk-client/lib/Service/ServiceError';
+import { FetchClientError } from '@veupathdb/http-utils';
 import {
   Action,
   DETAIL_LOADING,
@@ -37,9 +37,9 @@ export interface State {
   userDatasetRemoving: boolean;
   sharingModalOpen: boolean;
   sharingDatasetPending: boolean;
-  loadError?: ServiceError;
-  updateError?: ServiceError;
-  removalError?: ServiceError;
+  loadError?: FetchClientError;
+  updateError?: FetchClientError;
+  removalError?: FetchClientError;
   shareError: Error | undefined;
   shareSuccessful: boolean | undefined;
 }

--- a/packages/libs/user-datasets/src/lib/StoreModules/UserDatasetListStoreModule.ts
+++ b/packages/libs/user-datasets/src/lib/StoreModules/UserDatasetListStoreModule.ts
@@ -87,7 +87,7 @@ export function reduce(state: State = initialState, action: Action): State {
       };
 
     case LIST_ERROR_RECEIVED:
-      return action.payload.error.status === 403
+      return action.payload.error.statusCode === 403
         ? {
             ...state,
             status: 'forbidden',

--- a/packages/libs/user-datasets/src/lib/Utils/types.ts
+++ b/packages/libs/user-datasets/src/lib/Utils/types.ts
@@ -16,6 +16,7 @@ export interface UserDatasetMeta {
   description: string;
   name: string;
   summary: string;
+  visibility: UserDatasetVisibility;
 }
 
 export interface UserDatasetShare {
@@ -50,6 +51,7 @@ export interface UserDataset {
   status: UserDatasetVDI['status'];
   fileListing?: UserDatasetFileListing;
   importMessages: Array<string>;
+  visibility?: UserDatasetVisibility;
 }
 
 export interface UserDatasetUpload {
@@ -223,6 +225,8 @@ const statusDetails = intersection([
     install: array(installDetails),
   }),
 ]);
+
+export type UserDatasetVisibility = TypeOf<typeof visibilityOptions>;
 
 const visibilityOptions = keyof({
   private: null,

--- a/packages/libs/web-common/src/component-wrappers/AnswerController.scss
+++ b/packages/libs/web-common/src/component-wrappers/AnswerController.scss
@@ -3,3 +3,8 @@
     color: #069;
   }
 }
+.ClinEpiStudyAnswerController {
+  .wdk-AnswerHeader {
+    display: none;
+  }
+}

--- a/packages/libs/web-common/src/component-wrappers/StudyAnswerController.jsx
+++ b/packages/libs/web-common/src/component-wrappers/StudyAnswerController.jsx
@@ -8,7 +8,14 @@ import CategoryIcon from '../App/Categories/CategoryIcon';
 import StudySearchIconLinks from '../App/Studies/StudySearches';
 import { isPrereleaseStudy } from '@veupathdb/study-data-access/lib/data-restriction/DataRestrictionUtils';
 import { makeEdaRoute } from '../routes';
-import { useEda } from '../config';
+import { useEda, useUserDatasetsWorkspace } from '../config';
+
+import {
+  useDiyStudySummaryColumns,
+  useDiyStudySummaryRows,
+} from '../hooks/diyStudySummaries';
+
+import DataGrid from '@veupathdb/coreui/lib/components/grids/DataGrid';
 
 // wrapping WDKClient AnswerController for specific rendering on certain columns
 function StudyAnswerController(props) {
@@ -48,22 +55,86 @@ function StudyAnswerController(props) {
     [props.permissions]
   );
 
+  const curatedStudies = (
+    <props.DefaultComponent
+      {...props}
+      stateProps={{
+        ...props.stateProps,
+        records: visibleRecords,
+        meta: props.stateProps.meta && {
+          ...props.stateProps.meta,
+          totalCount,
+        },
+      }}
+      renderCellContent={renderCellContent}
+      useStickyFirstNColumns={1}
+    />
+  );
+
+  const columns = useDiyStudySummaryColumns();
+  const { userStudySummaryRows, communityStudySummaryRows } =
+    useDiyStudySummaryRows();
+
   return (
-    <React.Fragment>
-      <props.DefaultComponent
-        {...props}
-        stateProps={{
-          ...props.stateProps,
-          records: visibleRecords,
-          meta: props.stateProps.meta && {
-            ...props.stateProps.meta,
-            totalCount,
-          },
-        }}
-        renderCellContent={renderCellContent}
-        useStickyFirstNColumns={1}
-      />
-    </React.Fragment>
+    <div className="ClinEpiStudyAnswerController">
+      {!props.stateProps.isLoading &&
+        userStudySummaryRows != null &&
+        communityStudySummaryRows != null && (
+          <>
+            <h1>Study summaries</h1>
+            {useUserDatasetsWorkspace &&
+              useEda &&
+              userStudySummaryRows.length > 0 && (
+                <>
+                  <h2>My studies</h2>
+                  <DataGrid
+                    columns={columns}
+                    data={userStudySummaryRows}
+                    stylePreset="mesa"
+                    styleOverrides={{
+                      headerCells: {
+                        backgroundColor: '#e2e2e3',
+                        color: '#444',
+                        textTransform: 'none',
+                      },
+                      dataCells: {
+                        fontSize: '1.1em',
+                        color: 'black',
+                        verticalAlign: 'top',
+                      },
+                    }}
+                  />
+                </>
+              )}
+            {useUserDatasetsWorkspace &&
+              useEda &&
+              communityStudySummaryRows.length > 0 && (
+                <>
+                  <h2>Community studies</h2>
+                  <DataGrid
+                    columns={columns.slice(0, -1)}
+                    data={communityStudySummaryRows}
+                    stylePreset="mesa"
+                    styleOverrides={{
+                      headerCells: {
+                        backgroundColor: '#e2e2e3',
+                        color: '#444',
+                        textTransform: 'none',
+                      },
+                      dataCells: {
+                        fontSize: '1.1em',
+                        color: 'black',
+                        verticalAlign: 'top',
+                      },
+                    }}
+                  />
+                </>
+              )}
+            <h2>Curated studies</h2>
+          </>
+        )}
+      {curatedStudies}
+    </div>
   );
 }
 

--- a/packages/libs/web-common/src/hooks/diyDatasets.ts
+++ b/packages/libs/web-common/src/hooks/diyDatasets.ts
@@ -38,8 +38,6 @@ export function useDiyDatasets() {
   const communityDatasets = useWdkService(
     async (wdkService) => {
       assertIsVdiCompatibleWdkService(wdkService);
-      const user = await wdkService.getCurrentUser();
-      if (user.isGuest) return [];
       const userDatasets = await wdkService.getCommunityDatasets();
       const unsortedDiyEntries = userDatasets
         .filter((userDataset) => userDataset.projectIds.includes(projectId))

--- a/packages/libs/web-common/src/hooks/diyDatasets.ts
+++ b/packages/libs/web-common/src/hooks/diyDatasets.ts
@@ -55,13 +55,20 @@ export function useDiyDatasets() {
   );
 }
 
-function userDatasetToMenuItem(userDataset: UserDatasetVDI) {
+export interface EnrichedUserDataset extends UserDatasetVDI {
+  wdkDatasetId: string;
+  baseEdaRoute: string;
+  userDatasetsRoute: string;
+}
+
+function userDatasetToMenuItem(
+  userDataset: UserDatasetVDI
+): EnrichedUserDataset {
   const wdkDatasetId = `EDAUD_${userDataset.datasetId}`;
   return {
-    name: userDataset.name,
     wdkDatasetId,
-    userDatasetId: userDataset.datasetId,
     baseEdaRoute: `${makeEdaRoute(wdkDatasetId)}`,
     userDatasetsRoute: `/workspace/datasets/${userDataset.datasetId}`,
+    ...userDataset,
   };
 }

--- a/packages/libs/web-common/src/hooks/diyDatasets.ts
+++ b/packages/libs/web-common/src/hooks/diyDatasets.ts
@@ -26,6 +26,8 @@ export function useDiyDatasets() {
   const diyDatasets = useWdkService(
     async (wdkService) => {
       assertIsVdiCompatibleWdkService(wdkService);
+      const user = await wdkService.getCurrentUser();
+      if (user.isGuest) return [];
       const userDatasets = await wdkService.getCurrentUserDatasets(projectId);
       const unsortedDiyEntries = userDatasets.map(userDatasetToMenuItem);
       return orderBy(unsortedDiyEntries, ({ name }) => name);
@@ -36,6 +38,8 @@ export function useDiyDatasets() {
   const communityDatasets = useWdkService(
     async (wdkService) => {
       assertIsVdiCompatibleWdkService(wdkService);
+      const user = await wdkService.getCurrentUser();
+      if (user.isGuest) return [];
       const userDatasets = await wdkService.getCommunityDatasets();
       const unsortedDiyEntries = userDatasets
         .filter((userDataset) => userDataset.projectIds.includes(projectId))

--- a/packages/libs/web-common/src/hooks/diyDatasets.ts
+++ b/packages/libs/web-common/src/hooks/diyDatasets.ts
@@ -9,6 +9,12 @@ import {
   isDiyWdkRecordId,
   wdkRecordIdToDiyUserDatasetId,
 } from '@veupathdb/wdk-client/lib/Utils/diyDatasets';
+import { assertIsVdiCompatibleWdkService } from '@veupathdb/user-datasets/lib/Service';
+import { projectId } from '../config';
+import {
+  UserDataset,
+  UserDatasetVDI,
+} from '@veupathdb/user-datasets/lib/Utils/types';
 
 export function useDiyDatasets() {
   const [requestTimestamp, setRequestTimestamp] = useState(() => Date.now());
@@ -19,40 +25,21 @@ export function useDiyDatasets() {
 
   const diyDatasets = useWdkService(
     async (wdkService) => {
-      const { records: datasetRecords } = await wdkService.getAnswerJson(
-        {
-          searchName: 'AllDatasets',
-          searchConfig: {
-            parameters: {},
-          },
-        },
-        {
-          attributes: [],
-        }
-      );
+      assertIsVdiCompatibleWdkService(wdkService);
+      const userDatasets = await wdkService.getCurrentUserDatasets(projectId);
+      const unsortedDiyEntries = userDatasets.map(userDatasetToMenuItem);
+      return orderBy(unsortedDiyEntries, ({ name }) => name);
+    },
+    [requestTimestamp]
+  );
 
-      const unsortedDiyEntries = datasetRecords.flatMap((record) => {
-        const wdkDatasetId = record.id
-          .filter((part) => part.name === 'dataset_id')
-          .map((part) => part.value)[0];
-
-        if (wdkDatasetId == null || !isDiyWdkRecordId(wdkDatasetId)) {
-          return [];
-        }
-
-        const userDatasetId = wdkRecordIdToDiyUserDatasetId(wdkDatasetId);
-
-        return [
-          {
-            name: record.displayName,
-            wdkDatasetId,
-            userDatasetId,
-            baseEdaRoute: `${makeEdaRoute(wdkDatasetId)}`,
-            userDatasetsRoute: `/workspace/datasets/${userDatasetId}`,
-          },
-        ];
-      });
-
+  const communityDatasets = useWdkService(
+    async (wdkService) => {
+      assertIsVdiCompatibleWdkService(wdkService);
+      const userDatasets = await wdkService.getCommunityDatasets();
+      const unsortedDiyEntries = userDatasets
+        .filter((userDataset) => userDataset.projectIds.includes(projectId))
+        .map(userDatasetToMenuItem);
       return orderBy(unsortedDiyEntries, ({ name }) => name);
     },
     [requestTimestamp]
@@ -61,8 +48,20 @@ export function useDiyDatasets() {
   return useMemo(
     () => ({
       diyDatasets,
+      communityDatasets,
       reloadDiyDatasets,
     }),
-    [diyDatasets, reloadDiyDatasets]
+    [diyDatasets, communityDatasets, reloadDiyDatasets]
   );
+}
+
+function userDatasetToMenuItem(userDataset: UserDatasetVDI) {
+  const wdkDatasetId = `EDAUD_${userDataset.datasetId}`;
+  return {
+    name: userDataset.name,
+    wdkDatasetId,
+    userDatasetId: userDataset.datasetId,
+    baseEdaRoute: `${makeEdaRoute(wdkDatasetId)}`,
+    userDatasetsRoute: `/workspace/datasets/${userDataset.datasetId}`,
+  };
 }

--- a/packages/libs/web-common/src/hooks/diyStudySummaries.tsx
+++ b/packages/libs/web-common/src/hooks/diyStudySummaries.tsx
@@ -6,7 +6,6 @@ import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 
 import { EnrichedUserDataset, useDiyDatasets } from './diyDatasets';
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
-import { UserDatasetVDI } from '@veupathdb/user-datasets/lib/Utils/types';
 
 interface UserStudySummaryRow {
   name: string;
@@ -17,28 +16,16 @@ interface UserStudySummaryRow {
   sharedWith: string;
 }
 
-interface UserStudyColumnOptions {
-  linkToUserDatasets?: boolean;
-}
-
-export function useDiyStudySummaryColumns(
-  options: UserStudyColumnOptions = {}
-): Column<UserStudySummaryRow>[] {
-  const { linkToUserDatasets = false } = options;
+export function useDiyStudySummaryColumns(): Column<UserStudySummaryRow>[] {
   return useMemo(
     () => [
-      linkToUserDatasets
-        ? {
-            accessor: 'userDatasetWorkspaceUrl',
-            Header: 'Name',
-            Cell: function ({ value, row }) {
-              return <Link to={value}>{row.original.name}</Link>;
-            },
-          }
-        : {
-            accessor: 'name',
-            Header: 'Name',
-          },
+      {
+        accessor: 'userDatasetWorkspaceUrl',
+        Header: 'Name',
+        Cell: function ({ value, row }) {
+          return <Link to={value}>{row.original.name}</Link>;
+        },
+      },
       {
         accessor: 'edaWorkspaceUrl',
         Header: 'Explore & analyze',

--- a/packages/libs/web-common/src/hooks/diyStudySummaries.tsx
+++ b/packages/libs/web-common/src/hooks/diyStudySummaries.tsx
@@ -1,14 +1,12 @@
 import React, { useMemo } from 'react';
-
 import { Column } from 'react-table';
-
-import { keyBy } from 'lodash';
 
 import { Link } from '@veupathdb/wdk-client/lib/Components';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
-import { assertIsVdiCompatibleWdkService } from '@veupathdb/user-datasets/lib/Service';
 
-import { useDiyDatasets } from './diyDatasets';
+import { EnrichedUserDataset, useDiyDatasets } from './diyDatasets';
+import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
+import { UserDatasetVDI } from '@veupathdb/user-datasets/lib/Utils/types';
 
 interface UserStudySummaryRow {
   name: string;
@@ -19,16 +17,28 @@ interface UserStudySummaryRow {
   sharedWith: string;
 }
 
-export function useDiyStudySummaryColumns(): Column<UserStudySummaryRow>[] {
+interface UserStudyColumnOptions {
+  linkToUserDatasets?: boolean;
+}
+
+export function useDiyStudySummaryColumns(
+  options: UserStudyColumnOptions = {}
+): Column<UserStudySummaryRow>[] {
+  const { linkToUserDatasets = false } = options;
   return useMemo(
     () => [
-      {
-        accessor: 'userDatasetWorkspaceUrl',
-        Header: 'Name',
-        Cell: function ({ value, row }) {
-          return <Link to={value}>{row.original.name}</Link>;
-        },
-      },
+      linkToUserDatasets
+        ? {
+            accessor: 'userDatasetWorkspaceUrl',
+            Header: 'Name',
+            Cell: function ({ value, row }) {
+              return <Link to={value}>{row.original.name}</Link>;
+            },
+          }
+        : {
+            accessor: 'name',
+            Header: 'Name',
+          },
       {
         accessor: 'edaWorkspaceUrl',
         Header: 'Explore & analyze',
@@ -62,56 +72,42 @@ export function useDiyStudySummaryColumns(): Column<UserStudySummaryRow>[] {
   );
 }
 
-export function useDiyStudySummaryRows(): UserStudySummaryRow[] | undefined {
+export function useDiyStudySummaryRows(): {
+  userStudySummaryRows?: UserStudySummaryRow[];
+  communityStudySummaryRows?: UserStudySummaryRow[];
+} {
   const currentUser = useWdkService(
     (wdkService) => wdkService.getCurrentUser(),
     []
   );
 
-  const currentUserDatasets = useWdkService(
-    async (wdkService) => {
-      assertIsVdiCompatibleWdkService(wdkService);
-      if (currentUser == null) {
-        return undefined;
-      }
+  const { diyDatasets, communityDatasets } = useDiyDatasets();
 
-      if (currentUser.isGuest) {
-        return [];
-      }
-      return wdkService.getCurrentUserDatasets();
-    },
-    [currentUser]
+  const userStudySummaryRows = formatDatasets(currentUser, diyDatasets);
+  const communityStudySummaryRows = formatDatasets(
+    currentUser,
+    communityDatasets
   );
 
-  const { diyDatasets } = useDiyDatasets();
+  return { userStudySummaryRows, communityStudySummaryRows };
+}
 
-  const userStudySummaryRows = useMemo(() => {
-    if (
-      currentUser == null ||
-      currentUserDatasets == null ||
-      diyDatasets == null
-    ) {
+function formatDatasets(
+  currentUser: User | undefined,
+  userDatasets: EnrichedUserDataset[] | undefined
+) {
+  return useMemo(() => {
+    if (currentUser == null || userDatasets == null) {
       return undefined;
     }
 
-    const currentUserDatasetsById = keyBy(
-      currentUserDatasets,
-      (ud) => ud.datasetId
-    );
-
-    return diyDatasets.flatMap((diyDataset) => {
-      const userDataset = currentUserDatasetsById[diyDataset.userDatasetId];
-
-      if (userDataset == null) {
-        return [];
-      }
-
+    return userDatasets.flatMap((userDataset) => {
       return [
         {
-          name: diyDataset.name,
-          userDatasetWorkspaceUrl: diyDataset.userDatasetsRoute,
-          edaWorkspaceUrl: `${diyDataset.baseEdaRoute}/new`,
-          summary: userDataset.summary ?? '',
+          name: userDataset.name,
+          userDatasetWorkspaceUrl: userDataset.userDatasetsRoute,
+          edaWorkspaceUrl: `${userDataset.baseEdaRoute}/new`,
+          summary: userDataset.description ?? '',
           owner:
             userDataset.owner.userId === currentUser.id
               ? 'Me'
@@ -120,9 +116,7 @@ export function useDiyStudySummaryRows(): UserStudySummaryRow[] | undefined {
         },
       ];
     });
-  }, [currentUser, currentUserDatasets, diyDatasets]);
-
-  return userStudySummaryRows;
+  }, [currentUser, userDatasets]);
 }
 
 function formatUser(user: {

--- a/packages/sites/clinepi-site/webapp/js/client/component-wrappers/AnswerController.jsx
+++ b/packages/sites/clinepi-site/webapp/js/client/component-wrappers/AnswerController.jsx
@@ -1,27 +1,15 @@
 import React from 'react';
 
 import StudyAnswerController from '@veupathdb/web-common/lib/component-wrappers/StudyAnswerController';
-import {
-  useEda,
-  useUserDatasetsWorkspace,
-} from '@veupathdb/web-common/lib/config';
-import {
-  useDiyStudySummaryColumns,
-  useDiyStudySummaryRows,
-} from '@veupathdb/web-common/lib/hooks/diyStudySummaries';
-
-import DataGrid from '@veupathdb/coreui/lib/components/grids/DataGrid';
 
 import { withPermissions } from '@veupathdb/study-data-access/lib/data-restriction/Permissions';
-
-import './AnswerController.scss';
 
 const ClinEpiStudyAnswerController = withPermissions(StudyAnswerController);
 
 export default (AnswerController) => (props) => {
   if (props.ownProps.recordClass === 'dataset') {
     return (
-      <ClinEpiStudyAnswerControllerContainer
+      <ClinEpiStudyAnswerController
         {...props}
         DefaultComponent={AnswerController}
       />
@@ -30,69 +18,3 @@ export default (AnswerController) => (props) => {
 
   return <AnswerController {...props} />;
 };
-
-function ClinEpiStudyAnswerControllerContainer(props) {
-  const userColumns = useDiyStudySummaryColumns({ linkToUserDatasets: true });
-  const communityColumns = useDiyStudySummaryColumns({
-    linkToUserDatasets: false,
-  });
-  const { userStudySummaryRows, communityStudySummaryRows } =
-    useDiyStudySummaryRows();
-
-  return (
-    <div className="ClinEpiStudyAnswerController">
-      {!props.stateProps.isLoading &&
-        userStudySummaryRows != null &&
-        communityStudySummaryRows != null &&
-        userColumns != null && (
-          <>
-            <h1>Study summaries</h1>
-            {useUserDatasetsWorkspace &&
-              useEda &&
-              userStudySummaryRows.length > 0 && (
-                <>
-                  <h2>My studies</h2>
-                  <DataGrid
-                    columns={userColumns}
-                    data={userStudySummaryRows}
-                    stylePreset="mesa"
-                    styleOverrides={{
-                      headerCells: {
-                        backgroundColor: '#e2e2e3',
-                        color: '#444',
-                        textTransform: 'none',
-                      },
-                      dataCells: {
-                        fontSize: '1.1em',
-                        color: 'black',
-                        verticalAlign: 'top',
-                      },
-                    }}
-                  />
-                  <h2>Community studies</h2>
-                  <DataGrid
-                    columns={communityColumns.slice(0, -1)}
-                    data={communityStudySummaryRows}
-                    stylePreset="mesa"
-                    styleOverrides={{
-                      headerCells: {
-                        backgroundColor: '#e2e2e3',
-                        color: '#444',
-                        textTransform: 'none',
-                      },
-                      dataCells: {
-                        fontSize: '1.1em',
-                        color: 'black',
-                        verticalAlign: 'top',
-                      },
-                    }}
-                  />
-                  <h2>Curated studies</h2>
-                </>
-              )}
-          </>
-        )}
-      <ClinEpiStudyAnswerController {...props} />
-    </div>
-  );
-}

--- a/packages/sites/clinepi-site/webapp/js/client/component-wrappers/AnswerController.jsx
+++ b/packages/sites/clinepi-site/webapp/js/client/component-wrappers/AnswerController.jsx
@@ -32,14 +32,19 @@ export default (AnswerController) => (props) => {
 };
 
 function ClinEpiStudyAnswerControllerContainer(props) {
-  const columns = useDiyStudySummaryColumns();
-  const userStudySummaryRows = useDiyStudySummaryRows();
+  const userColumns = useDiyStudySummaryColumns({ linkToUserDatasets: true });
+  const communityColumns = useDiyStudySummaryColumns({
+    linkToUserDatasets: false,
+  });
+  const { userStudySummaryRows, communityStudySummaryRows } =
+    useDiyStudySummaryRows();
 
   return (
     <div className="ClinEpiStudyAnswerController">
       {!props.stateProps.isLoading &&
         userStudySummaryRows != null &&
-        columns != null && (
+        communityStudySummaryRows != null &&
+        userColumns != null && (
           <>
             <h1>Study summaries</h1>
             {useUserDatasetsWorkspace &&
@@ -48,8 +53,26 @@ function ClinEpiStudyAnswerControllerContainer(props) {
                 <>
                   <h2>My studies</h2>
                   <DataGrid
-                    columns={columns}
+                    columns={userColumns}
                     data={userStudySummaryRows}
+                    stylePreset="mesa"
+                    styleOverrides={{
+                      headerCells: {
+                        backgroundColor: '#e2e2e3',
+                        color: '#444',
+                        textTransform: 'none',
+                      },
+                      dataCells: {
+                        fontSize: '1.1em',
+                        color: 'black',
+                        verticalAlign: 'top',
+                      },
+                    }}
+                  />
+                  <h2>Community studies</h2>
+                  <DataGrid
+                    columns={communityColumns.slice(0, -1)}
+                    data={communityStudySummaryRows}
                     stylePreset="mesa"
                     styleOverrides={{
                       headerCells: {

--- a/packages/sites/clinepi-site/webapp/js/client/component-wrappers/AnswerController.scss
+++ b/packages/sites/clinepi-site/webapp/js/client/component-wrappers/AnswerController.scss
@@ -1,5 +1,0 @@
-.ClinEpiStudyAnswerController {
-  .wdk-AnswerHeader {
-    display: none;
-  }
-}

--- a/packages/sites/clinepi-site/webapp/js/client/component-wrappers/SiteHeader.jsx
+++ b/packages/sites/clinepi-site/webapp/js/client/component-wrappers/SiteHeader.jsx
@@ -24,10 +24,12 @@ export default function SiteHeaderWrapper() {
 
     const permissions = usePermissions();
 
-    const { diyDatasets, reloadDiyDatasets } = useDiyDatasets();
+    const { diyDatasets, communityDatasets, reloadDiyDatasets } =
+      useDiyDatasets();
 
     // for now, we default to each studies section being open
     const [expandUserStudies, setExpandUserStudies] = useState(true);
+    const [expandCommunityStudies, setExpandCommunityStudies] = useState(true);
     const [expandCuratedStudies, setExpandCuratedStudies] = useState(true);
 
     const handleStudiesMenuSearch = useCallback(
@@ -52,18 +54,24 @@ export default function SiteHeaderWrapper() {
         makeHeaderMenuItemsFactory(
           permissions,
           diyDatasets,
+          communityDatasets,
           reloadDiyDatasets,
           expandUserStudies,
           setExpandUserStudies,
+          expandCommunityStudies,
+          setExpandCommunityStudies,
           expandCuratedStudies,
           setExpandCuratedStudies
         ),
       [
         permissions,
         diyDatasets,
+        communityDatasets,
         reloadDiyDatasets,
         expandUserStudies,
         setExpandUserStudies,
+        expandCommunityStudies,
+        setExpandCommunityStudies,
         expandCuratedStudies,
         setExpandCuratedStudies,
       ]

--- a/packages/sites/clinepi-site/webapp/js/client/data/headerMenuItems.jsx
+++ b/packages/sites/clinepi-site/webapp/js/client/data/headerMenuItems.jsx
@@ -68,7 +68,7 @@ export default function makeHeaderMenuItemsFactory(
       stripHTML(study.name.toLowerCase()).includes(searchTerm.toLowerCase())
     );
 
-    const filteredCommunityDatasets = (
+    const filteredCommunityStudies = (
       useEda && useUserDatasetsWorkspace ? communityDatasets : []
     )?.filter((dataset) =>
       stripHTML(dataset.name.toLowerCase()).includes(searchTerm.toLowerCase())
@@ -77,6 +77,15 @@ export default function makeHeaderMenuItemsFactory(
     const filteredCuratedStudies = studies.entities?.filter((study) =>
       stripHTML(study.name.toLowerCase()).includes(searchTerm.toLowerCase())
     );
+
+    const isLoadingStudies =
+      permissionsValue.loading ||
+      filteredUserStudies == null ||
+      filteredCommunityStudies == null ||
+      filteredCuratedStudies == null;
+
+    const hasUserDatasets =
+      filteredUserStudies?.length > 0 || filteredCommunityStudies?.length > 0;
 
     return {
       mainMenu: [
@@ -112,87 +121,8 @@ export default function makeHeaderMenuItemsFactory(
                 ),
               },
             ].concat(
-              filteredCuratedStudies != null &&
-                filteredUserStudies != null &&
-                filteredCommunityDatasets != null &&
-                !permissionsValue.loading
-                ? diyDatasets?.length > 0 && studies.entities?.length > 0
-                  ? // here we have user studies and curated studies, so render "My studies" and "Curated studies" sections
-                    [
-                      {
-                        isVisible: filteredUserStudies.length > 0,
-                        text: (
-                          <CollapsibleDetailsSection
-                            summary="My studies"
-                            collapsibleDetails={filteredUserStudies.map(
-                              (study, idx) => (
-                                <DIYStudyMenuItem
-                                  key={idx}
-                                  name={study.name}
-                                  link={`${study.baseEdaRoute}/new`}
-                                  isChildOfCollapsibleSection={true}
-                                />
-                              )
-                            )}
-                            showDetails={expandUserStudies}
-                            setShowDetails={setExpandUserStudies}
-                          />
-                        ),
-                      },
-                      {
-                        isVisible: filteredCommunityDatasets.length > 0,
-                        text: (
-                          <CollapsibleDetailsSection
-                            summary="Community studies"
-                            collapsibleDetails={filteredCommunityDatasets.map(
-                              (study, idx) => (
-                                <DIYStudyMenuItem
-                                  key={idx}
-                                  name={study.name}
-                                  link={`${study.baseEdaRoute}/new`}
-                                  isChildOfCollapsibleSection={true}
-                                />
-                              )
-                            )}
-                            showDetails={expandCommunityStudies}
-                            setShowDetails={setExpandCommunityStudies}
-                          />
-                        ),
-                      },
-                    ].concat([
-                      {
-                        isVisible: filteredCuratedStudies.length > 0,
-                        text: (
-                          <CollapsibleDetailsSection
-                            summary="Curated studies"
-                            collapsibleDetails={filteredCuratedStudies.map(
-                              (study, idx) => (
-                                <StudyMenuItem
-                                  key={idx}
-                                  study={study}
-                                  config={siteConfig}
-                                  permissions={permissionsValue.permissions}
-                                  isChildOfCollapsibleSection={true}
-                                />
-                              )
-                            )}
-                            showDetails={expandCuratedStudies}
-                            setShowDetails={setExpandCuratedStudies}
-                          />
-                        ),
-                      },
-                    ])
-                  : // here we do not have user studies so no need for sections, just list the studies
-                    filteredCuratedStudies.map((study) => ({
-                      text: (
-                        <StudyMenuItem
-                          study={study}
-                          config={siteConfig}
-                          permissions={permissionsValue.permissions}
-                        />
-                      ),
-                    }))
-                : [
+              isLoadingStudies
+                ? [
                     {
                       text: (
                         <i
@@ -202,6 +132,89 @@ export default function makeHeaderMenuItemsFactory(
                       ),
                     },
                   ]
+                : [].concat(
+                    filteredUserStudies == null
+                      ? []
+                      : [
+                          {
+                            isVisible: filteredUserStudies.length > 0,
+                            text: (
+                              <CollapsibleDetailsSection
+                                summary="My studies"
+                                collapsibleDetails={filteredUserStudies.map(
+                                  (study, idx) => (
+                                    <DIYStudyMenuItem
+                                      key={idx}
+                                      name={study.name}
+                                      link={`${study.baseEdaRoute}/new`}
+                                      isChildOfCollapsibleSection={true}
+                                    />
+                                  )
+                                )}
+                                showDetails={expandUserStudies}
+                                setShowDetails={setExpandUserStudies}
+                              />
+                            ),
+                          },
+                        ],
+                    filteredCommunityStudies == null
+                      ? []
+                      : [
+                          {
+                            isVisible: filteredCommunityStudies.length > 0,
+                            text: (
+                              <CollapsibleDetailsSection
+                                summary="Community studies"
+                                collapsibleDetails={filteredCommunityStudies.map(
+                                  (study, idx) => (
+                                    <DIYStudyMenuItem
+                                      key={idx}
+                                      name={study.name}
+                                      link={`${study.baseEdaRoute}/new`}
+                                      isChildOfCollapsibleSection={true}
+                                    />
+                                  )
+                                )}
+                                showDetails={expandCommunityStudies}
+                                setShowDetails={setExpandCommunityStudies}
+                              />
+                            ),
+                          },
+                        ],
+                    filteredCuratedStudies == null || permissionsValue.loading
+                      ? []
+                      : [
+                          {
+                            isVisible: filteredCuratedStudies.length > 0,
+                            text: hasUserDatasets ? (
+                              <CollapsibleDetailsSection
+                                summary="Curated studies"
+                                collapsibleDetails={filteredCuratedStudies.map(
+                                  (study, idx) => (
+                                    <StudyMenuItem
+                                      key={idx}
+                                      study={study}
+                                      config={siteConfig}
+                                      permissions={permissionsValue.permissions}
+                                      isChildOfCollapsibleSection={true}
+                                    />
+                                  )
+                                )}
+                                showDetails={expandCuratedStudies}
+                                setShowDetails={setExpandCuratedStudies}
+                              />
+                            ) : (
+                              filteredCuratedStudies.map((study) => (
+                                <StudyMenuItem
+                                  study={study}
+                                  config={siteConfig}
+                                  permissions={permissionsValue.permissions}
+                                />
+                              ))
+                            ),
+                          },
+                        ]
+                  )
             ),
         },
         {

--- a/packages/sites/clinepi-site/webapp/js/client/data/headerMenuItems.jsx
+++ b/packages/sites/clinepi-site/webapp/js/client/data/headerMenuItems.jsx
@@ -27,9 +27,12 @@ import betaImage from '@veupathdb/wdk-client/lib/Core/Style/images/beta2-30.png'
 export default function makeHeaderMenuItemsFactory(
   permissionsValue,
   diyDatasets,
+  communityDatasets,
   reloadDiyDatasets,
   expandUserStudies,
   setExpandUserStudies,
+  expandCommunityStudies,
+  setExpandCommunityStudies,
   expandCuratedStudies,
   setExpandCuratedStudies
 ) {
@@ -63,6 +66,12 @@ export default function makeHeaderMenuItemsFactory(
       useEda && useUserDatasetsWorkspace ? diyDatasets : []
     )?.filter((study) =>
       stripHTML(study.name.toLowerCase()).includes(searchTerm.toLowerCase())
+    );
+
+    const filteredCommunityDatasets = (
+      useEda && useUserDatasetsWorkspace ? communityDatasets : []
+    )?.filter((dataset) =>
+      stripHTML(dataset.name.toLowerCase()).includes(searchTerm.toLowerCase())
     );
 
     const filteredCuratedStudies = studies.entities?.filter((study) =>
@@ -105,6 +114,7 @@ export default function makeHeaderMenuItemsFactory(
             ].concat(
               filteredCuratedStudies != null &&
                 filteredUserStudies != null &&
+                filteredCommunityDatasets != null &&
                 !permissionsValue.loading
                 ? diyDatasets?.length > 0 && studies.entities?.length > 0
                   ? // here we have user studies and curated studies, so render "My studies" and "Curated studies" sections
@@ -126,6 +136,26 @@ export default function makeHeaderMenuItemsFactory(
                             )}
                             showDetails={expandUserStudies}
                             setShowDetails={setExpandUserStudies}
+                          />
+                        ),
+                      },
+                      {
+                        isVisible: filteredCommunityDatasets.length > 0,
+                        text: (
+                          <CollapsibleDetailsSection
+                            summary="Community studies"
+                            collapsibleDetails={filteredCommunityDatasets.map(
+                              (study, idx) => (
+                                <DIYStudyMenuItem
+                                  key={idx}
+                                  name={study.name}
+                                  link={`${study.baseEdaRoute}/new`}
+                                  isChildOfCollapsibleSection={true}
+                                />
+                              )
+                            )}
+                            showDetails={expandCommunityStudies}
+                            setShowDetails={setExpandCommunityStudies}
                           />
                         ),
                       },

--- a/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
+++ b/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
@@ -92,6 +92,7 @@ export const userDatasetRoutes: RouteEntry[] = [
               <ExternalContentController url={helpTabContentUrl} />
             }
             dataNoun={{ singular: 'Study', plural: 'Studies' }}
+            enablePublicUserDatasets
           />
         </Suspense>
       );

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/gene-list-export-utils.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/gene-list-export-utils.tsx
@@ -374,6 +374,7 @@ export async function uploadGeneListUserDataset(
     name: step.customName,
     summary: `Genes from step "${step.customName}"`,
     description: datasetDescription,
+    visibility: 'private',
   });
 }
 

--- a/packages/sites/mbio-site/webapp/wdkCustomization/js/client/component-wrappers/index.js
+++ b/packages/sites/mbio-site/webapp/wdkCustomization/js/client/component-wrappers/index.js
@@ -75,7 +75,8 @@ function SiteFooter() {
 
 function SiteHeader() {
   const permissions = usePermissions();
-  const { diyDatasets, reloadDiyDatasets } = useDiyDatasets();
+  const { diyDatasets, communityDatasets, reloadDiyDatasets } =
+    useDiyDatasets();
   const [searchTerm, setSearchTerm] = useSessionBackedState(
     '',
     'SiteHeader__filterString',
@@ -85,6 +86,7 @@ function SiteHeader() {
 
   // for now, we default to each studies section being open
   const [expandUserStudies, setExpandUserStudies] = useState(true);
+  const [expandCommunityStudies, setExpandCommunityStudies] = useState(true);
   const [expandCuratedStudies, setExpandCuratedStudies] = useState(true);
 
   const handleStudiesMenuSearch = useCallback(
@@ -104,9 +106,12 @@ function SiteHeader() {
       makeHeaderMenuItemsFactory(
         permissions,
         diyDatasets,
+        communityDatasets,
         reloadDiyDatasets,
         expandUserStudies,
         setExpandUserStudies,
+        expandCommunityStudies,
+        setExpandCommunityStudies,
         expandCuratedStudies,
         setExpandCuratedStudies
       ),
@@ -236,9 +241,12 @@ function getHomeContent({ studies, searches, visualizations }) {
 function makeHeaderMenuItemsFactory(
   permissionsValue,
   diyDatasets,
+  communityStudies,
   reloadDiyDatasets,
   expandUserStudies,
   setExpandUserStudies,
+  expandCommunityStudies,
+  setExpandCommunityStudies,
   expandCuratedStudies,
   setExpandCuratedStudies
 ) {
@@ -251,8 +259,14 @@ function makeHeaderMenuItemsFactory(
     const { vimeoUrl } = siteConfig;
     const searchTerm = props.searchTerm;
     const setSearchTerm = props.setSearchTerm;
+
     const filteredUserStudies = (
       useEda && useUserDatasetsWorkspace ? diyDatasets : []
+    )?.filter((study) =>
+      stripHTML(study.name.toLowerCase()).includes(searchTerm.toLowerCase())
+    );
+    const filteredCommunityStudies = (
+      useEda && useUserDatasetsWorkspace ? communityStudies : []
     )?.filter((study) =>
       stripHTML(study.name.toLowerCase()).includes(searchTerm.toLowerCase())
     );
@@ -303,6 +317,7 @@ function makeHeaderMenuItemsFactory(
               },
             ].concat(
               filteredCuratedStudies != null &&
+                filteredCommunityStudies != null &&
                 filteredUserStudies != null &&
                 !permissionsValue.loading
                 ? diyDatasets?.length > 0 && studies.entities?.length > 0
@@ -325,6 +340,26 @@ function makeHeaderMenuItemsFactory(
                             )}
                             showDetails={expandUserStudies}
                             setShowDetails={setExpandUserStudies}
+                          />
+                        ),
+                      },
+                      {
+                        isVisible: filteredCommunityStudies.length > 0,
+                        text: (
+                          <CollapsibleDetailsSection
+                            summary="Community studies"
+                            collapsibleDetails={filteredCommunityStudies.map(
+                              (study, idx) => (
+                                <DIYStudyMenuItem
+                                  key={idx}
+                                  name={study.name}
+                                  link={`${study.baseEdaRoute}/new`}
+                                  isChildOfCollapsibleSection={true}
+                                />
+                              )
+                            )}
+                            showDetails={expandCommunityStudies}
+                            setShowDetails={setExpandCommunityStudies}
                           />
                         ),
                       },

--- a/packages/sites/mbio-site/webapp/wdkCustomization/js/client/component-wrappers/index.js
+++ b/packages/sites/mbio-site/webapp/wdkCustomization/js/client/component-wrappers/index.js
@@ -275,6 +275,15 @@ function makeHeaderMenuItemsFactory(
       stripHTML(study.name.toLowerCase()).includes(searchTerm.toLowerCase())
     );
 
+    const isLoadingStudies =
+      permissionsValue.loading ||
+      filteredUserStudies == null ||
+      filteredCommunityStudies == null ||
+      filteredCuratedStudies == null;
+
+    const hasUserDatasets =
+      filteredUserStudies?.length > 0 || filteredCommunityStudies?.length > 0;
+
     const studyTableIconStyle = {
       fontSize: '1.4em',
       marginRight: '.25em',
@@ -316,87 +325,8 @@ function makeHeaderMenuItemsFactory(
                 ),
               },
             ].concat(
-              filteredCuratedStudies != null &&
-                filteredCommunityStudies != null &&
-                filteredUserStudies != null &&
-                !permissionsValue.loading
-                ? diyDatasets?.length > 0 && studies.entities?.length > 0
-                  ? // here we have user studies and curated studies, so render "My studies" and "Curated studies" sections
-                    [
-                      {
-                        isVisible: filteredUserStudies.length > 0,
-                        text: (
-                          <CollapsibleDetailsSection
-                            summary="My studies"
-                            collapsibleDetails={filteredUserStudies.map(
-                              (study, idx) => (
-                                <DIYStudyMenuItem
-                                  key={idx}
-                                  name={study.name}
-                                  link={`${study.baseEdaRoute}/new`}
-                                  isChildOfCollapsibleSection={true}
-                                />
-                              )
-                            )}
-                            showDetails={expandUserStudies}
-                            setShowDetails={setExpandUserStudies}
-                          />
-                        ),
-                      },
-                      {
-                        isVisible: filteredCommunityStudies.length > 0,
-                        text: (
-                          <CollapsibleDetailsSection
-                            summary="Community studies"
-                            collapsibleDetails={filteredCommunityStudies.map(
-                              (study, idx) => (
-                                <DIYStudyMenuItem
-                                  key={idx}
-                                  name={study.name}
-                                  link={`${study.baseEdaRoute}/new`}
-                                  isChildOfCollapsibleSection={true}
-                                />
-                              )
-                            )}
-                            showDetails={expandCommunityStudies}
-                            setShowDetails={setExpandCommunityStudies}
-                          />
-                        ),
-                      },
-                    ].concat([
-                      {
-                        isVisible: filteredCuratedStudies.length > 0,
-                        text: (
-                          <CollapsibleDetailsSection
-                            summary="Curated studies"
-                            collapsibleDetails={filteredCuratedStudies.map(
-                              (study, idx) => (
-                                <StudyMenuItem
-                                  key={idx}
-                                  study={study}
-                                  config={siteConfig}
-                                  permissions={permissionsValue.permissions}
-                                  isChildOfCollapsibleSection={true}
-                                />
-                              )
-                            )}
-                            showDetails={expandCuratedStudies}
-                            setShowDetails={setExpandCuratedStudies}
-                          />
-                        ),
-                      },
-                    ])
-                  : // here we do not have user studies so need for sections; just list the studies
-                    filteredCuratedStudies.map((study) => ({
-                      text: (
-                        <StudyMenuItem
-                          study={study}
-                          config={siteConfig}
-                          permissions={permissionsValue.permissions}
-                        />
-                      ),
-                    }))
-                : [
+              isLoadingStudies
+                ? [
                     {
                       text: (
                         <i
@@ -406,6 +336,89 @@ function makeHeaderMenuItemsFactory(
                       ),
                     },
                   ]
+                : [].concat(
+                    filteredUserStudies == null
+                      ? []
+                      : [
+                          {
+                            isVisible: filteredUserStudies.length > 0,
+                            text: (
+                              <CollapsibleDetailsSection
+                                summary="My studies"
+                                collapsibleDetails={filteredUserStudies.map(
+                                  (study, idx) => (
+                                    <DIYStudyMenuItem
+                                      key={idx}
+                                      name={study.name}
+                                      link={`${study.baseEdaRoute}/new`}
+                                      isChildOfCollapsibleSection={true}
+                                    />
+                                  )
+                                )}
+                                showDetails={expandUserStudies}
+                                setShowDetails={setExpandUserStudies}
+                              />
+                            ),
+                          },
+                        ],
+                    filteredCommunityStudies == null
+                      ? []
+                      : [
+                          {
+                            isVisible: filteredCommunityStudies.length > 0,
+                            text: (
+                              <CollapsibleDetailsSection
+                                summary="Community studies"
+                                collapsibleDetails={filteredCommunityStudies.map(
+                                  (study, idx) => (
+                                    <DIYStudyMenuItem
+                                      key={idx}
+                                      name={study.name}
+                                      link={`${study.baseEdaRoute}/new`}
+                                      isChildOfCollapsibleSection={true}
+                                    />
+                                  )
+                                )}
+                                showDetails={expandCommunityStudies}
+                                setShowDetails={setExpandCommunityStudies}
+                              />
+                            ),
+                          },
+                        ],
+                    filteredCuratedStudies == null || permissionsValue.loading
+                      ? []
+                      : [
+                          {
+                            isVisible: filteredCuratedStudies.length > 0,
+                            text: hasUserDatasets ? (
+                              <CollapsibleDetailsSection
+                                summary="Curated studies"
+                                collapsibleDetails={filteredCuratedStudies.map(
+                                  (study, idx) => (
+                                    <StudyMenuItem
+                                      key={idx}
+                                      study={study}
+                                      config={siteConfig}
+                                      permissions={permissionsValue.permissions}
+                                      isChildOfCollapsibleSection={true}
+                                    />
+                                  )
+                                )}
+                                showDetails={expandCuratedStudies}
+                                setShowDetails={setExpandCuratedStudies}
+                              />
+                            ) : (
+                              filteredCuratedStudies.map((study) => (
+                                <StudyMenuItem
+                                  study={study}
+                                  config={siteConfig}
+                                  permissions={permissionsValue.permissions}
+                                />
+                              ))
+                            ),
+                          },
+                        ]
+                  )
             ),
         },
         {

--- a/packages/sites/mbio-site/webapp/wdkCustomization/js/client/routes/userDatasetRoutes.tsx
+++ b/packages/sites/mbio-site/webapp/wdkCustomization/js/client/routes/userDatasetRoutes.tsx
@@ -78,6 +78,7 @@ export const userDatasetRoutes: RouteEntry[] = [
               <ExternalContentController url={helpTabContentUrl} />
             }
             dataNoun={{ singular: 'Study', plural: 'Studies' }}
+            enablePublicUserDatasets
           />
         </Suspense>
       );


### PR DESCRIPTION
### Summary

This PR adds the ability to make a user dataset public. This is done by setting the new `visibility` property introduces by VDI.

_This feature is only visible on clinepi and mbio sites_.

### Screenshots

#### Toggle in sharing modal
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/18a76096-dec1-4e76-aab1-35ff2516d391)

#### New "Community" column in User Datasets table
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/0db1f9c7-e22b-46a9-9b98-d7b993b3fa7e)


#### New header menu section
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/e884ada0-bdb5-481e-8912-3c5e29e7285e)

#### New section on Study Summaries page
![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/afb329a4-8ab4-426c-8e22-27d7f0779372)
