### PR TITLE
Use tableState from wdk-client

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/common/RecordTableContainer.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/common/RecordTableContainer.jsx
@@ -2,7 +2,7 @@ import { cloneElement, Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { updateTableState } from '../../actioncreators/RecordViewActionCreators';
+import { updateTableState } from '@veupathdb/wdk-client/lib/Actions/RecordActions';
 
 /**
  * Tables that are fully collapsed on load.
@@ -126,7 +126,7 @@ RecordTableContainer.propTypes = {
 
 const enhance = connect(
   ({ record: state }, props) => ({
-    tableState: get(state, 'eupathdb.tables.' + props.table.name),
+    tableState: get(state, 'tableStates.' + props.table.name),
   }),
   { updateTableState }
 );

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/GeneRecordClasses.GeneRecordClass.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/GeneRecordClasses.GeneRecordClass.jsx
@@ -31,7 +31,6 @@ import {
   isNodeOverflowing,
 } from '@veupathdb/web-common/lib/util/domUtils';
 
-import { updateTableState } from '../../actioncreators/RecordViewActionCreators';
 import { projectId, webAppUrl } from '../../config';
 import * as Gbrowse from '../common/Gbrowse';
 import { OverviewThumbnails } from '../common/OverviewThumbnails';
@@ -1552,11 +1551,11 @@ class OrthologsForm extends SortKeyTable {
 
 const TranscriptionSummaryForm = connect(
   ({ record }) => ({
-    expressionGraphsTableState: record.eupathdb.tables?.ExpressionGraphs,
+    expressionGraphsTableState: record.tableStates?.ExpressionGraphs,
   }),
   {
     updateSectionVisibility: RecordActions.updateSectionVisibility,
-    updateTableState,
+    updateTableState: RecordActions.updateTableState,
   }
 )(
   class TranscriptionSummaryFormPres extends SortKeyTable {
@@ -1643,10 +1642,7 @@ const TranscriptionSummaryForm = connect(
                 this.props.updateTableState('ExpressionGraphs', {
                   ...this.props.expressionGraphsTableState,
                   searchTerm: '',
-                  selectedRow: {
-                    index: expressionGraphIndex,
-                    id: `ExpressionGraphs__${ExpressionGraphs[expressionGraphIndex].dataset_id}`,
-                  },
+                  selectedRow: expressionGraphIndex,
                 });
               }
             );


### PR DESCRIPTION
This PR updates genomics-site to use tableState from wdk-client. There is some additional logic in genomics-site that persists which row of a table is opened. If we want to retain this state, it should be on a pre-record basis.