### PR TITLE
Do not include referrer for jbrowse iframe, and address linting warnings

### DIFF
--- a/packages/libs/web-common/src/components/JbrowseIframe.tsx
+++ b/packages/libs/web-common/src/components/JbrowseIframe.tsx
@@ -140,11 +140,11 @@ export function JbrowseIframe(props: Props) {
       </div>
       <iframe
         key={'jbrowse-iframe-' + counter}
+        referrerPolicy="no-referrer"
         onLoad={onLoad}
         src={jbrowseUrl + '&tracklist=0&nav=1&overview=0&fullviewlink=0&menu=0'}
         width="100%"
         height={height}
-        scrolling="no"
         allowFullScreen={false}
       />
     </div>

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Jbrowse.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Jbrowse.tsx
@@ -42,12 +42,13 @@ export default function Jbrowse(props: Props) {
 
   return (
     <iframe
+      title="JBrowse"
+      referrerPolicy="no-referrer"
       onLoad={onLoad}
       id="jbrowse_iframe"
       src={props.src}
       width="100%"
       height="100%"
-      scrolling="no"
       allowFullScreen
     ></iframe>
   );


### PR DESCRIPTION
Fixes #1224

This PR adds a referrerPolicy that disabled the referrer header for jbrowse iframes.