### PR TITLE
Fix issue with how a 409 response from the WDK service is handled

### DIFF
--- a/packages/libs/wdk-client/src/Service/ServiceBase.ts
+++ b/packages/libs/wdk-client/src/Service/ServiceBase.ts
@@ -529,11 +529,16 @@ export const ServiceBase = (serviceUrl: string) => {
     });
   }
 
+  function getIsInvalidating() {
+    return _isInvalidating;
+  }
+
   return {
     _version,
     _fetchJson,
     _getFromCache,
     _clearCache,
+    getIsInvalidating,
     serviceUrl,
     sendRequest,
     submitError,

--- a/packages/libs/wdk-client/src/Service/ServiceBase.ts
+++ b/packages/libs/wdk-client/src/Service/ServiceBase.ts
@@ -307,9 +307,8 @@ export const ServiceBase = (serviceUrl: string) => {
         }
 
         return response.text().then((text) => {
-          // Return a Promise that never resolves, if we get an out-of-sync response;
-          // and clear the data cache store.
           if (response.status === 409 && text === CLIENT_OUT_OF_SYNC_TEXT) {
+            // Clear the data cache store and set _isInvalidating to true.
             if (!_isInvalidating) {
               _isInvalidating = true;
               _store
@@ -328,6 +327,9 @@ export const ServiceBase = (serviceUrl: string) => {
             }
           }
 
+          // Return a Promise that never resolves if we are invalidating.
+          // This prevents additional out-of-sync responses and prevents
+          // further updates to the UI.
           if (_isInvalidating) {
             return pendingPromise as Promise<T>;
           }

--- a/packages/libs/wdk-client/src/Service/ServiceBase.ts
+++ b/packages/libs/wdk-client/src/Service/ServiceBase.ts
@@ -307,6 +307,8 @@ export const ServiceBase = (serviceUrl: string) => {
         }
 
         return response.text().then((text) => {
+          // Return a Promise that never resolves, if we get an out-of-sync response;
+          // and clear the data cache store.
           if (response.status === 409 && text === CLIENT_OUT_OF_SYNC_TEXT) {
             if (!_isInvalidating) {
               _isInvalidating = true;
@@ -323,8 +325,8 @@ export const ServiceBase = (serviceUrl: string) => {
                 .then(() => {
                   window.location.reload();
                 });
-              return pendingPromise as Promise<T>;
             }
+            return pendingPromise as Promise<T>;
           }
 
           // FIXME Get uuid from response header when available

--- a/packages/libs/wdk-client/src/Service/ServiceBase.ts
+++ b/packages/libs/wdk-client/src/Service/ServiceBase.ts
@@ -326,6 +326,9 @@ export const ServiceBase = (serviceUrl: string) => {
                   window.location.reload();
                 });
             }
+          }
+
+          if (_isInvalidating) {
             return pendingPromise as Promise<T>;
           }
 

--- a/packages/libs/wdk-client/src/StoreModules/UnhandledErrorStoreModule.ts
+++ b/packages/libs/wdk-client/src/StoreModules/UnhandledErrorStoreModule.ts
@@ -60,7 +60,9 @@ export function observe(
     'unhandledrejection'
   ).pipe(
     filter((event: PromiseRejectionEvent) => {
-      return !ignoreError(String(event.reason));
+      return (
+        !ignoreError(String(event.reason)) && !wdkService.getIsInvalidating()
+      );
     }),
     map((event: PromiseRejectionEvent) => notifyUnhandledError(event.reason))
   );
@@ -70,7 +72,7 @@ export function observe(
     'error'
   ).pipe(
     filter((event: ErrorEvent) => {
-      return !ignoreError(event.message);
+      return !ignoreError(event.message) && !wdkService.getIsInvalidating();
     }),
     map((event: ErrorEvent) => {
       return notifyUnhandledError(event.error ?? event.message);


### PR DESCRIPTION
fixes #1216

This PR addresses an issue where errors are thrown when the client is clearing the data cache store and reloading the page. 

Changes include:

- Move a return statement outside of an if-block
- Expose `_isInvalidating` and use that to suppress the error modal.

