### PR TITLE
Throw synchronous error in usePromise context, if `throwError` is `true`.

### DIFF
--- a/packages/libs/eda/src/lib/core/hooks/promise.ts
+++ b/packages/libs/eda/src/lib/core/hooks/promise.ts
@@ -45,9 +45,6 @@ export function usePromise<T>(
       },
       (error) => {
         if (ignoreResolve) return;
-        if (throwError) {
-          throw error;
-        }
         setState({
           error,
           pending: false,
@@ -57,6 +54,7 @@ export function usePromise<T>(
     return function cleanup() {
       ignoreResolve = true;
     };
-  }, [keepPreviousValue, task, throwError]);
+  }, [keepPreviousValue, task]);
+  if (state.error && throwError) throw state.error;
   return state;
 }


### PR DESCRIPTION
fixes #1136

This PR fixes the semantics of `throwError` such that the error can be caught by the caller of `usePromise(..., { throwError: true })`.