### PR TITLE
New optional Mesa inline table behaviour using tooltips

### DIFF
--- a/packages/libs/components/src/components/tidytree/TreeTable.tsx
+++ b/packages/libs/components/src/components/tidytree/TreeTable.tsx
@@ -81,6 +81,7 @@ export default function TreeTable<RowType>(props: TreeTableProps<RowType>) {
       ...props.tableProps.options,
       deriveRowClassName: (_) => rowStyleClassName,
       inline: true,
+      inlineUseTooltips: true,
       inlineMaxHeight: `${rowHeight}px`,
       inlineMaxWidth: `${maxColumnWidth}px`,
     },

--- a/packages/libs/coreui/src/components/Mesa/Ui/DataCell.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/DataCell.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import Templates from '../Templates';
 import { makeClassifier } from '../Utils/Utils';
 
+import { Tooltip } from '../../../components/info/Tooltip';
+
 const dataCellClass = makeClassifier('DataCell');
 
 class DataCell extends React.PureComponent {
@@ -64,7 +66,29 @@ class DataCell extends React.PureComponent {
     width = width ? { width, maxWidth: width, minWidth: width } : {};
     style = Object.assign({}, style, width, whiteSpace);
     className = dataCellClass() + (className ? ' ' + className : '');
-    const children = this.renderContent();
+
+    const content = this.renderContent();
+    const columnName = column.name ?? column.key;
+
+    // Ideally the tooltip would also be conditional on there
+    // being actual content, but this is not trivial without
+    // copy-pasting the getValue logic from this.renderContent().
+    // Verdict: not worth it
+    const children = options.inlineUseTooltips ? (
+      <Tooltip
+        title={
+          <>
+            {columnName && <span>{columnName}:</span>}
+            {content}
+          </>
+        }
+      >
+        {content}
+      </Tooltip>
+    ) : (
+      content
+    );
+
     const props = {
       style,
       children,

--- a/packages/libs/coreui/src/components/Mesa/Ui/DataRow.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/DataRow.jsx
@@ -44,7 +44,6 @@ class DataRow extends React.PureComponent {
     const { row, rowIndex, options } = this.props;
     const { inline, onRowClick, inlineUseTooltips } = options;
     if (!inline && !onRowClick) return;
-    console.log({ options });
     if (inline && !inlineUseTooltips)
       this.setState({ expanded: !this.state.expanded });
     if (typeof onRowClick === 'function') onRowClick(row, rowIndex);

--- a/packages/libs/coreui/src/components/Mesa/Ui/DataRow.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/DataRow.jsx
@@ -30,22 +30,23 @@ class DataRow extends React.PureComponent {
 
   expandRow() {
     const { options } = this.props;
-    if (!options.inline) return;
+    if (!options.inline || options.inlineUseTooltips) return;
     this.setState({ expanded: true });
   }
 
   collapseRow() {
     const { options } = this.props;
-    if (!options.inline) return;
+    if (!options.inline || options.inlineUseTooltips) return;
     this.setState({ expanded: false });
   }
 
   handleRowClick() {
     const { row, rowIndex, options } = this.props;
-    const { inline, onRowClick } = options;
+    const { inline, onRowClick, inlineUseTooltips } = options;
     if (!inline && !onRowClick) return;
-
-    if (inline) this.setState({ expanded: !this.state.expanded });
+    console.log({ options });
+    if (inline && !inlineUseTooltips)
+      this.setState({ expanded: !this.state.expanded });
     if (typeof onRowClick === 'function') onRowClick(row, rowIndex);
   }
 

--- a/packages/libs/coreui/src/components/Mesa/types.ts
+++ b/packages/libs/coreui/src/components/Mesa/types.ts
@@ -36,7 +36,7 @@ export interface MesaStateProps<
     inline?: boolean;
     inlineMaxWidth?: string;
     inlineMaxHeight?: string;
-    inlineUseTooltips?: boolean; // on clicking on a row, don't expand the row height-wise to show the full contents, use a tooltip instead
+    inlineUseTooltips?: boolean; // don't use onClick to show the full contents, use an onMouseOver tooltip instead
     className?: string;
     errOnOverflow?: boolean;
     editableColumns?: boolean;

--- a/packages/libs/coreui/src/components/Mesa/types.ts
+++ b/packages/libs/coreui/src/components/Mesa/types.ts
@@ -36,6 +36,7 @@ export interface MesaStateProps<
     inline?: boolean;
     inlineMaxWidth?: string;
     inlineMaxHeight?: string;
+    inlineUseTooltips?: boolean; // on clicking on a row, don't expand the row height-wise to show the full contents, use a tooltip instead
     className?: string;
     errOnOverflow?: boolean;
     editableColumns?: boolean;


### PR DESCRIPTION
Note this targets the ongoing orthogroup branch.

The default Mesa behaviour when `options.inline` is `true`, is for cell contents to be truncated so the rows are equal height. Clicking on the rows expands them to show the full contents.

This wasn't acceptable for ortho, where the tree and table alignment is messed up by expanding rows. (Also browser scroll-to behaviour is unpredictable and you can't easily find the row you expanded.)

With this PR there's a new configuration option: `inlineUseTooltips` which removes the click behaviour and adds tooltips to all table cells.

It would be nice to do this for
a) only cells with content
b) only cells that overflow

but neither are economical to implement at this time.