### PR TITLE
User datasets tweaks

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
@@ -251,7 +251,7 @@ function UploadForm({
     datasetUploadType.formConfig.description?.inputProps;
 
   const summaryRequired = summaryInputProps?.required ?? true;
-  const descriptionRequired = descriptionInputProps?.required ?? true;
+  const descriptionRequired = descriptionInputProps?.required ?? false;
 
   const defaultFileInputField = (
     <FileInput
@@ -418,7 +418,7 @@ function UploadForm({
           <TextBox
             type="input"
             id="data-set-summary"
-            placeholder="brief summary of the data set contents"
+            placeholder="brief summary of the data set contents in a few sentences"
             required={summaryRequired}
             {...summaryInputProps}
             value={summary}
@@ -434,7 +434,7 @@ function UploadForm({
           </FieldLabel>
           <TextArea
             id="data-set-description"
-            placeholder="brief description of the data set contents"
+            placeholder="longer description of the data set contents"
             required={descriptionRequired}
             {...descriptionInputProps}
             value={description}

--- a/packages/libs/user-datasets/src/lib/Utils/upload-config.tsx
+++ b/packages/libs/user-datasets/src/lib/Utils/upload-config.tsx
@@ -12,14 +12,14 @@ export const uploadTypeConfig: DatasetUploadTypeConfig<ImplementedUploadTypes> =
       formConfig: {
         summary: {
           inputProps: {
-            placeholder: 'brief summary of the data set in 1-2 sentences',
+            placeholder: 'brief summary of the study in a few sentences',
           },
         },
         description: {
           inputProps: {
             required: false,
             placeholder:
-              'optional longer description of the data set including background, study objectives, methodology, etc.',
+              'optional longer description of the summary including background, study objectives, methodology, etc.',
           },
         },
         renderInfo: () => (
@@ -78,14 +78,14 @@ export const uploadTypeConfig: DatasetUploadTypeConfig<ImplementedUploadTypes> =
       formConfig: {
         summary: {
           inputProps: {
-            placeholder: 'brief summary of the data set in 1-2 sentences',
+            placeholder: 'brief summary of the study in a few sentences',
           },
         },
         description: {
           inputProps: {
             required: false,
             placeholder:
-              'optional longer description of the data set including background, study objectives, methodology, etc.',
+              'optional longer description of the study including background, study objectives, methodology, etc.',
           },
         },
         uploadMethodConfig: {

--- a/packages/libs/web-common/src/component-wrappers/AnswerController.scss
+++ b/packages/libs/web-common/src/component-wrappers/AnswerController.scss
@@ -4,6 +4,20 @@
   }
 }
 .ClinEpiStudyAnswerController {
+  h2 {
+    padding: 0;
+  }
+
+  > * + * {
+    margin-block-start: 2em;
+    margin-block-end: 2em;
+  }
+
+  > * > * + * {
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+  }
+
   .wdk-AnswerHeader {
     display: none;
   }

--- a/packages/libs/web-common/src/component-wrappers/StudyAnswerController.jsx
+++ b/packages/libs/web-common/src/component-wrappers/StudyAnswerController.jsx
@@ -109,17 +109,21 @@ function StudyAnswerController(props) {
     communityStudySummaryRows ?? []
   );
 
+  const showUserDatasetTables =
+    !props.stateProps.isLoading &&
+    userStudySummaryRows != null &&
+    communityStudySummaryRows != null;
+
   return (
-    <div className="ClinEpiStudyAnswerController">
-      {!props.stateProps.isLoading &&
-        userStudySummaryRows != null &&
-        communityStudySummaryRows != null && (
+    <>
+      <h1>Study summaries</h1>
+      <div className="ClinEpiStudyAnswerController">
+        {showUserDatasetTables && (
           <>
-            <h1>Study summaries</h1>
             {useUserDatasetsWorkspace &&
               useEda &&
               userStudySummaryRows.length > 0 && (
-                <>
+                <div>
                   <h2>My studies</h2>
                   <RecordFilter
                     searchTerm={userStudySearchTerm}
@@ -151,12 +155,12 @@ function StudyAnswerController(props) {
                       },
                     }}
                   />
-                </>
+                </div>
               )}
             {useUserDatasetsWorkspace &&
               useEda &&
               communityStudySummaryRows.length > 0 && (
-                <>
+                <div>
                   <h2>Community studies</h2>
                   <RecordFilter
                     searchTerm={communityStudySearchTerm}
@@ -188,13 +192,16 @@ function StudyAnswerController(props) {
                       },
                     }}
                   />
-                </>
+                </div>
               )}
-            <h2>Curated studies</h2>
           </>
         )}
-      {curatedStudies}
-    </div>
+        <div>
+          {showUserDatasetTables && <h2>Curated studies</h2>}
+          {curatedStudies}
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/packages/libs/web-common/src/hooks/diyStudySummaries.tsx
+++ b/packages/libs/web-common/src/hooks/diyStudySummaries.tsx
@@ -20,26 +20,10 @@ export function useDiyStudySummaryColumns(): Column<UserStudySummaryRow>[] {
   return useMemo(
     () => [
       {
-        accessor: 'userDatasetWorkspaceUrl',
+        accessor: 'edaWorkspaceUrl',
         Header: 'Name',
         Cell: function ({ value, row }) {
           return <Link to={value}>{row.original.name}</Link>;
-        },
-      },
-      {
-        accessor: 'edaWorkspaceUrl',
-        Header: 'Explore & analyze',
-        Cell: function ({ value }) {
-          return (
-            <div style={{ textAlign: 'center' }}>
-              <Link to={value} className="StudyMenuItem-RecordLink">
-                <i
-                  style={{ color: 'black', fontSize: '2em' }}
-                  className="ebrc-icon-edaIcon"
-                ></i>
-              </Link>
-            </div>
-          );
         },
       },
       {


### PR DESCRIPTION
This PR makes the following tweaks, related to user datasets:

1. Updated upload form and verbiage.
2. Removed link to user dataset workspace from summaries tables.
3. Refined vertical spacing between elements on summaries page.


**Screenshots:**

![image](https://github.com/user-attachments/assets/ae86738d-2189-498f-a42d-aafa0451c87a)

![image](https://github.com/user-attachments/assets/392814f9-7d6c-458e-b79c-aa154040aee0)
