### PR TITLE
use `useDeferredValue` to improve responsiveness of filter checkboxes 

### DIFF
--- a/packages/libs/coreui/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
@@ -2,8 +2,7 @@ import React, {
   useCallback,
   MouseEventHandler,
   useMemo,
-  useState,
-  useEffect,
+  useDeferredValue,
 } from 'react';
 import { css } from '@emotion/react';
 import { merge } from 'lodash';
@@ -1100,7 +1099,7 @@ export default CheckboxTree;
 function useTreeState<T>(props: CheckboxTreeProps<T>) {
   const {
     tree,
-    searchTerm,
+    searchTerm: volatileSearchTerm,
     searchPredicate,
     getNodeId,
     getNodeChildren,
@@ -1112,13 +1111,16 @@ function useTreeState<T>(props: CheckboxTreeProps<T>) {
     expandedList,
     filteredList,
   } = props;
+
+  const searchTerm = useDeferredValue(volatileSearchTerm);
+
   const statefulTree = useMemo(
     () => createStatefulTree(tree, getNodeChildren),
     [tree, getNodeChildren]
   );
 
   // initialize stateful tree; this immutable tree structure will be replaced with each state change
-  const makeTreeState = useCallback(() => {
+  const treeState = useMemo(() => {
     const isLeafVisible = createIsLeafVisible(
       tree,
       searchTerm,
@@ -1162,22 +1164,6 @@ function useTreeState<T>(props: CheckboxTreeProps<T>) {
     expandedList,
     filteredList,
   ]);
-
-  const [treeState, setTreeState] = useState(makeTreeState);
-
-  useEffect(() => {
-    function performUpdate() {
-      setTreeState(makeTreeState());
-    }
-    if (searchTerm) {
-      const timerId = setTimeout(performUpdate, 250);
-      return function cancel() {
-        clearTimeout(timerId);
-      };
-    } else {
-      performUpdate();
-    }
-  }, [makeTreeState, searchTerm]);
 
   return treeState;
 }

--- a/packages/libs/coreui/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/checkboxes/CheckboxTree/CheckboxTree.tsx
@@ -1099,7 +1099,6 @@ export default CheckboxTree;
 function useTreeState<T>(props: CheckboxTreeProps<T>) {
   const {
     tree,
-    searchTerm: volatileSearchTerm,
     searchPredicate,
     getNodeId,
     getNodeChildren,
@@ -1112,7 +1111,7 @@ function useTreeState<T>(props: CheckboxTreeProps<T>) {
     filteredList,
   } = props;
 
-  const searchTerm = useDeferredValue(volatileSearchTerm);
+  const searchTerm = useDeferredValue(props.searchTerm);
 
   const statefulTree = useMemo(
     () => createStatefulTree(tree, getNodeChildren),

--- a/packages/libs/coreui/src/hooks.tsx
+++ b/packages/libs/coreui/src/hooks.tsx
@@ -1,4 +1,10 @@
-import { useEffect } from 'react';
+import {
+  Dispatch,
+  SetStateAction,
+  useDeferredValue,
+  useEffect,
+  useState,
+} from 'react';
 
 export const useCoreUIFonts = () =>
   useEffect(() => {
@@ -20,3 +26,28 @@ export const useCoreUIFonts = () =>
     linkThree.setAttribute('rel', 'stylesheet');
     document.head.appendChild(linkThree);
   }, []);
+
+// This hook functions similarly to `useState`, but with the added benefit
+// of deferring updates to the state value. The primary state value (first element in the
+// returned array) is 'deferred', meaning that updates to this value are handled as low-priority
+// and can be interrupted if the state changes rapidly, preventing unnecessary re-renders.
+// This is particularly useful for expensive renders or non-urgent updates.
+//
+// The third return value represents the 'raw' or 'volatile' state, which reflects
+// the immediate state changes and should be used in UI elements that require responsive updates
+// (e.g., form inputs, user feedback). You can ignore this value if not needed, making it
+// a drop-in replacement for `useState`.
+//
+// Usage:
+// const [deferredState, setState, volatileState] = useDeferredState(initialValue);
+// - `deferredState`: Use for non-urgent rendering, allowing the UI to remain responsive.
+// - `setState`: The state setter function, as in `useState`.
+// - `volatileState`: Use when immediate, responsive updates are needed, such as in user interactions.
+export function useDeferredState<T>(
+  initialValue: T
+): [T, Dispatch<SetStateAction<T>>, T] {
+  const [volatileState, setState] = useState(initialValue);
+  const deferredState = useDeferredValue(volatileState);
+
+  return [deferredState, setState, volatileState];
+}

--- a/packages/libs/coreui/src/index.ts
+++ b/packages/libs/coreui/src/index.ts
@@ -36,3 +36,6 @@ export { default as colors } from './definitions/colors';
 
 // Icons
 export * from './components/icons';
+
+// Hooks
+export * from './hooks';

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -3,7 +3,10 @@ import React, { useMemo, useState } from 'react';
 import { orderBy } from 'lodash';
 
 import { Checkbox } from '@veupathdb/wdk-client/lib/Components';
-import { LinksPosition } from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
+import {
+  CheckboxTreeStyleSpec,
+  LinksPosition,
+} from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { makeSearchHelpText } from '@veupathdb/wdk-client/lib/Utils/SearchUtils';
 import {
@@ -26,6 +29,18 @@ import './PhyleticDistributionCheckbox.scss';
 import { SelectTree } from '@veupathdb/coreui';
 
 const cx = makeClassNameHelper('PhyleticDistributionCheckbox');
+
+const styleOverridesForPopover: CheckboxTreeStyleSpec = {
+  treeSection: {
+    container: {
+      width: 500,
+      height: 'min(600px, 75vh)',
+    },
+  },
+  searchAndFilterWrapper: {
+    width: 500,
+  },
+};
 
 interface Props {
   selectionConfig: SelectionConfig;
@@ -72,6 +87,9 @@ export function PhyleticDistributionCheckbox({
 
   return (
     <SelectTree
+      styleOverrides={
+        selectionConfig.selectable ? styleOverridesForPopover : undefined
+      }
       hasPopoverButton={selectionConfig.selectable}
       buttonDisplayContent="Organism"
       tree={prunedPhyleticDistributionUiTree}

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -1,5 +1,6 @@
 import React, {
   CSSProperties,
+  useCallback,
   useDeferredValue,
   useMemo,
   useState,
@@ -289,6 +290,14 @@ export function RecordTable_Sequences(
     [mesaColumns]
   );
 
+  const handleSpeciesSelection = useCallback(
+    (species: string[]) => {
+      setSelectedSpecies(species);
+      setTablePageNumber(1);
+    },
+    [setSelectedSpecies, setTablePageNumber]
+  );
+
   if (
     !sortedRows ||
     (numSequences >= MIN_SEQUENCES_FOR_TREE &&
@@ -440,10 +449,7 @@ export function RecordTable_Sequences(
       <RecordTable_TaxonCounts_Filter
         key={`taxonFilter-${resetCounter}`}
         selectedSpecies={volatileSelectedSpecies}
-        onSpeciesSelected={(species) => {
-          setSelectedSpecies(species);
-          setTablePageNumber(1);
-        }}
+        onSpeciesSelected={handleSpeciesSelection}
         record={props.record}
         recordClass={props.recordClass}
         table={props.recordClass.tablesMap.TaxonCounts}

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -1,4 +1,9 @@
-import React, { CSSProperties, useMemo, useState } from 'react';
+import React, {
+  CSSProperties,
+  useDeferredValue,
+  useMemo,
+  useState,
+} from 'react';
 import TreeTable from '@veupathdb/components/lib/components/tidytree/TreeTable';
 import { RecordTableProps, WrappedComponentProps } from './Types';
 import { useOrthoService } from 'ortho-client/hooks/orthoService';
@@ -46,11 +51,18 @@ export function RecordTable_Sequences(
   );
 
   const [resetCounter, setResetCounter] = useState(0); // used for forcing re-render of filter buttons
-  const [selectedSpecies, setSelectedSpecies] = useState<string[]>([]);
-  const [pfamFilterIds, setPfamFilterIds] = useState<string[]>([]);
-  const [corePeripheralFilterValue, setCorePeripheralFilterValue] = useState<
-    ('core' | 'peripheral')[]
-  >([]);
+
+  const [volatileSelectedSpecies, setSelectedSpecies] = useState<string[]>([]);
+  const selectedSpecies = useDeferredValue(volatileSelectedSpecies);
+
+  const [volatilePfamFilterIds, setPfamFilterIds] = useState<string[]>([]);
+  const pfamFilterIds = useDeferredValue(volatilePfamFilterIds);
+
+  const [volatileCorePeripheralFilterValue, setCorePeripheralFilterValue] =
+    useState<('core' | 'peripheral')[]>([]);
+  const corePeripheralFilterValue = useDeferredValue(
+    volatileCorePeripheralFilterValue
+  );
 
   const groupName = props.record.id.find(
     ({ name }) => name === 'group_name'
@@ -390,7 +402,7 @@ export function RecordTable_Sequences(
         ),
         value: formatAttributeValue(row.accession),
       }))}
-      value={pfamFilterIds}
+      value={volatilePfamFilterIds}
       onChange={(ids) => {
         setPfamFilterIds(ids);
         setTablePageNumber(1);
@@ -413,7 +425,7 @@ export function RecordTable_Sequences(
           value: 'peripheral',
         },
       ]}
-      value={corePeripheralFilterValue}
+      value={volatileCorePeripheralFilterValue}
       onChange={(value) => {
         setCorePeripheralFilterValue(value);
         setTablePageNumber(1);
@@ -427,7 +439,7 @@ export function RecordTable_Sequences(
       // eslint-disable-next-line react/jsx-pascal-case
       <RecordTable_TaxonCounts_Filter
         key={`taxonFilter-${resetCounter}`}
-        selectedSpecies={selectedSpecies}
+        selectedSpecies={volatileSelectedSpecies}
         onSpeciesSelected={(species) => {
           setSelectedSpecies(species);
           setTablePageNumber(1);

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -1,10 +1,4 @@
-import React, {
-  CSSProperties,
-  useCallback,
-  useDeferredValue,
-  useMemo,
-  useState,
-} from 'react';
+import React, { CSSProperties, useCallback, useMemo, useState } from 'react';
 import TreeTable from '@veupathdb/components/lib/components/tidytree/TreeTable';
 import { RecordTableProps, WrappedComponentProps } from './Types';
 import { useOrthoService } from 'ortho-client/hooks/orthoService';
@@ -24,7 +18,12 @@ import { extractPfamDomain } from 'ortho-client/records/utils';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 import { RowCounter } from '@veupathdb/coreui/lib/components/Mesa';
 import { PfamDomain } from 'ortho-client/components/pfam-domains/PfamDomain';
-import { FloatingButton, SelectList, Undo } from '@veupathdb/coreui';
+import {
+  FloatingButton,
+  SelectList,
+  Undo,
+  useDeferredState,
+} from '@veupathdb/coreui';
 import { RecordTable_TaxonCounts_Filter } from './RecordTable_TaxonCounts_Filter';
 import { formatAttributeValue } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { RecordFilter } from '@veupathdb/wdk-client/lib/Views/Records/RecordTable/RecordFilter';
@@ -53,17 +52,17 @@ export function RecordTable_Sequences(
 
   const [resetCounter, setResetCounter] = useState(0); // used for forcing re-render of filter buttons
 
-  const [volatileSelectedSpecies, setSelectedSpecies] = useState<string[]>([]);
-  const selectedSpecies = useDeferredValue(volatileSelectedSpecies);
+  const [selectedSpecies, setSelectedSpecies, volatileSelectedSpecies] =
+    useDeferredState<string[]>([]);
 
-  const [volatilePfamFilterIds, setPfamFilterIds] = useState<string[]>([]);
-  const pfamFilterIds = useDeferredValue(volatilePfamFilterIds);
+  const [pfamFilterIds, setPfamFilterIds, volatilePfamFilterIds] =
+    useDeferredState<string[]>([]);
 
-  const [volatileCorePeripheralFilterValue, setCorePeripheralFilterValue] =
-    useState<('core' | 'peripheral')[]>([]);
-  const corePeripheralFilterValue = useDeferredValue(
-    volatileCorePeripheralFilterValue
-  );
+  const [
+    corePeripheralFilterValue,
+    setCorePeripheralFilterValue,
+    volatileCorePeripheralFilterValue,
+  ] = useDeferredState<('core' | 'peripheral')[]>([]);
 
   const groupName = props.record.id.find(
     ({ name }) => name === 'group_name'


### PR DESCRIPTION
Interestingly this works pretty much as expected - the filter checkboxes update way before the table is rerendered. Unclicking them is the same.

All in all it's a better UX... except... when the organism filter is filtered using the text search, e.g. for 'gam'.  Then when you click on the Anopheles gambiae Pest checkbox, the behaviour is OK, but when unchecking the same box the checkbox doesn't update until the tree-table has updated. If the text search is cleared and the same checkbox is unchecked, it unchecks fairly quickly, as intended. I wonder what's going on?


Note, we could encapsulate the `useState` and `useDeferredValue` with something like this:

```
import { useState, useDeferredValue } from 'react';

function useDeferredState<T>(initialValue : T) : [T, T, Dispatch<SetStateAction<T>>] {
  const [state, setState] = useState(initialValue);
  const deferredState = useDeferredValue(state);

  return [state, deferredState, setState];
}
```
If so, where would we put it?