### PR TITLE
EDA: standalone downloads

### DIFF
--- a/packages/libs/eda/src/lib/workspace/EDAWorkspaceHeading.tsx
+++ b/packages/libs/eda/src/lib/workspace/EDAWorkspaceHeading.tsx
@@ -57,7 +57,8 @@ export function EDAWorkspaceHeading({
       permissionsValue.permissions.perDataset[
         studyRecord.attributes.dataset_id as string
       ]?.actionAuthorization.subsetting
-    );
+    ) &&
+    !isStubEntity(studyMetadata.rootEntity);
 
   useEffect(() => {
     setDialogIsOpen(false);
@@ -166,8 +167,9 @@ export function EDAWorkspaceHeading({
         isStubEntity(studyMetadata.rootEntity) && (
           <Banner
             banner={{
-              type: 'error',
-              message: 'Data for this study is not currently available.',
+              type: 'info',
+              message:
+                'This study has not been integrated into the analysis workspace, but data files are available on the Download tab.',
             }}
           />
         )}

--- a/packages/libs/eda/src/lib/workspace/StandaloneStudyPage.tsx
+++ b/packages/libs/eda/src/lib/workspace/StandaloneStudyPage.tsx
@@ -1,8 +1,11 @@
 import { ApprovalStatus } from '@veupathdb/study-data-access/lib/data-restriction/dataRestrictionHooks';
 import { usePermissions } from '@veupathdb/study-data-access/lib/data-restriction/permissionsHooks';
 import { RestrictedPage } from '@veupathdb/study-data-access/lib/data-restriction/RestrictedPage';
+import { Tabs } from '@veupathdb/wdk-client/lib/Components';
 import { RecordController } from '@veupathdb/wdk-client/lib/Controllers';
-import { useStudyRecord } from '../core';
+import { useState } from 'react';
+import { useDownloadClient, useStudyRecord } from '../core';
+import DownloadTab from './DownloadTab';
 import { EDAWorkspaceHeading } from './EDAWorkspaceHeading';
 
 interface Props {
@@ -22,6 +25,7 @@ export function StandaloneStudyPage(props: Props) {
     isStudyExplorerWorkspace = false,
   } = props;
   const studyRecord = useStudyRecord();
+  const downloadClient = useDownloadClient();
   const permissionsValue = usePermissions();
   const approvalStatus: ApprovalStatus = permissionsValue.loading
     ? 'loading'
@@ -32,12 +36,37 @@ export function StandaloneStudyPage(props: Props) {
         .studyMetadata
     ? 'approved'
     : 'not-approved';
+  const [activeTab, setActiveTab] = useState('details');
   return (
     <RestrictedPage approvalStatus={approvalStatus}>
       <EDAWorkspaceHeading
         isStudyExplorerWorkspace={isStudyExplorerWorkspace}
       />
-      <RecordController recordClass="dataset" primaryKey={studyId} />
+      <Tabs
+        tabs={[
+          {
+            key: 'details',
+            display: 'Study details',
+            content: (
+              <RecordController recordClass="dataset" primaryKey={studyId} />
+            ),
+          },
+          {
+            key: 'downloads',
+            display: 'Download',
+            content: (
+              <DownloadTab
+                downloadClient={downloadClient}
+                analysisState={undefined}
+                totalCounts={undefined}
+                filteredCounts={undefined}
+              />
+            ),
+          },
+        ]}
+        activeTab={activeTab}
+        onTabSelected={setActiveTab}
+      />
     </RestrictedPage>
   );
 }

--- a/packages/libs/eda/src/lib/workspace/StandaloneStudyPage.tsx
+++ b/packages/libs/eda/src/lib/workspace/StandaloneStudyPage.tsx
@@ -48,7 +48,9 @@ export function StandaloneStudyPage(props: Props) {
             key: 'details',
             display: 'Study details',
             content: (
-              <RecordController recordClass="dataset" primaryKey={studyId} />
+              <div style={{ minHeight: '10em' }}>
+                <RecordController recordClass="dataset" primaryKey={studyId} />
+              </div>
             ),
           },
           {


### PR DESCRIPTION
This PR adds a "Download" tab to standalone study pages in EDA

![image](https://github.com/VEuPathDB/web-monorepo/assets/365139/9bf0bb28-d179-4942-b92a-9de3524d69b2)
