### PR TITLE
export both plotly plot and legend images

### DIFF
--- a/packages/libs/components/src/components/plotControls/PlotLegend.tsx
+++ b/packages/libs/components/src/components/plotControls/PlotLegend.tsx
@@ -34,6 +34,8 @@ export default function PlotLegend({
         type === 'colorscale' ||
         type === 'bubble') && (
         <div
+          // set id for export legend
+          id="plotLegend"
           style={{
             display: 'inline-block', // for general usage (e.g., story)
             border: '1px solid #dedede',

--- a/packages/libs/components/src/components/plotControls/PlotListLegend.tsx
+++ b/packages/libs/components/src/components/plotControls/PlotListLegend.tsx
@@ -269,6 +269,8 @@ export default function PlotListLegend({
                         whiteSpace: 'nowrap',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
+                        // set width to avoid unnecessary ellipsis for image export
+                        width: '100%',
                       }}
                     >
                       {item.label === 'No data' ||


### PR DESCRIPTION
Hi @dmfalke This is an attempt to possibly address https://github.com/VEuPathDB/web-monorepo/issues/946, especially based on the last/latest comment, https://github.com/VEuPathDB/web-monorepo/issues/946#issuecomment-2117931778.

I have tried many ways, even trying to use html-to-image, which is a forked version of the dom-to-image and more updated library, but realized that dom-to-image was already installed and worked just fine for our purpose so I sticked to it. There were several issues but I could manage to find ways. From my various tests, this seems to work as intended, but just in case, I made this as a draft PR as there may be a better way 🤔