### PR TITLE
Display invalid filters so they can be removed

### DIFF
--- a/packages/libs/eda/src/lib/core/components/FilterChipList.tsx
+++ b/packages/libs/eda/src/lib/core/components/FilterChipList.tsx
@@ -130,7 +130,7 @@ export default function FilterChipList(props: Props) {
           } else {
             return (
               <FilterChip
-                tooltipText="This filter contains a reference to a variable that does not exist for this study. Remove this filter to continue working with your analysis."
+                tooltipText="Remove this filter to continue working with your analysis. This filter contains a reference to a variable that does not exist for this study."
                 isActive={false}
                 onDelete={() => removeFilter(filter)}
                 key={`${filter.entityId}/${filter.variableId}`}

--- a/packages/libs/eda/src/lib/core/components/FilterChipList.tsx
+++ b/packages/libs/eda/src/lib/core/components/FilterChipList.tsx
@@ -5,6 +5,7 @@ import { Filter } from '../types/filter';
 import { findEntityAndVariable } from '../utils/study-metadata';
 import { ReactNode, Fragment } from 'react';
 import { VariableLink, VariableLinkConfig } from './VariableLink';
+import { colors, Warning } from '@veupathdb/coreui';
 
 // Material UI CSS declarations
 const useStyles = makeStyles((theme) => ({
@@ -127,7 +128,18 @@ export default function FilterChipList(props: Props) {
               </FilterChip>
             );
           } else {
-            return null;
+            return (
+              <FilterChip
+                tooltipText="This filter contains a reference to a variable that does not exist for this study. Remove this filter to continue working with your analysis."
+                isActive={false}
+                onDelete={() => removeFilter(filter)}
+                key={`${filter.entityId}/${filter.variableId}`}
+              >
+                <>
+                  <Warning fill={colors.warning[600]} /> Invalid filter
+                </>
+              </FilterChip>
+            );
           }
         })}
       </div>


### PR DESCRIPTION
This PR renders EDA filters with invalid variable references, so that they can be removed from an analysis. A tooltip in included, explaining why the filter is invalid.

![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/d174b6ec-94f2-45ec-88f9-283f8c42d218)
