### PR TITLE
Refactor OrthoMCL's Sequences table to enable Mesa's selection column

### DIFF
--- a/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
@@ -114,14 +114,15 @@ class RecordTable extends Component {
     const columns = this.getColumns(this.props);
     const data = this.getOrderedData(this.props);
     const isOrthologTableWithData =
-      this.props.table.name === 'Orthologs' && value.length > 0;
+      this.props.orthoTableProps != null && value.length > 0;
     const clustalInputRow = isOrthologTableWithData
       ? columns.find((c) => c.name === 'clustalInput')
       : undefined;
 
     // Manipulate columns to match properties expected in Mesa
     const mesaReadyColumns = columns
-      .filter((c) => c.isDisplayable)
+      // NOTE: prefer to change ortho's clustalInput columns to not be displayable
+      .filter((c) => c.isDisplayable && c.name !== 'clustalInput')
       .map((c) => {
         const {
           name,
@@ -265,7 +266,8 @@ class RecordTable extends Component {
         sort: this.state.sort,
         expandedRows,
         filteredRowCount: mesaReadyRows.length - filteredRows.length,
-        ...(isOrthologTableWithData
+        ...(isOrthologTableWithData &&
+        this.props.orthoTableProps.groupBySelected != null
           ? { groupBySelected: this.props.orthoTableProps.groupBySelected }
           : {}),
       },

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.jsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.jsx
@@ -1,62 +1,110 @@
 import lodash from 'lodash';
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo, useRef, useState, useCallback } from 'react';
 
 // function RecordTable_TaxonCounts({ value }: WrappedComponentProps<RecordTableProps>) {
 export function RecordTable_Sequences(props) {
   const formRef = useRef(null);
-
-  function toggleAll(checked) {
-    const node = formRef.current;
-    if (node == null) return;
-    for (const input of node.querySelectorAll('input[name="msa_full_ids"]')) {
-      input.checked = checked;
-    }
-  }
+  const [selectedRowIds, setSelectedRowIds] = useState([]);
 
   const sortedValue = useSortedValue(props.value);
 
-  return (
-    <form
-      ref={formRef}
-      action="/cgi-bin/msaOrthoMCL"
-      target="_blank"
-      method="post"
-    >
-      <input type="hidden" name="project_id" value="OrthoMCL" />
-
-      <props.DefaultComponent {...props} value={sortedValue} />
-      <input
-        type="button"
-        name="CheckAll"
-        value="Check All"
-        onClick={() => toggleAll(true)}
-      />
-      <input
-        type="button"
-        name="UnCheckAll"
-        value="Uncheck All"
-        onClick={() => toggleAll(false)}
-      />
-      <br />
-      <p>
-        Please note: selecting a large number of proteins will take several
-        minutes to align.
-      </p>
-      <div id="userOptions">
-        <p>
-          Output format: &nbsp;
-          <select name="clustalOutFormat">
-            <option value="clu">Mismatches highlighted</option>
-            <option value="fasta">FASTA</option>
-            <option value="phy">PHYLIP</option>
-            <option value="st">STOCKHOLM</option>
-            <option value="vie">VIENNA</option>
-          </select>
-        </p>
-        <input type="submit" value="Run Clustal Omega for selected proteins" />
-      </div>
-    </form>
+  const isRowSelected = useCallback(
+    ({ full_id }) => selectedRowIds.includes(full_id),
+    [selectedRowIds]
   );
+
+  const onRowSelect = useCallback(
+    ({ full_id }) => setSelectedRowIds(selectedRowIds.concat(full_id)),
+    [selectedRowIds]
+  );
+
+  const onRowDeselect = useCallback(
+    ({ full_id }) =>
+      setSelectedRowIds(selectedRowIds.filter((id) => id !== full_id)),
+    [selectedRowIds]
+  );
+
+  const onMultipleRowSelect = useCallback(
+    (rows) =>
+      setSelectedRowIds(
+        selectedRowIds.concat(rows.map((row) => row['full_id']))
+      ),
+    [selectedRowIds]
+  );
+
+  const onMultipleRowDeselect = useCallback(
+    (rows) =>
+      setSelectedRowIds(
+        selectedRowIds.filter((row) => rows.includes(row['full_id']))
+      ),
+    [selectedRowIds]
+  );
+
+  if (props.value.length === 0) {
+    return <props.DefaultComponent {...props} value={sortedValue} />;
+  } else {
+    const orthoTableProps = {
+      options: {
+        isRowSelected,
+        selectedNoun: 'protein',
+        selectedPluralNoun: 'proteins',
+      },
+      eventHandlers: {
+        onRowSelect,
+        onRowDeselect,
+        onMultipleRowSelect,
+        onMultipleRowDeselect,
+      },
+      actions: [
+        {
+          selectionRequired: false,
+          element() {
+            return null;
+          },
+          callback: () => null,
+        },
+      ],
+    };
+
+    return (
+      <form
+        ref={formRef}
+        action="/cgi-bin/msaOrthoMCL"
+        target="_blank"
+        method="post"
+      >
+        <input type="hidden" name="project_id" value="OrthoMCL" />
+        {selectedRowIds.map((id) => (
+          <input key={id} type="hidden" name="msa_full_ids" value={id} />
+        ))}
+        <props.DefaultComponent
+          {...props}
+          value={sortedValue}
+          orthoTableProps={orthoTableProps}
+        />
+        <p>
+          Please note: selecting a large number of proteins will take several
+          minutes to align.
+        </p>
+        <div id="userOptions">
+          <p>
+            Output format: &nbsp;
+            <select name="clustalOutFormat">
+              <option value="clu">Mismatches highlighted</option>
+              <option value="fasta">FASTA</option>
+              <option value="phy">PHYLIP</option>
+              <option value="st">STOCKHOLM</option>
+              <option value="vie">VIENNA</option>
+            </select>
+          </p>
+          <input
+            type="submit"
+            value="Run Clustal Omega for selected proteins"
+          />
+        </div>
+      </form>
+    );
+  }
 }
 
 function useSortedValue(value) {


### PR DESCRIPTION
Resolves #1148

A couple notes:
1. I don't have an ortho dev site to run these changes on to ensure the actual POST works, but it's wired up very similarly to the genomics version that works.
2. I can make the model change to change the isDisplayable flag (or whatever it's actually called in the XML) of the clusterInput column if you think it's worth doing; again, not sure what the future of this UI is with respect to the tree diagram.