### PR TITLE
Ortho table tweaks for OMCL7

### DIFF
--- a/packages/libs/coreui/src/components/Mesa/Ui/RowCounter.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/RowCounter.jsx
@@ -54,7 +54,16 @@ class RowCounter extends React.PureComponent {
     }
 
     return (
-      <div className="RowCounter">
+      <div
+        className="RowCounter"
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          flexDirection: 'row',
+          flexWrap: 'wrap',
+          columnGap: '1em',
+        }}
+      >
         {countString}
         {filterString}
       </div>

--- a/packages/libs/coreui/src/components/Mesa/Ui/RowCounter.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/RowCounter.jsx
@@ -54,16 +54,7 @@ class RowCounter extends React.PureComponent {
     }
 
     return (
-      <div
-        className="RowCounter"
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          flexDirection: 'row',
-          flexWrap: 'wrap',
-          columnGap: '1em',
-        }}
-      >
+      <div className="RowCounter">
         {countString}
         {filterString}
       </div>

--- a/packages/libs/coreui/src/components/Mesa/style/Ui/TableToolbar.scss
+++ b/packages/libs/coreui/src/components/Mesa/style/Ui/TableToolbar.scss
@@ -18,6 +18,14 @@
   .TableToolbar-Info {
     font-size: 80%;
     padding: 0px 20px 0px 10px;
+
+    .RowCounter {
+      display: flex;
+      justify-content: flex-start;
+      flex-direction: row;
+      flex-wrap: wrap;
+      column-gap: 1em;
+    }
   }
 
   .TableToolbar-Children {

--- a/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordFilter.tsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordFilter.tsx
@@ -24,7 +24,7 @@ type RecordFilterSelectorProps = {
 interface RecordFilterProps
   extends Omit<
     RecordFilterSelectorProps,
-    'toggleFilterFieldSelect' | 'containerClassName'
+    'toggleFilterFieldSelector' | 'containerClassName'
   > {
   searchTerm: string;
   onSearchTermChange: (searchTerm: string) => void;

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -73,7 +73,7 @@ export function PhyleticDistributionCheckbox({
   return (
     <SelectTree
       hasPopoverButton={selectionConfig.selectable}
-      buttonDisplayContent="Species"
+      buttonDisplayContent="Organism"
       tree={prunedPhyleticDistributionUiTree}
       getNodeId={getTaxonNodeId}
       getNodeChildren={getNodeChildren}

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -64,21 +64,11 @@ export function RecordTable_Sequences(
   const [highlightedNodes, setHighlightedNodes] = useState<string[]>([]);
 
   const mesaColumns: MesaColumn<RowType>[] = props.table.attributes
+    .filter(({ isDisplayable }) => isDisplayable)
     .map(({ name, displayName, type }) => ({
       key: name,
       name: displayName,
       type: type === 'link' ? 'wdkLink' : type,
-    }))
-    // and remove a raw HTML checkbox field - we'll use Mesa's built-in checkboxes for this
-    // and an object-laden 'sequence_link' field - the ID seems to be replicated in the full_id field
-    .filter(
-      ({ key }) =>
-        key !== 'clustalInput' && key !== 'full_id' && key !== 'taxon_abbrev'
-    )
-    // rename some headings (shouldn't this be done on the back end?)
-    .map((column) => ({
-      ...column,
-      name: column.name === 'Taxon' ? 'Clade' : column.name,
     }));
 
   const mesaRows = props.value;

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -499,8 +499,7 @@ export function RecordTable_Sequences(
             flexDirection: 'row',
             gap: '1em',
             alignItems: 'center',
-            flexWrap: 'wrap',
-            justifyContent: 'flex-start',
+            justifyContent: 'flex-end',
           }}
         >
           <strong>Filters: </strong>

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -71,7 +71,10 @@ export function RecordTable_Sequences(
     }))
     // and remove a raw HTML checkbox field - we'll use Mesa's built-in checkboxes for this
     // and an object-laden 'sequence_link' field - the ID seems to be replicated in the full_id field
-    .filter(({ key }) => key !== 'clustalInput' && key !== 'full_id');
+    .filter(
+      ({ key }) =>
+        key !== 'clustalInput' && key !== 'full_id' && key !== 'taxon_abbrev'
+    );
 
   const mesaRows = props.value;
   const pfamRows = props.record.tables['PFams'];

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -74,7 +74,12 @@ export function RecordTable_Sequences(
     .filter(
       ({ key }) =>
         key !== 'clustalInput' && key !== 'full_id' && key !== 'taxon_abbrev'
-    );
+    )
+    // rename some headings (shouldn't this be done on the back end?)
+    .map((column) => ({
+      ...column,
+      name: column.name === 'Taxon' ? 'Clade' : column.name,
+    }));
 
   const mesaRows = props.value;
   const pfamRows = props.record.tables['PFams'];


### PR DESCRIPTION
- [x] remove taxon abbreviation column
- [x] taxon header to "Clade"
- [x] Change filter “Species” to “Organism”
- [x] add pop-up help for the text search box (same text as in the Similar groups section)

also did

- [x] improved layout of filters (no more orphan wrapping of the reset button)