### PR TITLE
Orthogroup tree table  1254 fixes

### DIFF
--- a/packages/libs/coreui/src/components/inputs/SelectList.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectList.tsx
@@ -1,6 +1,9 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 import PopoverButton from '../buttons/PopoverButton/PopoverButton';
-import CheckboxList, { CheckboxListProps } from './checkboxes/CheckboxList';
+import CheckboxList, {
+  CheckboxListProps,
+  Item,
+} from './checkboxes/CheckboxList';
 
 export interface SelectListProps<T> extends CheckboxListProps<T> {
   children?: ReactNode;
@@ -30,13 +33,13 @@ export default function SelectList<T>({
 }: SelectListProps<T>) {
   const [selected, setSelected] = useState<SelectListProps<T>['value']>(value);
   const [buttonDisplayContent, setButtonDisplayContent] = useState<ReactNode>(
-    value.length ? value.join(', ') : defaultButtonDisplayContent
+    getDisplayContent(value, items, defaultButtonDisplayContent)
   );
 
   const onClose = () => {
     onChange(selected);
     setButtonDisplayContent(
-      selected.length ? selected.join(', ') : defaultButtonDisplayContent
+      getDisplayContent(selected, items, defaultButtonDisplayContent)
     );
   };
 
@@ -61,9 +64,9 @@ export default function SelectList<T>({
     setSelected(value);
     if (instantUpdate) return; // we don't want the button text changing on every click
     setButtonDisplayContent(
-      value.length ? value.join(', ') : defaultButtonDisplayContent
+      getDisplayContent(value, items, defaultButtonDisplayContent)
     );
-  }, [value, defaultButtonDisplayContent]);
+  }, [value, items, defaultButtonDisplayContent]);
 
   const buttonLabel = (
     <span
@@ -102,4 +105,18 @@ export default function SelectList<T>({
       </div>
     </PopoverButton>
   );
+}
+
+// Returns button display content based on `value` array, mapping to display names from `items` when available.
+// If no matching display name is found, uses the value itself. Returns `defaultContent` if `value` is empty.
+function getDisplayContent<T>(
+  value: T[],
+  items: Item<T>[],
+  defaultContent: ReactNode
+): ReactNode {
+  return value.length
+    ? value
+        .map((v) => items.find((item) => item.value === v)?.display ?? v)
+        .join(', ')
+    : defaultContent;
 }

--- a/packages/libs/coreui/src/components/inputs/SelectList.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectList.tsx
@@ -18,7 +18,7 @@ export interface SelectListProps<T> extends CheckboxListProps<T> {
   instantUpdate?: boolean;
 }
 
-export default function SelectList<T>({
+export default function SelectList<T extends ReactNode>({
   name,
   items,
   value,
@@ -109,14 +109,16 @@ export default function SelectList<T>({
 
 // Returns button display content based on `value` array, mapping to display names from `items` when available.
 // If no matching display name is found, uses the value itself. Returns `defaultContent` if `value` is empty.
-function getDisplayContent<T>(
+function getDisplayContent<T extends ReactNode>(
   value: T[],
   items: Item<T>[],
   defaultContent: ReactNode
 ): ReactNode {
   return value.length
     ? value
-        .map((v) => items.find((item) => item.value === v)?.display ?? v)
-        .join(', ')
+        .map<ReactNode>(
+          (v) => items.find((item) => item.value === v)?.display ?? v
+        )
+        .reduce((accum, elem) => (accum ? [accum, ',', elem] : elem), null)
     : defaultContent;
 }

--- a/packages/libs/coreui/src/components/inputs/SelectList.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectList.tsx
@@ -5,7 +5,8 @@ import CheckboxList, {
   Item,
 } from './checkboxes/CheckboxList';
 
-export interface SelectListProps<T> extends CheckboxListProps<T> {
+export interface SelectListProps<T extends string>
+  extends CheckboxListProps<T> {
   children?: ReactNode;
   /** A button's content if/when no values are currently selected */
   defaultButtonDisplayContent: ReactNode;
@@ -18,7 +19,7 @@ export interface SelectListProps<T> extends CheckboxListProps<T> {
   instantUpdate?: boolean;
 }
 
-export default function SelectList<T extends ReactNode>({
+export default function SelectList<T extends string>({
   name,
   items,
   value,
@@ -109,7 +110,7 @@ export default function SelectList<T extends ReactNode>({
 
 // Returns button display content based on `value` array, mapping to display names from `items` when available.
 // If no matching display name is found, uses the value itself. Returns `defaultContent` if `value` is empty.
-function getDisplayContent<T extends ReactNode>(
+function getDisplayContent<T extends string>(
   value: T[],
   items: Item<T>[],
   defaultContent: ReactNode

--- a/packages/libs/coreui/src/components/inputs/checkboxes/CheckboxList.tsx
+++ b/packages/libs/coreui/src/components/inputs/checkboxes/CheckboxList.tsx
@@ -76,7 +76,7 @@ export type Item<T> = {
   disabled?: boolean;
 };
 
-export type CheckboxListProps<T> = {
+export type CheckboxListProps<T extends string> = {
   /** Optional name attribute for the native input element */
   name?: string;
 
@@ -99,7 +99,7 @@ export type CheckboxListProps<T> = {
   disabledCheckboxTooltipContent?: ReactNode;
 };
 
-export default function CheckboxList<T>({
+export default function CheckboxList<T extends string>({
   name,
   items,
   value,

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -398,13 +398,7 @@ export function RecordTable_Sequences(
 
   // None shall pass! (hooks, at least)
 
-  if (
-    !mesaState ||
-    !sortedRows ||
-    (numSequences >= MIN_SEQUENCES_FOR_TREE &&
-      numSequences <= MAX_SEQUENCES_FOR_TREE &&
-      (tree == null || treeResponse == null))
-  ) {
+  if (!mesaState || !sortedRows || !tree || !treeResponse) {
     return <Loading />;
   }
 

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -98,7 +98,10 @@ export function RecordTable_Sequences(
   const numSequences = mesaRows.length;
 
   const treeResponse = useOrthoService(
-    (orthoService) => orthoService.getGroupTree(groupName),
+    (orthoService) => {
+      if (numSequences < 3) return Promise.resolve(undefined);
+      return orthoService.getGroupTree(groupName);
+    },
     [groupName, numSequences]
   );
 
@@ -195,7 +198,7 @@ export function RecordTable_Sequences(
   const { tree, leaves, sortedRows } = useMemo(() => {
     const tree = treeResponse == null ? undefined : parseNewick(treeResponse);
     const leaves = tree && getLeaves(tree);
-    const sortedRows = leaves && sortRows(leaves, mesaRows);
+    const sortedRows = leaves ? sortRows(leaves, mesaRows) : mesaRows;
     return { tree, leaves, sortedRows };
   }, [treeResponse, mesaRows]);
 
@@ -406,6 +409,7 @@ export function RecordTable_Sequences(
   }
 
   if (
+    numSequences >= 3 &&
     mesaRows != null &&
     sortedRows != null &&
     (mesaRows.length !== sortedRows.length ||
@@ -638,8 +642,9 @@ export function RecordTable_Sequences(
   if (filteredRows == null) return null;
 
   const warningText =
-    filteredRows.length > MAX_SEQUENCES_FOR_TREE ||
-    filteredRows.length < MIN_SEQUENCES_FOR_TREE ? (
+    numSequences >= 3 &&
+    (filteredRows.length > MAX_SEQUENCES_FOR_TREE ||
+      filteredRows.length < MIN_SEQUENCES_FOR_TREE) ? (
       <span>
         To see a phylogenetic tree please use a filter to display between{' '}
         {MIN_SEQUENCES_FOR_TREE.toLocaleString()} and{' '}

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -42,7 +42,7 @@ import { RecordFilter } from '@veupathdb/wdk-client/lib/Views/Records/RecordTabl
 import {
   areTermsInStringRegexString,
   parseSearchQueryString,
-} from '../../../../../../../libs/wdk-client/lib/Utils/SearchUtils';
+} from '@veupathdb/wdk-client/lib/Utils/SearchUtils';
 
 type RowType = Record<string, AttributeValue>;
 

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -99,7 +99,8 @@ export function RecordTable_Sequences(
 
   const treeResponse = useOrthoService(
     (orthoService) => {
-      if (numSequences < 3) return Promise.resolve(undefined);
+      if (numSequences < MIN_SEQUENCES_FOR_TREE)
+        return Promise.resolve(undefined);
       return orthoService.getGroupTree(groupName);
     },
     [groupName, numSequences]
@@ -403,7 +404,7 @@ export function RecordTable_Sequences(
   }
 
   if (
-    numSequences >= 3 &&
+    numSequences >= MIN_SEQUENCES_FOR_TREE &&
     mesaRows != null &&
     sortedRows != null &&
     (mesaRows.length !== sortedRows.length ||
@@ -637,7 +638,7 @@ export function RecordTable_Sequences(
   if (filteredRows == null) return null;
 
   const warningText =
-    numSequences >= 3 &&
+    numSequences >= MIN_SEQUENCES_FOR_TREE &&
     (filteredRows.length > MAX_SEQUENCES_FOR_TREE ||
       filteredRows.length < MIN_SEQUENCES_FOR_TREE) ? (
       <span>

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -9,7 +9,7 @@ import React, {
 import TreeTable from '@veupathdb/components/lib/components/tidytree/TreeTable';
 import { RecordTableProps, WrappedComponentProps } from './Types';
 import { useOrthoService } from 'ortho-client/hooks/orthoService';
-import { Loading } from '@veupathdb/wdk-client/lib/Components';
+import { Loading, Link } from '@veupathdb/wdk-client/lib/Components';
 import { Branch, parseNewick } from 'patristic';
 import {
   AttributeValue,
@@ -404,7 +404,8 @@ export function RecordTable_Sequences(
   if (
     mesaRows != null &&
     sortedRows != null &&
-    mesaRows.length !== sortedRows.length
+    (mesaRows.length !== sortedRows.length ||
+      mesaRows.length !== leaves?.length)
   ) {
     console.log(
       'Tree and protein list mismatch. A=Tree, B=Table. Summary below:'
@@ -419,8 +420,13 @@ export function RecordTable_Sequences(
       <Banner
         banner={{
           type: 'warning',
-          message:
-            'Tree and protein list mismatch. Please contact the helpdesk',
+          message: (
+            <span>
+              A data processing error has occurred on our end. We apologize for
+              the inconvenience. If this problem persists, please{' '}
+              <Link to="/contact-us">contact us</Link>.
+            </span>
+          ),
         }}
       />
     );

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -524,6 +524,7 @@ export function RecordTable_Sequences(
       onPress={() => {
         proteinFilterButtonRef.current?.close();
         setProteinFilterIds([]);
+        setTablePageNumber(1);
       }}
     />
   );
@@ -532,6 +533,7 @@ export function RecordTable_Sequences(
     proteinFilterButtonRef.current?.close();
     setProteinFilterIds(highlightedNodes);
     setHighlightedNodes([]);
+    setTablePageNumber(1);
   };
 
   const proteinFilter = (

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -39,6 +39,10 @@ import {
 import { RecordTable_TaxonCounts_Filter } from './RecordTable_TaxonCounts_Filter';
 import { formatAttributeValue } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { RecordFilter } from '@veupathdb/wdk-client/lib/Views/Records/RecordTable/RecordFilter';
+import {
+  areTermsInStringRegexString,
+  parseSearchQueryString,
+} from '../../../../../../../libs/wdk-client/lib/Utils/SearchUtils';
 
 type RowType = Record<string, AttributeValue>;
 
@@ -800,14 +804,9 @@ function rowMatch(row: RowType, query: RegExp, keys?: string[]): boolean {
 
 function createSafeSearchRegExp(input: string): RegExp | undefined {
   if (input === '') return undefined;
-  try {
-    // Attempt to create a RegExp from the user input directly
-    return new RegExp(input, 'i');
-  } catch (error) {
-    // If an error occurs (e.g., invalid RegExp), escape the input and create a literal search RegExp
-    const escapedInput = input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(escapedInput, 'i');
-  }
+  const queryTerms = parseSearchQueryString(input);
+  const searchTermRegex = areTermsInStringRegexString(queryTerms);
+  return new RegExp(searchTermRegex, 'i');
 }
 
 function logIdMismatches(A: string[], B: string[]) {

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -623,12 +623,13 @@ export function RecordTable_Sequences(
           corePeripheralFilterValue.length +
           selectedSpecies.length +
           proteinFilterIds.length ===
-        0
+          0 && searchQuery === ''
       }
       icon={Undo}
       size={'medium'}
       themeRole={'primary'}
       onPress={() => {
+        setSearchQuery('');
         setProteinFilterIds([]);
         setPfamFilterIds([]);
         setCorePeripheralFilterValue([]);
@@ -695,6 +696,7 @@ export function RecordTable_Sequences(
         }}
       >
         <RecordFilter
+          key={`text-search-${resetCounter}`}
           searchTerm={searchQuery}
           onSearchTermChange={setSearchQuery}
           recordDisplayName="Proteins"

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -622,6 +622,22 @@ export function RecordTable_Sequences(
 
   if (filteredRows == null) return null;
 
+  const warningText =
+    filteredRows.length > MAX_SEQUENCES_FOR_TREE ||
+    filteredRows.length < MIN_SEQUENCES_FOR_TREE ? (
+      <span>
+        To see a phylogenetic tree please use a filter to display between{' '}
+        {MIN_SEQUENCES_FOR_TREE.toLocaleString()} and{' '}
+        {MAX_SEQUENCES_FOR_TREE.toLocaleString()} sequences
+      </span>
+    ) : filteredRows.length < sortedRows.length ? (
+      <span>
+        Note: The ortholog group's phylogeny has been pruned to display only the
+        currently filtered proteins. This may differ from a tree constructed{' '}
+        <i>de novo</i> using only these sequences.
+      </span>
+    ) : undefined;
+
   return (
     <div
       style={
@@ -630,8 +646,7 @@ export function RecordTable_Sequences(
         } as CSSProperties
       }
     >
-      {(filteredRows.length > MAX_SEQUENCES_FOR_TREE ||
-        filteredRows.length < MIN_SEQUENCES_FOR_TREE) && (
+      {warningText && (
         <div
           style={{
             display: 'flex',
@@ -645,9 +660,7 @@ export function RecordTable_Sequences(
             fontWeight: 500,
           }}
         >
-          To see a phylogenetic tree please use a filter to display between{' '}
-          {MIN_SEQUENCES_FOR_TREE.toLocaleString()} and{' '}
-          {MAX_SEQUENCES_FOR_TREE.toLocaleString()} sequences
+          {warningText}
         </div>
       )}
       <div

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -428,7 +428,10 @@ export function RecordTable_Sequences(
             <span>
               A data processing error has occurred on our end. We apologize for
               the inconvenience. If this problem persists, please{' '}
-              <Link to="/contact-us">contact us</Link>.
+              <Link target="_blank" to="/contact-us">
+                contact us
+              </Link>
+              .
             </span>
           ),
         }}


### PR DESCRIPTION
Resolves #1254 

I looked into improving the responsiveness of the table paging controls with useDeferredState, but it was not possible due to the memoisation of `mesaState` - which has a mix of "slow" and "volatile" dependencies. I wonder if that memoisation isn't actually necessary? (Answer: I removed it and this reintroduced the janky search field checkboxes...)