### PR TITLE
Orthogroup tree table  pfam filter

### DIFF
--- a/packages/libs/components/src/components/tidytree/HorizontalDendrogram.tsx
+++ b/packages/libs/components/src/components/tidytree/HorizontalDendrogram.tsx
@@ -55,6 +55,10 @@ export interface HorizontalDendrogramProps {
    * highlight whole subtrees ('monophyletic') or just leaves ('none')
    */
   highlightMode?: 'monophyletic' | 'none';
+  /**
+   * highlight color (optional - default is tidytree's yellow/orange)
+   */
+  highlightColor?: string;
 }
 
 /**
@@ -72,6 +76,7 @@ export function HorizontalDendrogram({
   options: { ruler = false, margin = [0, 0, 0, 0], interactive = true },
   highlightedNodeIds,
   highlightMode,
+  highlightColor,
   hStretch = 1.0,
   containerStyles,
 }: HorizontalDendrogramProps) {
@@ -122,6 +127,7 @@ export function HorizontalDendrogram({
       tidyTreeRef.current.setColorOptions({
         nodeColorMode: 'predicate',
         branchColorMode: highlightMode ?? 'none',
+        highlightColor: highlightColor,
         leavesOnly: true,
         predicate: (node) => highlightedNodeIds.includes(node.__data__.data.id),
         defaultBranchColor: '#333',

--- a/packages/libs/components/src/components/tidytree/TreeTable.tsx
+++ b/packages/libs/components/src/components/tidytree/TreeTable.tsx
@@ -87,6 +87,11 @@ export default function TreeTable<RowType>(props: TreeTableProps<RowType>) {
     },
   };
 
+  // if `hideTree` is used more dynamically than at present
+  // (for example if the user sorts the table)
+  // then the table container styling will need
+  // { marginLeft: hideTree ? props.treeProps.width : 0 }
+  // to stop the table jumping around horizontally
   return (
     <div
       style={{ display: 'flex', alignItems: 'flex-end', flexDirection: 'row' }}
@@ -101,7 +106,6 @@ export default function TreeTable<RowType>(props: TreeTableProps<RowType>) {
       )}
       <div
         css={{
-          marginLeft: hideTree ? props.treeProps.width : 0,
           flexGrow: 1,
           width: 1 /* arbitrary non-zero width seems necessary for flex */,
           '.DataTable': {

--- a/packages/libs/components/src/components/tidytree/TreeTable.tsx
+++ b/packages/libs/components/src/components/tidytree/TreeTable.tsx
@@ -79,7 +79,10 @@ export default function TreeTable<RowType>(props: TreeTableProps<RowType>) {
     ...props.tableProps,
     options: {
       ...props.tableProps.options,
-      deriveRowClassName: (_) => rowStyleClassName,
+      deriveRowClassName: mergeDeriveRowClassName(
+        props.tableProps.options?.deriveRowClassName,
+        (_) => rowStyleClassName
+      ),
       inline: true,
       inlineUseTooltips: true,
       inlineMaxHeight: `${rowHeight}px`,
@@ -117,4 +120,17 @@ export default function TreeTable<RowType>(props: TreeTableProps<RowType>) {
       </div>
     </div>
   );
+}
+
+function mergeDeriveRowClassName<RowType>(
+  func1: ((row: RowType) => string | undefined) | undefined,
+  func2: ((row: RowType) => string | undefined) | undefined
+): ((row: RowType) => string | undefined) | undefined {
+  if (func1 == null && func2 == null) return undefined;
+  return (row: RowType) => {
+    const className1 = func1 && func1(row);
+    const className2 = func2 && func2(row);
+    // Combine the class names that are defined
+    return [className1, className2].filter(Boolean).join(' ') || undefined;
+  };
 }

--- a/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
@@ -29,9 +29,27 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
     onClose();
   }, [shouldCloseOnSelection, selectedList]);
 
+  function truncatedButtonContent(selectedList: string[]) {
+    return (
+      <span
+        style={{
+          // this styling is copied from SelectList!
+          maxWidth: '300px',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {selectedList.join(', ')}
+      </span>
+    );
+  }
+
   const onClose = () => {
     setButtonDisplayContent(
-      selectedList.length ? selectedList.join(', ') : props.buttonDisplayContent
+      selectedList.length
+        ? truncatedButtonContent(selectedList)
+        : props.buttonDisplayContent
     );
   };
 

--- a/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
@@ -84,7 +84,9 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
       onClose={onClose}
       isDisabled={props.isDisabled}
     >
-      {wrapPopover ? wrapPopover(checkboxTree) : checkboxTree}
+      <div css={{ margin: '1em' }}>
+        {wrapPopover ? wrapPopover(checkboxTree) : checkboxTree}
+      </div>
     </PopoverButton>
   );
 }

--- a/packages/libs/coreui/src/components/inputs/checkboxes/CheckboxList.tsx
+++ b/packages/libs/coreui/src/components/inputs/checkboxes/CheckboxList.tsx
@@ -205,7 +205,7 @@ export default function CheckboxList<T>({
                   </label>
                 </Tooltip>
               ) : (
-                <label>
+                <label css={{ display: 'flex', gap: '1ex' }}>
                   <input {...sharedInputAttributes} /> {item.display}
                 </label>
               )}

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -25,6 +25,7 @@ import {
 } from 'ortho-client/utils/taxons';
 
 import './PhyleticDistributionCheckbox.scss';
+import { SelectTree } from '@veupathdb/coreui';
 
 const cx = makeClassNameHelper('PhyleticDistributionCheckbox');
 
@@ -41,6 +42,7 @@ type SelectionConfig =
   | {
       selectable: true;
       onSpeciesSelected: (selection: string[]) => void;
+      selectedSpecies: string[];
     };
 
 export function PhyleticDistributionCheckbox({
@@ -71,40 +73,42 @@ export function PhyleticDistributionCheckbox({
   );
 
   return (
-    <div className={cx()}>
-      <CheckboxTree
-        tree={prunedPhyleticDistributionUiTree}
-        getNodeId={getTaxonNodeId}
-        getNodeChildren={getNodeChildren}
-        onExpansionChange={setExpandedNodes}
-        shouldExpandOnClick={false}
-        expandedList={expandedNodes}
-        renderNode={renderNode}
-        isMultiPick={selectionConfig.selectable}
-        isSelectable={selectionConfig.selectable}
-        onSelectionChange={
-          selectionConfig.selectable
-            ? selectionConfig.onSpeciesSelected
-            : undefined
-        }
-        isSearchable
-        searchBoxPlaceholder="Type a taxonomic name"
-        searchBoxHelp={makeSearchHelpText('the taxons below')}
-        searchTerm={searchTerm}
-        onSearchTermChange={setSearchTerm}
-        searchPredicate={taxonSearchPredicate}
-        linksPosition={LinksPosition.Top}
-        additionalActions={[
-          <label className={cx('--MissingSpeciesFilter')}>
-            <Checkbox
-              value={hideMissingSpecies}
-              onChange={setHideMissingSpecies}
-            />
-            &nbsp; Hide zero counts
-          </label>,
-        ]}
-      />
-    </div>
+    <SelectTree
+      buttonDisplayContent="Species"
+      tree={prunedPhyleticDistributionUiTree}
+      getNodeId={getTaxonNodeId}
+      getNodeChildren={getNodeChildren}
+      onExpansionChange={setExpandedNodes}
+      shouldExpandOnClick={false}
+      expandedList={expandedNodes}
+      renderNode={renderNode}
+      isMultiPick={selectionConfig.selectable}
+      isSelectable={selectionConfig.selectable}
+      onSelectionChange={
+        selectionConfig.selectable
+          ? selectionConfig.onSpeciesSelected
+          : undefined
+      }
+      selectedList={
+        selectionConfig.selectable ? selectionConfig.selectedSpecies : undefined
+      }
+      isSearchable
+      searchBoxPlaceholder="Type a taxonomic name"
+      searchBoxHelp={makeSearchHelpText('the taxons below')}
+      searchTerm={searchTerm}
+      onSearchTermChange={setSearchTerm}
+      searchPredicate={taxonSearchPredicate}
+      linksPosition={LinksPosition.Top}
+      additionalActions={[
+        <label className={cx('--MissingSpeciesFilter')}>
+          <Checkbox
+            value={hideMissingSpecies}
+            onChange={setHideMissingSpecies}
+          />
+          &nbsp; Hide zero counts
+        </label>,
+      ]}
+    />
   );
 }
 

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -89,6 +89,7 @@ export function PhyleticDistributionCheckbox({
           ? selectionConfig.onSpeciesSelected
           : undefined
       }
+      shouldOnlyUpdateOnClose={true}
       selectedList={
         selectionConfig.selectable ? selectionConfig.selectedSpecies : undefined
       }

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -3,9 +3,7 @@ import React, { useMemo, useState } from 'react';
 import { orderBy } from 'lodash';
 
 import { Checkbox } from '@veupathdb/wdk-client/lib/Components';
-import CheckboxTree, {
-  LinksPosition,
-} from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
+import { LinksPosition } from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { makeSearchHelpText } from '@veupathdb/wdk-client/lib/Utils/SearchUtils';
 import {

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/RecordTable_TaxonCounts_Filter.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/RecordTable_TaxonCounts_Filter.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import { RecordTableProps, WrappedComponentProps } from './Types';
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
-import PopoverButton from '@veupathdb/coreui/lib/components/buttons/PopoverButton/PopoverButton';
 import { PhyleticDistributionCheckbox } from 'ortho-client/components/phyletic-distribution/PhyleticDistributionCheckbox';
 import { taxonCountsTableValueToMap } from './utils';
 import { useTaxonUiMetadata } from 'ortho-client/hooks/taxons';

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/RecordTable_TaxonCounts_Filter.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/RecordTable_TaxonCounts_Filter.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo } from 'react';
+import { RecordTableProps, WrappedComponentProps } from './Types';
+import { Loading } from '@veupathdb/wdk-client/lib/Components';
+import PopoverButton from '@veupathdb/coreui/lib/components/buttons/PopoverButton/PopoverButton';
+import { PhyleticDistributionCheckbox } from 'ortho-client/components/phyletic-distribution/PhyleticDistributionCheckbox';
+import { taxonCountsTableValueToMap } from './utils';
+import { useTaxonUiMetadata } from 'ortho-client/hooks/taxons';
+
+export interface Props extends WrappedComponentProps<RecordTableProps> {
+  selectedSpecies: string[];
+  onSpeciesSelected: (taxons: string[]) => void;
+}
+
+export function RecordTable_TaxonCounts_Filter({
+  value,
+  selectedSpecies,
+  onSpeciesSelected,
+}: Props) {
+  const selectionConfig = useMemo(
+    () =>
+      ({
+        selectable: true,
+        onSpeciesSelected,
+        selectedSpecies,
+      } as const),
+    [onSpeciesSelected, selectedSpecies]
+  );
+
+  const speciesCounts = useMemo(
+    () => taxonCountsTableValueToMap(value),
+    [value]
+  );
+
+  const taxonUiMetadata = useTaxonUiMetadata();
+
+  return taxonUiMetadata == null ? (
+    <Loading />
+  ) : (
+    <PhyleticDistributionCheckbox
+      selectionConfig={selectionConfig}
+      speciesCounts={speciesCounts}
+      taxonTree={taxonUiMetadata.taxonTree}
+    />
+  );
+}

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -22,6 +22,7 @@ import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
 import Mesa, { RowCounter } from '@veupathdb/coreui/lib/components/Mesa';
 import { PfamDomain } from 'ortho-client/components/pfam-domains/PfamDomain';
+import { SelectList } from '@veupathdb/coreui';
 
 type RowType = Record<string, AttributeValue>;
 const CorePeripheralFilterStates = ['both', 'core', 'peripheral'] as const;
@@ -320,67 +321,43 @@ export function RecordTable_Sequences(
   const clustalDisabled =
     highlightedNodes == null || highlightedNodes.length < 2;
 
-  const pfamMesaState: MesaStateProps<RowType> = {
-    options: {
-      isRowSelected: (row: RowType) =>
-        pfamFilterIds.includes(row.accession as string),
-    },
-    uiState: {},
-    rows: pfamRows,
-    columns: [
-      {
-        key: 'accession',
-        name: 'PFam accession',
-      },
-      {
-        key: 'symbol',
-        name: 'Symbol',
-      },
-      {
-        key: 'description',
-        name: 'Description',
-      },
-      {
-        key: 'num_proteins',
-        name: 'Count',
-        helpText: 'Number of proteins that contain this domain',
-      },
-      {
-        key: 'graphic',
-        name: 'Graphic',
-        renderCell: (cellProps: { row: RowType }) => {
-          const pfamId = cellProps.row.accession as string;
-          const symbol = cellProps.row.symbol as string;
-          return <PfamDomain pfamId={pfamId} title={`${pfamId} (${symbol})`} />;
-        },
-      },
-    ],
-    eventHandlers: {
-      onRowSelect: (row: RowType) =>
-        setPfamFilterIds((prev) => [...prev, row.accession as string]),
-      onRowDeselect: (row: RowType) =>
-        setPfamFilterIds((prev) => prev.filter((id) => id !== row.accession)),
-    },
-  };
-
   const rowCount = (filteredRows ?? sortedRows).length;
+
+  const pfamDomains = pfamRows.length > 0 && (
+    <SelectList
+      defaultButtonDisplayContent="Pfam domains"
+      items={pfamRows.map((row) => ({
+        display: (
+          <div
+            style={{
+              display: 'flex',
+              margin: '.25em 0',
+              alignItems: 'center',
+              gap: '1em',
+              verticalAlign: 'middle',
+              width: '100%',
+            }}
+          >
+            <PfamDomain
+              style={{ width: 100 }}
+              pfamId={row.accession as string}
+            />
+            <div>{row.accession}</div>
+            <div>{row.description}</div>
+            <div style={{ marginLeft: 'auto' }}>
+              {row.num_proteins} proteins
+            </div>
+          </div>
+        ),
+        value: row.accession as string,
+      }))}
+      value={pfamFilterIds}
+      onChange={setPfamFilterIds}
+    />
+  );
 
   return (
     <>
-      {pfamRows.length > 0 && (
-        <div
-          style={{
-            marginLeft: treeWidth,
-            display: 'flex',
-            flexDirection: 'row-reverse',
-          }}
-        >
-          <div>
-            <h4>PFam legend</h4>
-            <Mesa state={pfamMesaState} />
-          </div>
-        </div>
-      )}
       <div
         style={{
           marginLeft: treeWidth,
@@ -409,6 +386,7 @@ export function RecordTable_Sequences(
             />
           </div>
         </div>
+        {pfamDomains}
         <RadioButtonGroup
           options={[...CorePeripheralFilterStates]}
           optionLabels={CorePeripheralFilterStates.map(

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -23,6 +23,7 @@ import { RowCounter } from '@veupathdb/coreui/lib/components/Mesa';
 import { PfamDomain } from 'ortho-client/components/pfam-domains/PfamDomain';
 import { SelectList } from '@veupathdb/coreui';
 import { RecordTable_TaxonCounts_Filter } from './RecordTable_TaxonCounts_Filter';
+import { css, cx } from '@emotion/css';
 
 type RowType = Record<string, AttributeValue>;
 
@@ -30,6 +31,8 @@ const treeWidth = 200;
 const MIN_SEQUENCES_FOR_TREE = 3;
 const MAX_SEQUENCES_FOR_TREE = 9999;
 const MAX_SEQUENCES_TO_SHOW_ALL = 2000;
+
+const highlightColor = '#feb640';
 
 export function RecordTable_Sequences(
   props: WrappedComponentProps<RecordTableProps>
@@ -296,10 +299,22 @@ export function RecordTable_Sequences(
     );
   }
 
+  const highlightedRowClassName = cx(
+    css`
+      & td {
+        background-color: ${highlightColor} !important;
+      }
+    `
+  );
+
   const mesaState: MesaStateProps<RowType> = {
     options: {
       isRowSelected: (row: RowType) =>
         highlightedNodes.includes(row.full_id as string),
+      deriveRowClassName: (row: RowType) =>
+        highlightedNodes.includes(row.full_id as string)
+          ? highlightedRowClassName
+          : undefined,
     },
     uiState: {},
     rows: sortedRows,
@@ -317,6 +332,7 @@ export function RecordTable_Sequences(
     data: finalNewick,
     width: treeWidth,
     highlightMode: 'monophyletic' as const,
+    highlightColor,
     highlightedNodeIds: highlightedNodes,
   };
 

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -28,6 +28,7 @@ type RowType = Record<string, AttributeValue>;
 
 const treeWidth = 200;
 const MIN_SEQUENCES_FOR_TREE = 3;
+const MAX_SEQUENCES_FOR_TREE = 9999;
 const MAX_SEQUENCES_TO_SHOW_ALL = 2000;
 
 export function RecordTable_Sequences(
@@ -74,7 +75,8 @@ export function RecordTable_Sequences(
   >(numSequences > MAX_SEQUENCES_TO_SHOW_ALL ? ['core'] : []);
 
   const treeResponse = useOrthoService(
-    numSequences >= MIN_SEQUENCES_FOR_TREE
+    numSequences >= MIN_SEQUENCES_FOR_TREE &&
+      numSequences <= MAX_SEQUENCES_FOR_TREE
       ? (orthoService) => orthoService.getGroupTree(groupName)
       : () => Promise.resolve(undefined), // avoid making a request we know will fail and cause a "We're sorry, something went wrong." modal
     [groupName, numSequences]
@@ -133,7 +135,8 @@ export function RecordTable_Sequences(
   // parse the tree and other expensive processing asynchronously
   const [tree, setTree] = useState<Branch>();
   const [leaves, setLeaves] = useState<Branch[]>();
-  const [sortedRows, setSortedRows] = useState<TableValue>();
+  // default unsorted `sortedRows`!
+  const [sortedRows, setSortedRows] = useState<TableValue>(mesaRows);
 
   useEffect(() => {
     if (!treeResponse) return;
@@ -257,6 +260,7 @@ export function RecordTable_Sequences(
   if (
     !sortedRows ||
     (numSequences >= MIN_SEQUENCES_FOR_TREE &&
+      numSequences <= MAX_SEQUENCES_FOR_TREE &&
       (tree == null || treeResponse == null))
   ) {
     return (
@@ -388,9 +392,17 @@ export function RecordTable_Sequences(
 
   return (
     <>
+      {numSequences > MAX_SEQUENCES_FOR_TREE && (
+        <div>
+          <strong>
+            Note: no phylogenetic tree is displayed because this group has more
+            than {MAX_SEQUENCES_FOR_TREE.toLocaleString()} sequences.
+          </strong>
+        </div>
+      )}
       <div
         style={{
-          marginLeft: treeWidth,
+          marginLeft: finalNewick ? treeWidth : 0,
           padding: '10px',
           display: 'flex',
           flexDirection: 'row',

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -19,24 +19,12 @@ import { groupBy, difference } from 'lodash';
 import { PfamDomainArchitecture } from 'ortho-client/components/pfam-domains/PfamDomainArchitecture';
 import { extractPfamDomain } from 'ortho-client/records/utils';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
-import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
-import Mesa, { RowCounter } from '@veupathdb/coreui/lib/components/Mesa';
+import { RowCounter } from '@veupathdb/coreui/lib/components/Mesa';
 import { PfamDomain } from 'ortho-client/components/pfam-domains/PfamDomain';
 import { SelectList } from '@veupathdb/coreui';
 import { RecordTable_TaxonCounts_Filter } from './RecordTable_TaxonCounts_Filter';
 
 type RowType = Record<string, AttributeValue>;
-const CorePeripheralFilterStates = ['both', 'core', 'peripheral'] as const;
-type CorePeripheralFilterState = typeof CorePeripheralFilterStates[number];
-
-const CorePeripheralFilterStateLabels: Record<
-  CorePeripheralFilterState,
-  string
-> = {
-  both: 'Core & Peripheral',
-  core: 'Core only',
-  peripheral: 'Peripheral only',
-};
 
 const treeWidth = 200;
 const MIN_SEQUENCES_FOR_TREE = 3;

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -33,6 +33,7 @@ const MAX_SEQUENCES_FOR_TREE = 9999;
 const MAX_SEQUENCES_TO_SHOW_ALL = 2000;
 
 const highlightColor = '#feb640';
+const highlightColor50 = highlightColor + '7f';
 
 export function RecordTable_Sequences(
   props: WrappedComponentProps<RecordTableProps>
@@ -302,7 +303,7 @@ export function RecordTable_Sequences(
   const highlightedRowClassName = cx(
     css`
       & td {
-        background-color: ${highlightColor} !important;
+        background-color: ${highlightColor50} !important;
       }
     `
   );

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -435,6 +435,8 @@ export function RecordTable_Sequences(
             gap: '1em',
             alignItems: 'center',
             marginLeft: 'auto',
+            flexWrap: 'wrap',
+            justifyContent: 'flex-end',
           }}
         >
           <strong>Filters: </strong>


### PR DESCRIPTION
This PR introduces table filters to the tree table section of group pages. There are three filters: pfam domains, core/peripheral, and species.

The first two filters are applied after the popover is dismissed, while the third one is applied immediately. This is a bug, as the intended behavior is to apply the selection after the popover is dismissed. **Question: Which behavior is preferable?** 

Here is a screenshot:
![image](https://github.com/user-attachments/assets/a7fa6a10-56c4-4bca-b771-7e9658f606a0)

### TODO

- [ ] Remove "Phyletic distribution" section
- [ ] Move "Protein" section to top
- [ ] Add ability to highlight table rows from species filter