### PR TITLE
Eda study data race condition

### DIFF
--- a/packages/libs/eda/src/lib/core/components/EDAAnalysisListContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/EDAAnalysisListContainer.tsx
@@ -40,7 +40,7 @@ export function EDAAnalysisListContainer(props: Props) {
   const studyMetadata = useStudyMetadata(studyId, subsettingClient);
   const contextValue = useDeepValue({
     ...studyRecordState,
-    studyMetadata,
+    studyMetadata: studyMetadata.value,
     analysisClient,
     subsettingClient,
     dataClient,

--- a/packages/libs/eda/src/lib/core/components/EDAWorkspaceContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/EDAWorkspaceContainer.tsx
@@ -44,12 +44,13 @@ export function EDAWorkspaceContainer(props: Props) {
 
   const wdkStudyRecordState = useWdkStudyRecord(studyId);
   const studyMetadata = useStudyMetadata(studyId, subsettingClient);
-  if (wdkStudyRecordState == null || studyMetadata == null) return <Loading />;
+  if (wdkStudyRecordState == null || studyMetadata.value == null)
+    return <Loading />;
   return (
     <EDAWorkspaceContainerWithLoadedData
       {...props}
       wdkStudyRecord={wdkStudyRecordState}
-      studyMetadata={studyMetadata}
+      studyMetadata={studyMetadata.value}
     />
   );
 }

--- a/packages/libs/eda/src/lib/core/hooks/study.ts
+++ b/packages/libs/eda/src/lib/core/hooks/study.ts
@@ -186,7 +186,7 @@ export function isStubEntity(entity: StudyEntity) {
 
 export function useStudyMetadata(datasetId: string, client: SubsettingClient) {
   const permissionsResponse = usePermissions();
-  const { error, value } = usePromise(
+  return usePromise(
     useCallback(async () => {
       if (permissionsResponse.loading) return;
       const { permissions } = permissionsResponse;
@@ -208,8 +208,10 @@ export function useStudyMetadata(datasetId: string, client: SubsettingClient) {
         }
         throw error;
       }
-    }, [client, datasetId, permissionsResponse])
+    }, [client, datasetId, permissionsResponse]),
+    {
+      keepPreviousValue: false,
+      throwError: true,
+    }
   );
-  if (error) throw error;
-  return value;
 }

--- a/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
+++ b/packages/sites/clinepi-site/webapp/js/client/routes/userDatasetRoutes.tsx
@@ -103,7 +103,7 @@ export const userDatasetRoutes: RouteEntry[] = [
 function useEdaStudyMetadata(wdkDatasetId: string) {
   try {
     const subsettingClient = useConfiguredSubsettingClient(edaServiceUrl);
-    return useStudyMetadata(wdkDatasetId, subsettingClient);
+    return useStudyMetadata(wdkDatasetId, subsettingClient).value;
   } catch (error) {
     console.error(error);
     return undefined;


### PR DESCRIPTION
fixes #1131 

This PR adds options to `usePromise`, allowing for more control over its behavior. This allows us to force the `value` property of the hook's return value to be `undefined` when it is in a pending state. It also allows us to force errors to be thrown.

These changes provide a more declarative interface, preventing unintentional bugs.