### PR TITLE
Restore the buttonless phyletic distribution

### DIFF
--- a/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
@@ -8,6 +8,7 @@ import CheckboxTree, {
 export interface SelectTreeProps<T> extends CheckboxTreeProps<T> {
   buttonDisplayContent: ReactNode;
   shouldCloseOnSelection?: boolean;
+  hasPopoverButton?: boolean;
   wrapPopover?: (checkboxTree: ReactNode) => ReactNode;
   isDisabled?: boolean;
   /** update `selectedList` state instantly when a selection is made (default: true) */
@@ -24,6 +25,7 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
     selectedList,
     onSelectionChange,
     shouldCloseOnSelection,
+    hasPopoverButton = true,
     instantUpdate = true,
     wrapPopover,
   } = props;
@@ -115,7 +117,7 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
     />
   );
 
-  return (
+  return hasPopoverButton ? (
     <PopoverButton
       key={shouldCloseOnSelection ? key : ''}
       buttonDisplayContent={buttonDisplayContent}
@@ -126,6 +128,8 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
         {wrapPopover ? wrapPopover(checkboxTree) : checkboxTree}
       </div>
     </PopoverButton>
+  ) : (
+    <>{wrapPopover ? wrapPopover(checkboxTree) : checkboxTree}</>
   );
 }
 

--- a/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
@@ -8,7 +8,7 @@ import CheckboxTree, {
 export interface SelectTreeProps<T> extends CheckboxTreeProps<T> {
   buttonDisplayContent: ReactNode;
   shouldCloseOnSelection?: boolean;
-  hasPopoverButton?: boolean;
+  hasPopoverButton?: boolean; // default=true
   wrapPopover?: (checkboxTree: ReactNode) => ReactNode;
   isDisabled?: boolean;
   /** update `selectedList` state instantly when a selection is made (default: true) */

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -72,6 +72,7 @@ export function PhyleticDistributionCheckbox({
 
   return (
     <SelectTree
+      hasPopoverButton={selectionConfig.selectable}
       buttonDisplayContent="Species"
       tree={prunedPhyleticDistributionUiTree}
       getNodeId={getTaxonNodeId}


### PR DESCRIPTION
Here's the phyletic distribution back at the top of the page. Species filter-drop down still works as before!


![image](https://github.com/user-attachments/assets/4eced5b7-987d-416e-bcbf-8c4036c88031)
