### PR TITLE
Fix how validation bundle error responses are handled

### DIFF
--- a/packages/libs/wdk-client/src/Actions/UserActions.ts
+++ b/packages/libs/wdk-client/src/Actions/UserActions.ts
@@ -17,9 +17,6 @@ import {
 } from '../Utils/WdkUser';
 import { UserProfileFormData } from '../StoreModules/UserProfileStoreModule';
 import { InferType } from 'prop-types';
-import { ValidationBundle } from '../Service/ValidationBundle';
-import { ServiceError } from '../Service/ServiceError';
-import { is } from '../Utils/Json';
 import { makeCommonErrorMessage } from '../Utils/Errors';
 
 export type Action =

--- a/packages/libs/wdk-client/src/Utils/Errors.ts
+++ b/packages/libs/wdk-client/src/Utils/Errors.ts
@@ -9,13 +9,11 @@ import {
   isServerError,
   isClientError,
   isInputError,
-  isServiceError,
 } from '../Service/ServiceError';
 import {
   ValidationBundle,
   makeErrorMessage as makeValidationBundleErrorMessage,
 } from '../Service/ValidationBundle';
-import { is } from './Json';
 
 type ErrorType<Type, Instance> = {
   type: Type;
@@ -53,23 +51,22 @@ export function getTypedError(error: unknown, info?: unknown): WdkError {
       info,
     };
   if (isClientError(error)) {
-    const validationBundle = parseJson(error.response);
-    if (is(ValidationBundle, validationBundle)) {
-      return {
-        type: 'validation',
-        message: makeValidationBundleErrorMessage(validationBundle),
-        id: uuid(),
-        error: validationBundle,
-        info,
-      };
-    }
-    return {
-      type: 'client',
-      message: error.response,
-      id: error.logMarker,
-      error,
-      info,
-    };
+    const result = ValidationBundle(parseJson(error.response));
+    return result.status === 'ok'
+      ? {
+          type: 'validation',
+          message: makeValidationBundleErrorMessage(result.value),
+          id: uuid(),
+          error: result.value,
+          info,
+        }
+      : {
+          type: 'client',
+          message: error.response,
+          id: error.logMarker,
+          error,
+          info,
+        };
   }
   if (isInputError(error))
     return {

--- a/packages/libs/wdk-client/src/Utils/Json.ts
+++ b/packages/libs/wdk-client/src/Utils/Json.ts
@@ -444,10 +444,6 @@ export function lazy<T>(decoderThunk: () => Decoder<T>) {
 // Decoder
 // -------
 
-export function is<T, S>(decoder: Decoder<T>, value: unknown): value is T {
-  return decoder(value).status === 'ok';
-}
-
 // Run `decoder` on `jsonString`
 export function decode<T>(decoder: Decoder<T>, jsonString: string): T {
   let t: any;


### PR DESCRIPTION
This PR fixes how validation bundle errors are handled. We were passing the Error object to the `ok` function from the `JSON` module, which expects a parsed json object. This PR addresses that by first parsing `error.response`, and then passing that parsed value to the `ok` function. It also moves the checks to the `clientError` block, which is when we would expect a validation bundle error.

This can be tested by attempting to register a new user using an email address associated with an existing user. The validation error should be unpacked from the validation bundle and displayed as a human-readable message:

![Screenshot from 2024-08-22 14-02-57](https://github.com/user-attachments/assets/220452c7-3b14-4c65-b210-15dc02715029)