### PR TITLE
EDA viz - handle invalid variable selections

### DIFF
--- a/packages/libs/eda/src/lib/core/utils/data-element-constraints.ts
+++ b/packages/libs/eda/src/lib/core/utils/data-element-constraints.ts
@@ -286,6 +286,13 @@ export function filterConstraints(
       if (value == null) return true;
       // Ignore constraints that are on this selectedVarReference
       if (selectedVarReference === variableName) return true;
+      // {{ treat invalid selections as "empty" and return true
+      const entityAndVariable = findEntityAndVariable(entities, value);
+      if (entityAndVariable == null) return true;
+      const { variable } = entityAndVariable;
+      if (variable.type === 'category') return true;
+      // }}
+
       // If a constraint does not declare shapes or types and it allows multivalued variables, then any value is allowed, thus the constraint is "in-play"
       if (
         isEmpty(constraint.allowedShapes) &&
@@ -296,15 +303,8 @@ export function filterConstraints(
         constraint.allowMultiValued
       )
         return true;
+
       // Check that the value's associated variable has compatible characteristics
-      const entityAndVariable = findEntityAndVariable(entities, value);
-      if (entityAndVariable == null)
-        throw new Error(
-          `Could not find selected entity and variable: entityId = ${value.entityId}; variableId = ${value.variableId}.`
-        );
-      const { variable } = entityAndVariable;
-      if (variable.type === 'category')
-        throw new Error('Categories are not allowed for variable constraints.');
       const typeIsValid =
         isEmpty(constraint.allowedTypes) ||
         constraint.allowedTypes?.includes(variable.type);


### PR DESCRIPTION
This PR addresses cases where a selected variable for an EDA viz is no longer available (for example, due to data being reloaded).

Here is an example illustrating the current UX: https://microbiomedb.org/mbio/app/workspace/analyses/lkrccJY/import. Go to visualizations, and select the first one to see the current UX.

This screenshot illustrates the new UX:
![image](https://github.com/user-attachments/assets/8208b32e-e565-473a-b02f-773ae80904d3)
