### PR TITLE
Remove hash from url for static content, to make page more stable

### DIFF
--- a/packages/libs/web-common/src/routes.jsx
+++ b/packages/libs/web-common/src/routes.jsx
@@ -160,12 +160,7 @@ export const wrapRoutes = (wdkRoutes) => [
     requiresLogin: false,
     component: (props) => (
       <ExternalContentController
-        url={
-          communitySite +
-          props.match.params.path +
-          props.location.search +
-          props.location.hash
-        }
+        url={communitySite + props.match.params.path + props.location.search}
       />
     ),
   },


### PR DESCRIPTION
This PR removes the hash of the current location from the `url` prop of `ExternalContentController` used for static-content. Including the hash causes page updated whenever the hash changes, which is not desirable.