### PR TITLE
Userdatasets rnaseq fixes

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/Detail/BigwigDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/BigwigDatasetDetail.jsx
@@ -25,6 +25,7 @@ class BigwigDatasetDetail extends UserDatasetDetail {
     const { wdkService } = this.context;
     const { dependencies } = userDataset;
     let genome;
+    // FIXME Can a UD have multiple of these dependencies?
     dependencies.forEach(function (dependency) {
       if (dependency.resourceIdentifier.endsWith('_Genome')) {
         const regex = new RegExp(
@@ -34,6 +35,7 @@ class BigwigDatasetDetail extends UserDatasetDetail {
         genome = genomeList[1];
       }
     });
+    if (genome == null) return;
     wdkService
       .getAnswerJson(
         {

--- a/packages/libs/user-datasets/src/lib/Components/Detail/BigwigDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/BigwigDatasetDetail.jsx
@@ -21,11 +21,15 @@ class BigwigDatasetDetail extends UserDatasetDetail {
   }
 
   componentDidMount() {
-    const { userDataset } = this.props;
+    const {
+      userDataset,
+      config: { projectId },
+    } = this.props;
     const { wdkService } = this.context;
     const { dependencies } = userDataset;
+    if (!userDataset.projects.includes(projectId)) return;
     let genome;
-    // FIXME Can a UD have multiple of these dependencies?
+    // There will only ever be one such dependency in this array
     dependencies.forEach(function (dependency) {
       if (dependency.resourceIdentifier.endsWith('_Genome')) {
         const regex = new RegExp(

--- a/packages/libs/user-datasets/src/lib/Components/Detail/BigwigDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/BigwigDatasetDetail.jsx
@@ -93,9 +93,11 @@ class BigwigDatasetDetail extends UserDatasetDetail {
   renderTracksSection() {
     const { userDataset, appUrl, projectName, config, fileListing } =
       this.props;
-    const installFiles = fileListing.install?.contents?.map((file) => ({
-      dataFileName: file.fileName,
-    }));
+    const installFiles = fileListing.install?.contents
+      ?.filter((file) => file.fileName.endsWith('.bw'))
+      .map((file) => ({
+        dataFileName: file.fileName,
+      }));
     const { status } = userDataset;
 
     const rows =


### PR DESCRIPTION
Fixes #1117

This PR addresses two issues with RNA-Seq datasets:
1. Prevents a WDK search request when dependencies are not yet installed.
2. Prevents non-bigwig files from appearing in the **Genome Browser Tracks** table

When addressing the first issues, I noticed that it's feasible for there to be multiple genomic dependencies, but the code does not account for it. It will always use the last one in the array. It's possible that this will never happen in the real world, but it might be worth asking about. I will post a question on slack. 