### PR TITLE
add network selector icon

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/NetworkVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/NetworkVisualization.tsx
@@ -13,7 +13,7 @@ import { RequestOptions } from '../options/types';
 import NetworkPlot, {
   NetworkPlotProps,
 } from '@veupathdb/components/lib/plots/NetworkPlot';
-import BipartiteNetworkSVG from './selectorIcons/BipartiteNetworkSVG';
+import NetworkSVG from './selectorIcons/NetworkSVG';
 import {
   NetworkResponse,
   NetworkRequestParams,
@@ -67,7 +67,7 @@ const plotContainerStyles = {
 };
 
 export const networkVisualization = createVisualizationPlugin({
-  selectorIcon: BipartiteNetworkSVG, // Placeholder for now until ann has created a new one!
+  selectorIcon: NetworkSVG, // Placeholder for now until ann has created a new one!
   fullscreenComponent: NetworkViz,
   createDefaultConfig: createDefaultConfig,
 });

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/selectorIcons/BipartiteNetworkSVG.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/selectorIcons/BipartiteNetworkSVG.tsx
@@ -11,20 +11,10 @@ export default function BipartiteNetworkSVG({
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 500 500"
     >
-      {/* <defs>
-        <style type="text/css">
-          .primary-markers&#123;fill-rule:evenodd;clip-rule:evenodd;stroke:#FFFFFF;stroke-width:4.0441;stroke-miterlimit:10;&#125;
-          .secondary-markers&#123;fill-rule:evenodd;clip-rule:evenodd;stroke:#FFFFFF;stroke-width:4.0441;stroke-miterlimit:10;&#125;
-        </style>
-      </defs> */}
       <defs>
         <style>
-          {/* .secondary-marker&#123;fill:#9fc5df;&#125; */}
           .nodes&#123;stroke:#fff;stroke-miterlimit:10;stroke-width:4.04px;&#125;
-          {/* .primary-marker&#123;fill:#408abf;&#125; */}
           .edges&#123;fill:none;fill-rule:evenodd;stroke-linejoin:bevel;stroke-width:5.6px;&#125;
-          {/* .primary-stroke&#123;stroke:#408abf;&#125;
-          .secondary-stroke&#123;stroke:#9fc5df;&#125; */}
         </style>
       </defs>
       <g style={{ stroke: primaryColor }}>

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/selectorIcons/NetworkSVG.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/selectorIcons/NetworkSVG.tsx
@@ -1,0 +1,143 @@
+import { DuotoneSvgProps } from './types';
+
+export default function NetworkSVG({
+  primaryColor,
+  secondaryColor,
+}: DuotoneSvgProps) {
+  return (
+    // <!-- Generator: Adobe Illustrator 25.4.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+    <svg
+      id="uuid-8215261f-e96d-4a10-9dbd-5463907addab"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 500 500"
+    >
+      <defs>
+        <style>
+          .nodes&#123;stroke:#fff;stroke-miterlimit:10;stroke-width:4.04px;&#125;
+          .edges&#123;fill:none;fill-rule:evenodd;stroke-linejoin:bevel;stroke-width:5.6px;&#125;
+        </style>
+      </defs>
+      <g style={{ stroke: primaryColor }}>
+        <polyline
+          className="edges"
+          points="292.4 392.3 397.4 393.6 421.8 307.1"
+        />
+        <polyline
+          className="edges"
+          points="430.4 194.8 312.8 147.4 400.9 72.1 430.4 194.8"
+        />
+        <polyline className="edges" points="66.3 170.4 183 158.7 141.7 65.3" />
+        <polyline
+          className="edges"
+          points="116.6 432.6 90.5 300.5 191.6 353.7 116.6 432.6"
+        />
+      </g>
+      <g style={{ stroke: secondaryColor }}>
+        <polyline
+          className="edges"
+          points="183 158.7 261.2 254.5 191.6 353.7"
+        />
+        <polyline
+          className="edges"
+          points="312.8 147.4 261.2 254.5 430.4 194.8"
+        />
+      </g>
+      <g style={{ fill: primaryColor }}>
+        <circle
+          id="uuid-c5c4f58c-4ae1-4e69-930c-a6fe8cd5cb62"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="66.3"
+          cy="169.5"
+          r="16.5"
+        />
+        <circle
+          id="uuid-21785f59-91fb-4866-ad0a-b8aaf0dffbe1"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="141.7"
+          cy="65.3"
+          r="16.5"
+        />
+        <circle
+          id="uuid-aa79ac44-90b7-43e3-9063-e89ec5127190"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="116.6"
+          cy="432.6"
+          r="16.5"
+        />
+        <circle
+          id="uuid-5364b129-7945-44ff-9e62-c091258eed44"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="402"
+          cy="72.1"
+          r="16.5"
+        />
+        <circle
+          id="uuid-73ebd4e0-c455-4ee3-92cc-7350ce431000"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="430.4"
+          cy="193.9"
+          r="16.5"
+        />
+        <circle
+          id="uuid-39fd6320-aba4-4fd2-9e40-fd4e34ff04de"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="191.6"
+          cy="353.7"
+          r="16.5"
+        />
+        <circle
+          id="uuid-869f9791-cb96-4cb1-8cc6-dd55ac0c619f"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="292.4"
+          cy="390.8"
+          r="16.5"
+        />
+        <circle
+          id="uuid-6f105e62-decf-4d48-875d-285fd1099436"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="397.4"
+          cy="393.6"
+          r="16.5"
+        />
+        <circle
+          id="uuid-325dab86-8cdd-43db-81b8-b69ac7ebbebd"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="421.8"
+          cy="307.1"
+          r="16.5"
+        />
+        <circle
+          id="uuid-8c7789df-90ea-46ff-bcec-772a0385cd19"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="92.3"
+          cy="300.5"
+          r="16.5"
+        />
+        <circle
+          id="uuid-33c223b9-7ceb-423c-9d50-8e158c4b0c54"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="183"
+          cy="158.7"
+          r="16.5"
+        />
+        <circle
+          id="uuid-449fc218-e479-4e1b-a1fa-0674a9b9ab4e"
+          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          cx="312.8"
+          cy="147.4"
+          r="16.5"
+        />
+      </g>
+      <g style={{ fill: secondaryColor }}>
+        <circle
+          id="uuid-f8a68f4c-c4bd-4a49-8e2a-453c82f07fab"
+          className="uuid-d7d5c1c6-5220-44f5-ae66-18a92385fcb6"
+          cx="261.2"
+          cy="254.5"
+          r="16.5"
+        />
+      </g>
+    </svg>
+    // R = 16.53r
+  );
+}

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/selectorIcons/NetworkSVG.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/selectorIcons/NetworkSVG.tsx
@@ -45,84 +45,84 @@ export default function NetworkSVG({
       <g style={{ fill: primaryColor }}>
         <circle
           id="uuid-c5c4f58c-4ae1-4e69-930c-a6fe8cd5cb62"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="66.3"
           cy="169.5"
           r="16.5"
         />
         <circle
           id="uuid-21785f59-91fb-4866-ad0a-b8aaf0dffbe1"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="141.7"
           cy="65.3"
           r="16.5"
         />
         <circle
           id="uuid-aa79ac44-90b7-43e3-9063-e89ec5127190"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="116.6"
           cy="432.6"
           r="16.5"
         />
         <circle
           id="uuid-5364b129-7945-44ff-9e62-c091258eed44"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="402"
           cy="72.1"
           r="16.5"
         />
         <circle
           id="uuid-73ebd4e0-c455-4ee3-92cc-7350ce431000"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="430.4"
           cy="193.9"
           r="16.5"
         />
         <circle
           id="uuid-39fd6320-aba4-4fd2-9e40-fd4e34ff04de"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="191.6"
           cy="353.7"
           r="16.5"
         />
         <circle
           id="uuid-869f9791-cb96-4cb1-8cc6-dd55ac0c619f"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="292.4"
           cy="390.8"
           r="16.5"
         />
         <circle
           id="uuid-6f105e62-decf-4d48-875d-285fd1099436"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="397.4"
           cy="393.6"
           r="16.5"
         />
         <circle
           id="uuid-325dab86-8cdd-43db-81b8-b69ac7ebbebd"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="421.8"
           cy="307.1"
           r="16.5"
         />
         <circle
           id="uuid-8c7789df-90ea-46ff-bcec-772a0385cd19"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="92.3"
           cy="300.5"
           r="16.5"
         />
         <circle
           id="uuid-33c223b9-7ceb-423c-9d50-8e158c4b0c54"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="183"
           cy="158.7"
           r="16.5"
         />
         <circle
           id="uuid-449fc218-e479-4e1b-a1fa-0674a9b9ab4e"
-          className="uuid-c55ce6aa-77df-4cee-8622-d6eb7412672c"
+          className="nodes"
           cx="312.8"
           cy="147.4"
           r="16.5"
@@ -131,7 +131,7 @@ export default function NetworkSVG({
       <g style={{ fill: secondaryColor }}>
         <circle
           id="uuid-f8a68f4c-c4bd-4a49-8e2a-453c82f07fab"
-          className="uuid-d7d5c1c6-5220-44f5-ae66-18a92385fcb6"
+          className="nodes"
           cx="261.2"
           cy="254.5"
           r="16.5"


### PR DESCRIPTION
Resolves #1109 

<img width="926" alt="Screen Shot 2024-07-02 at 10 50 28 AM" src="https://github.com/VEuPathDB/web-monorepo/assets/11710234/999e857f-fb7e-4de9-98d8-f99382e9f521">


Adds network viz selector icon. Also cleans up a little old code from the bipartite selector icon.
