### PR TITLE
Add tooltip reasons for disabled RadioButtonGroup options and style Map marker configuration panel a bit better

### DIFF
--- a/packages/libs/components/src/components/widgets/RadioButtonGroup.tsx
+++ b/packages/libs/components/src/components/widgets/RadioButtonGroup.tsx
@@ -1,10 +1,10 @@
-// widget for radio button group
 import React, { ReactNode } from 'react';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import { Typography } from '@material-ui/core';
+import { Tooltip } from '@veupathdb/coreui';
 import { DARKEST_GRAY, MEDIUM_GRAY } from '../../constants/colors';
 
 export type RadioButtonGroupProps = {
@@ -22,6 +22,10 @@ export type RadioButtonGroupProps = {
   onOptionSelected: (option: string) => void;
   /** Additional widget container styles. Optional. */
   containerStyles?: React.CSSProperties;
+  /** Additional label (title) styles. Optional. */
+  labelStyles?: React.CSSProperties;
+  /** Additional option label styles. Optional. */
+  optionLabelStyles?: React.CSSProperties;
   /** location of radio button label: start: label & button; end: button & label */
   labelPlacement?: 'start' | 'end' | 'top' | 'bottom';
   /** minimum width to set up equivalently spaced width per item */
@@ -33,7 +37,7 @@ export type RadioButtonGroupProps = {
   /** marginRight of radio button item: default 16px from MUI */
   itemMarginRight?: number | string;
   /** disabled list to disable radio button item(s): grayed out */
-  disabledList?: string[];
+  disabledList?: string[] | Map<string, ReactNode>;
 };
 
 /**
@@ -48,6 +52,8 @@ export default function RadioButtonGroup({
   selectedOption,
   onOptionSelected,
   containerStyles = {},
+  labelStyles = {},
+  optionLabelStyles = {},
   labelPlacement,
   minWidth,
   buttonColor = 'primary',
@@ -55,8 +61,20 @@ export default function RadioButtonGroup({
   itemMarginRight,
   disabledList,
 }: RadioButtonGroupProps) {
-  // perhaps not using focused?
-  // const [focused, setFocused] = useState(false);
+  const isDisabled = (option: string) => {
+    if (!disabledList) return false;
+    if (Array.isArray(disabledList)) {
+      return disabledList.includes(option);
+    }
+    return disabledList.has(option);
+  };
+
+  const getDisabledReason = (option: string) => {
+    if (disabledList instanceof Map) {
+      return disabledList.get(option);
+    }
+    return null;
+  };
 
   return (
     <div
@@ -70,14 +88,16 @@ export default function RadioButtonGroup({
         marginLeft: margins ? margins[3] : '',
         ...containerStyles,
       }}
-      // perhaps not using focused?
-      // onMouseOver={() => setFocused(true)}
-      // onMouseOut={() => setFocused(false)}
     >
       {label && (
         <Typography
           variant="button"
-          style={{ color: DARKEST_GRAY, fontWeight: 500, fontSize: '1.2em' }}
+          style={{
+            color: DARKEST_GRAY,
+            fontWeight: 500,
+            fontSize: '1.2em',
+            ...labelStyles,
+          }}
         >
           {label}
         </Typography>
@@ -89,49 +109,50 @@ export default function RadioButtonGroup({
           aria-label={`${label} control button group`}
           row={orientation === 'horizontal' ? true : false}
         >
-          {options.map((option, index) => (
-            <FormControlLabel
-              key={index}
-              value={option}
-              label={
-                optionLabels != null &&
-                optionLabels.length === options.length ? (
-                  <span
-                    style={{
-                      color: disabledList?.includes(option)
-                        ? MEDIUM_GRAY
-                        : DARKEST_GRAY,
-                      fontSize: '0.9em',
-                    }}
-                  >
-                    {optionLabels[index]}
-                  </span>
-                ) : (
-                  <span
-                    style={{
-                      color: disabledList?.includes(option)
-                        ? MEDIUM_GRAY
-                        : DARKEST_GRAY,
-                      fontSize: '0.9em',
-                    }}
-                  >
-                    {option}
-                  </span>
-                )
-              }
-              disabled={disabledList?.includes(option)}
-              labelPlacement={labelPlacement}
-              // primary: blue; secondary: red
-              control={<Radio color={buttonColor} />}
-              style={{
-                marginRight: itemMarginRight,
-                fontSize: '0.75em',
-                fontWeight: 400,
-                textTransform: 'capitalize',
-                minWidth: minWidth,
-              }}
-            />
-          ))}
+          {options.map((option, index) => {
+            const disabled = isDisabled(option);
+            const disabledReason = getDisabledReason(option);
+
+            const labelElement = (
+              <span
+                style={{
+                  color: disabled ? MEDIUM_GRAY : DARKEST_GRAY,
+                  fontSize: '0.9em',
+                  ...optionLabelStyles,
+                }}
+              >
+                {optionLabels != null && optionLabels.length === options.length
+                  ? optionLabels[index]
+                  : option}
+              </span>
+            );
+
+            const formControlLabel = (
+              <FormControlLabel
+                key={index}
+                value={option}
+                label={labelElement}
+                disabled={disabled}
+                labelPlacement={labelPlacement}
+                control={<Radio color={buttonColor} />}
+                style={{
+                  marginRight: itemMarginRight,
+                  fontSize: '0.75em',
+                  fontWeight: 400,
+                  textTransform: 'capitalize',
+                  minWidth: minWidth,
+                }}
+              />
+            );
+
+            return disabledReason ? (
+              <Tooltip title={disabledReason} key={index}>
+                {formControlLabel}
+              </Tooltip>
+            ) : (
+              formControlLabel
+            );
+          })}
         </RadioGroup>
       </FormControl>
     </div>

--- a/packages/libs/components/src/components/widgets/RadioButtonGroup.tsx
+++ b/packages/libs/components/src/components/widgets/RadioButtonGroup.tsx
@@ -36,7 +36,9 @@ export type RadioButtonGroupProps = {
   margins?: string[];
   /** marginRight of radio button item: default 16px from MUI */
   itemMarginRight?: number | string;
-  /** disabled list to disable radio button item(s): grayed out */
+  /** disabled list (same values as `options`) to disable radio button item(s): grayed out
+   * if a Map is used, then the values are used in Tooltips to explain why each option is disabled
+   */
   disabledList?: string[] | Map<string, ReactNode>;
 };
 

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/BarPlotMarkerConfigurationMenu.tsx
@@ -242,37 +242,45 @@ export function BarPlotMarkerConfigurationMenu({
           continuousMarkerPreview
         )}
       </div>
-      <div style={{ maxWidth: '360px', marginTop: '1em' }}>
-        <div
-          style={{
-            color: gray[900],
-            fontWeight: 500,
-            fontSize: '1.2em',
-            marginBottom: '0.5em',
-          }}
-        >
-          Marker X-axis controls
-        </div>
-        <RadioButtonGroup
-          containerStyles={
-            {
-              // marginTop: 20,
+      {overlayConfiguration?.overlayType === 'continuous' && (
+        <div style={{ maxWidth: '360px', marginTop: '1em' }}>
+          <div
+            style={{
+              color: gray[900],
+              fontWeight: 500,
+              fontSize: '1.2em',
+              marginBottom: '0.5em',
+            }}
+          >
+            Marker X-axis controls
+          </div>
+          <RadioButtonGroup
+            containerStyles={
+              {
+                // marginTop: 20,
+              }
             }
-          }
-          label="Binning method"
-          selectedOption={configuration.binningMethod ?? 'equalInterval'}
-          options={['equalInterval', 'quantile', 'standardDeviation']}
-          optionLabels={['Equal interval', 'Quantile (10)', 'Std. dev.']}
-          buttonColor={'primary'}
-          // margins={['-1em', '0', '0', '0em']}
-          onOptionSelected={handleBinningMethodSelection}
-          disabledList={
-            overlayConfiguration?.overlayType === 'continuous'
-              ? []
-              : ['equalInterval', 'quantile', 'standardDeviation']
-          }
-        />
-      </div>
+            label="Binning method"
+            labelStyles={{ fontSize: '1.0em', marginBottom: '-0.5em' }}
+            selectedOption={configuration.binningMethod ?? 'equalInterval'}
+            options={['equalInterval', 'quantile', 'standardDeviation']}
+            optionLabels={['Equal interval', 'Quantile (10)', 'Std. dev.']}
+            buttonColor={'primary'}
+            // margins={['-1em', '0', '0', '0em']}
+            onOptionSelected={handleBinningMethodSelection}
+            disabledList={
+              overlayConfiguration?.overlayType === 'continuous'
+                ? new Map([
+                    [
+                      'standardDeviation',
+                      'This option is currently disabled for maintenance reasons',
+                    ],
+                  ])
+                : undefined
+            }
+          />
+        </div>
+      )}
       <div style={{ maxWidth: '360px', marginTop: '1em', marginBottom: '1em' }}>
         <div
           style={{
@@ -291,6 +299,7 @@ export function BarPlotMarkerConfigurationMenu({
             }
           }
           label="Plot mode"
+          labelStyles={{ fontSize: '1.0em', marginBottom: '-0.5em' }}
           selectedOption={configuration.selectedPlotMode || 'count'}
           options={['count', 'proportion']}
           optionLabels={['Count', 'Proportion']}

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/CategoricalMarkerConfigurationTable.tsx
@@ -250,6 +250,7 @@ export function CategoricalMarkerConfigurationTable<
             // marginTop: 20,
           }
         }
+        labelStyles={{ fontSize: '1.0em', marginBottom: '-0.5em' }}
         label="Show counts for:"
         selectedOption={
           selectedCountsOption == null ? 'filtered' : selectedCountsOption

--- a/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
+++ b/packages/libs/eda/src/lib/map/analysis/MarkerConfiguration/PieMarkerConfigurationMenu.tsx
@@ -231,6 +231,7 @@ export function PieMarkerConfigurationMenu({
             }
           }
           label="Binning method"
+          labelStyles={{ fontSize: '1.0em', marginBottom: '-0.5em' }}
           selectedOption={configuration.binningMethod ?? 'equalInterval'}
           options={['equalInterval', 'quantile', 'standardDeviation']}
           optionLabels={['Equal interval', 'Quantile (10)', 'Std. dev.']}
@@ -239,8 +240,13 @@ export function PieMarkerConfigurationMenu({
           onOptionSelected={handleBinningMethodSelection}
           disabledList={
             overlayConfiguration?.overlayType === 'continuous'
-              ? []
-              : ['equalInterval', 'quantile', 'standardDeviation']
+              ? new Map([
+                  [
+                    'standardDeviation',
+                    'This option is currently disabled for maintenance reasons',
+                  ],
+                ])
+              : undefined
           }
         />
       )}


### PR DESCRIPTION
Fixes #1167 

Before / After
![image](https://github.com/user-attachments/assets/42541a44-0f01-49dd-86f8-52ee9e288ef3) ![image](https://github.com/user-attachments/assets/740d3ab9-385d-41d8-b1d0-5709e5acc7fe)

(tooltip is `This option is currently disabled for maintenance reasons`)

Before / After (notice the removal of an all-disabled "Marker X-axis controls" section)
![image](https://github.com/user-attachments/assets/49dea7fc-6193-4cec-9794-c4a064a7dc62) ![image](https://github.com/user-attachments/assets/108a37b7-44ae-4ab3-aa88-a6eb0cf1157a)

Before / After
![image](https://github.com/user-attachments/assets/569a3cf3-5345-462f-8f23-4a519cbb050f) ![image](https://github.com/user-attachments/assets/01bc3fec-1fd2-4e00-b33a-2366e737c43a)


