### PR TITLE
Override wdkService methods to omit the blast input query from WDK service requests

### DIFF
--- a/packages/libs/multi-blast/src/lib/utils/wdkServiceIntegration.ts
+++ b/packages/libs/multi-blast/src/lib/utils/wdkServiceIntegration.ts
@@ -24,6 +24,8 @@ export function wrapWdkService(
     ...wdkService,
     getBlastParamInternalValues:
       blastCompatibleWdkServiceWrappers.getBlastParamInternalValues(wdkService),
+    // Send an empty input query value, since they can potentially be very large
+    // when multiple sequences are included.
     getRefreshedDependentParams(
       questionUrlSegment,
       paramName,
@@ -43,6 +45,8 @@ export function wrapWdkService(
         paramValues
       );
     },
+    // Send an empty input query value, since they can potentially be very large
+    // when multiple sequences are included.
     getQuestionGivenParameters(questionUrlSegment, paramValues) {
       if (questionUrlSegment.endsWith('MultiBlast')) {
         paramValues = {

--- a/packages/libs/multi-blast/src/lib/utils/wdkServiceIntegration.ts
+++ b/packages/libs/multi-blast/src/lib/utils/wdkServiceIntegration.ts
@@ -5,6 +5,8 @@ import {
   record,
   string,
 } from '@veupathdb/wdk-client/lib/Utils/Json';
+import { omit } from 'lodash';
+import { BLAST_QUERY_SEQUENCE_PARAM_NAME } from './params';
 
 const blastParamInternalValues = objectOf(
   record({
@@ -22,6 +24,37 @@ export function wrapWdkService(
     ...wdkService,
     getBlastParamInternalValues:
       blastCompatibleWdkServiceWrappers.getBlastParamInternalValues(wdkService),
+    getRefreshedDependentParams(
+      questionUrlSegment,
+      paramName,
+      paramValue,
+      paramValues
+    ) {
+      if (questionUrlSegment.endsWith('MultiBlast')) {
+        paramValues = {
+          ...paramValues,
+          [BLAST_QUERY_SEQUENCE_PARAM_NAME]: '',
+        };
+      }
+      return wdkService.getRefreshedDependentParams(
+        questionUrlSegment,
+        paramName,
+        paramValue,
+        paramValues
+      );
+    },
+    getQuestionGivenParameters(questionUrlSegment, paramValues) {
+      if (questionUrlSegment.endsWith('MultiBlast')) {
+        paramValues = {
+          ...paramValues,
+          [BLAST_QUERY_SEQUENCE_PARAM_NAME]: '',
+        };
+      }
+      return wdkService.getQuestionGivenParameters(
+        questionUrlSegment,
+        paramValues
+      );
+    },
   };
 }
 


### PR DESCRIPTION
This PR removes the multi-blast input query from requests to `/refreshed-dependent-params`. Note that this also affects the revise form for individual query steps. Remove the value does not impact the response, since it is not part of the dependency chain.