### PR TITLE
Wait for all content to load before rendering

### DIFF
--- a/packages/libs/eda/src/lib/workspace/PublicAnalysesRoute.tsx
+++ b/packages/libs/eda/src/lib/workspace/PublicAnalysesRoute.tsx
@@ -33,16 +33,18 @@ export function PublicAnalysesRoute({
     []
   );
 
-  const studyRecordsMetadata: StudyRecordMetadata[] = [
-    ...map(studyRecords, (record) => ({
-      id: getStudyId(record)!,
-      displayName: record.displayName ?? 'Unknown Study',
-    })),
-    ...map(communityDatasets, (ud) => ({
-      id: diyUserDatasetIdToWdkRecordId(ud.datasetId),
-      displayName: ud.name,
-    })),
-  ];
+  const studyRecordsMetadata: StudyRecordMetadata[] | undefined =
+    studyRecords &&
+      communityDatasets && [
+        ...map(studyRecords, (record) => ({
+          id: getStudyId(record)!,
+          displayName: record.displayName ?? 'Unknown Study',
+        })),
+        ...map(communityDatasets, (ud) => ({
+          id: diyUserDatasetIdToWdkRecordId(ud.datasetId),
+          displayName: ud.name,
+        })),
+      ];
 
   const location = useLocation();
   const makeAnalysisLink = useCallback(


### PR DESCRIPTION
Prevents the temporary "Unknown Study" name appearing while dataset records are loading:


https://github.com/user-attachments/assets/80e15d5d-49a6-4967-8ded-135c79172e42

