### PR TITLE
set cursor pointer for network node label

### DIFF
--- a/packages/libs/components/src/plots/Node.tsx
+++ b/packages/libs/components/src/plots/Node.tsx
@@ -90,7 +90,7 @@ export function NodeWithLabel(props: NodeWithLabelProps) {
           fill={labelColor}
           id="NodeLabelText"
           style={{
-            cursor: 'ponter',
+            cursor: 'pointer',
             zIndex: 1000,
             display: showLabel ? 'block' : hover ? 'block' : 'none',
           }}


### PR DESCRIPTION
This will address https://github.com/VEuPathDB/web-monorepo/issues/1165. 

@asizemore Simply put, it was a typo, though it took some time to find the reason as it was hard to notice 😓