### PR TITLE
remove typeof operator

### DIFF
--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetDetailController.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetDetailController.tsx
@@ -257,7 +257,7 @@ class UserDatasetDetailController extends PageController<MergedProps> {
 
     if (entry?.resource == null) return <Loading />;
 
-    const DetailView = this.getDetailView(typeof entry.resource.type);
+    const DetailView = this.getDetailView(entry.resource.type);
     return entry.resource.meta.visibility !== 'public' &&
       user &&
       user.isGuest ? (


### PR DESCRIPTION
Pass the `type` property to `getDetailView`. This fixes a bug where custom views are not being used.