### PR TITLE
Handle hash change

### DIFF
--- a/packages/libs/wdk-client/src/Core/Root.tsx
+++ b/packages/libs/wdk-client/src/Core/Root.tsx
@@ -74,6 +74,7 @@ export default class Root extends React.Component<Props, State> {
     if (!target || !(target instanceof HTMLAnchorElement)) return;
 
     let isDefaultPrevented = event.defaultPrevented;
+    let isHashChange = target.getAttribute('href')?.startsWith('#');
     let hasModifiers =
       event.metaKey ||
       event.altKey ||
@@ -89,6 +90,7 @@ export default class Root extends React.Component<Props, State> {
       hasModifiers ||
       hasTarget ||
       !href.startsWith(this.props.rootUrl) ||
+      isHashChange ||
       isRouterLink
     )
       return;

--- a/packages/libs/web-common/src/components/records/Sequence.tsx
+++ b/packages/libs/web-common/src/components/records/Sequence.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useIsRefOverflowingVertically } from '@veupathdb/wdk-client/lib/Hooks/Overflow';
 import { writeTextToClipboard } from '@veupathdb/wdk-client/lib/Utils/DomUtils';
 
-const NUM_COLS = 8000000;
+const NUM_COLS = 80;
 
 interface Props {
   accession?: string;

--- a/packages/libs/web-common/src/components/records/Sequence.tsx
+++ b/packages/libs/web-common/src/components/records/Sequence.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useIsRefOverflowingVertically } from '@veupathdb/wdk-client/lib/Hooks/Overflow';
 import { writeTextToClipboard } from '@veupathdb/wdk-client/lib/Utils/DomUtils';
 
-const NUM_COLS = 80;
+const NUM_COLS = 8000000;
 
 interface Props {
   accession?: string;

--- a/packages/libs/web-common/src/components/records/Sequence.tsx
+++ b/packages/libs/web-common/src/components/records/Sequence.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useIsRefOverflowingVertically } from '@veupathdb/wdk-client/lib/Hooks/Overflow';
 import { writeTextToClipboard } from '@veupathdb/wdk-client/lib/Utils/DomUtils';
 
-const NUM_COLS = 80;
+const NUM_COLS = 8000000;
 
 interface Props {
   accession?: string;
@@ -28,7 +28,7 @@ function Sequence(props: Props) {
   const onClickCopyButton = useCallback(() => {
     if (ref.current) {
       const sequenceLines = makeSequenceLines(ref.current.textContent ?? '');
-
+      //const sequenceLines = ref.current.textContent ?? '';
       const newClipboardLines =
         accession == null
           ? sequenceLines
@@ -48,7 +48,6 @@ function Sequence(props: Props) {
   }, [ref.current, isExpanded]);
 
   const style = {
-    width: `${NUM_COLS + 0.5}ch`,
     whiteSpace: 'break-spaces',
     wordBreak: 'break-all',
     maxHeight: isExpanded ? '' : '30vh',
@@ -145,8 +144,9 @@ Sequence.defaultProps = {
 
 function handleCopy(event: React.ClipboardEvent) {
   const string = window.getSelection()?.toString() ?? '';
-  const selection = makeSequenceLines(string).join('\n');
-  event.clipboardData.setData('text/plain', selection);
+  //const selection = makeSequenceLines(string).join('\n');
+  //event.clipboardData.setData('text/plain', selection);
+  event.clipboardData.setData('text/plain', string);
   event.preventDefault();
 }
 


### PR DESCRIPTION
This PR changes the global click handler in Root.tsx so that the browser will handle links that only contain a hash (eg, `<a href="#foo">Go to page section.</a>`).