### PR TITLE
Mesa fix layout

### DIFF
--- a/packages/libs/coreui/src/components/Mesa/Components/AnchoredTooltip.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Components/AnchoredTooltip.jsx
@@ -3,7 +3,6 @@ import { debounce } from 'lodash';
 
 import MesaTooltip from './MesaTooltip';
 import Events from '../Utils/Events';
-import { MESA_SCROLL_EVENT, MESA_REFLOW_EVENT } from '../Ui/MesaContants';
 
 class AnchoredTooltip extends React.Component {
   constructor(props) {
@@ -19,8 +18,6 @@ class AnchoredTooltip extends React.Component {
     this.listeners = {
       scroll: Events.add('scroll', this.updatePosition),
       resize: Events.add('resize', this.updatePosition),
-      MesaScroll: Events.add(MESA_SCROLL_EVENT, this.updatePosition),
-      MesaReflow: Events.add(MESA_REFLOW_EVENT, this.updatePosition),
     };
   }
 

--- a/packages/libs/coreui/src/components/Mesa/Ui/ExpansionCell.tsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/ExpansionCell.tsx
@@ -42,21 +42,13 @@ export default function ExpansionCell({
     const title = 'Show or hide all row details';
 
     return (
-      <th className="wdk-DataTableCell wdk-DataTableCell__childRowToggle">
+      <th className="HeadingCell ChildRowToggle">
         {inert ? null : areAllRowsExpanded ? (
-          <button
-            className="wdk-DataTableCellExpand"
-            title={title}
-            onClick={handler}
-          >
+          <button title={title} onClick={handler}>
             <ArrowDown />
           </button>
         ) : (
-          <button
-            className="wdk-DataTableCellExpand"
-            title={title}
-            onClick={handler}
-          >
+          <button title={title} onClick={handler}>
             <ArrowRight />
           </button>
         )}
@@ -82,13 +74,13 @@ export default function ExpansionCell({
     };
 
     return (
-      <td className="wdk-DataTable wdk-DataTableCell__childRowToggle">
+      <td className="ChildRowToggle">
         {inert ? null : isExpanded ? (
-          <button className="wdk-DataTableCellExpand" onClick={handler}>
+          <button onClick={handler}>
             <ArrowDown />
           </button>
         ) : (
-          <button className="wdk-DataTableCellExpand" onClick={handler}>
+          <button onClick={handler}>
             <ArrowRight />
           </button>
         )}

--- a/packages/libs/coreui/src/components/Mesa/Ui/HeadingCell.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Ui/HeadingCell.jsx
@@ -6,7 +6,6 @@ import Icon from '../Components/Icon';
 import HelpTrigger from '../Components/HelpTrigger';
 import { makeClassifier } from '../Utils/Utils';
 import Events, { EventsFactory } from '../Utils/Events';
-import { MESA_SCROLL_EVENT, MESA_REFLOW_EVENT } from './MesaContants';
 
 const headingCellClass = makeClassifier('HeadingCell');
 
@@ -42,8 +41,6 @@ class HeadingCell extends React.PureComponent {
     this.listeners = {
       scroll: Events.add('scroll', this.updateOffset),
       resize: Events.add('resize', this.updateOffset),
-      MesaScroll: Events.add(MESA_SCROLL_EVENT, this.updateOffset),
-      MesaReflow: Events.add(MESA_REFLOW_EVENT, this.updateOffset),
     };
   }
 

--- a/packages/libs/coreui/src/components/Mesa/style/Cells.scss
+++ b/packages/libs/coreui/src/components/Mesa/style/Cells.scss
@@ -1,6 +1,9 @@
 $StickyColumnBorderColor: rgb(204, 204, 204);
 
 .MesaComponent {
+  tr {
+    white-space: break-spaces;
+  }
   th {
     background-color: #e2e2e2;
     transition: background 0.25s;

--- a/packages/libs/coreui/src/components/Mesa/style/Ui/DataTable.scss
+++ b/packages/libs/coreui/src/components/Mesa/style/Ui/DataTable.scss
@@ -1,63 +1,71 @@
 .MesaComponent {
   .DataTable {
     font-size: $fontSize;
-    width: 100%;
+    display: inline-block;
     margin-bottom: 1.5em;
-    display: grid;
-    grid-template-columns: auto 1fr;
-    grid-template-areas:
-      '. header'
-      'margin body';
-    z-index: 0;
+    width: 100%;
+
+    &--HasMargin {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      grid-template-areas: 'margin table';
+
+      .DataTable-Margin {
+        grid-area: margin;
+      }
+      align-items: end;
+
+      table {
+        grid-area: table;
+      }
+    }
 
     &--Sticky {
-      overflow: auto;
-      .DataTable-Header {
-        position: sticky;
-        top: 0;
-        z-index: 1;
-      }
-    }
-
-    .DataTable-Header {
-      grid-area: header;
-    }
-
-    .DataTable-Body {
-      grid-area: body;
-    }
-
-    .DataTable-Margin {
-      grid-area: margin;
-    }
-
-    table {
-      width: 100%;
-      border-collapse: separate;
-    }
-
-    .DataTable-Sticky {
-      display: block;
+      z-index: 0;
       overflow: auto;
       position: relative;
-      z-index: 0;
       max-height: 70vh;
-
-      .DataTable-Header,
-      .DataTable-Body {
-        display: block;
-      }
-
-      .DataTable-Body {
-        position: relative;
-        padding-bottom: 1.5em; /* prevent macos scrollbar from occluding last row */
-      }
-
-      .DataTable-Header {
-        overflow: visible;
-        top: 0;
+      padding-bottom: 1.5em; /* prevent macos scrollbar from occluding last row */
+      thead {
         position: sticky;
-        z-index: 1;
+        top: 0;
+        z-index: 2;
+        overflow: visible;
+      }
+    }
+
+    > table {
+      width: 100%;
+      border-collapse: separate;
+
+      td,
+      tr {
+        .ChildRowToggle {
+          width: 4em;
+          vertical-align: middle;
+          text-align: center;
+          padding: 0;
+
+          > button {
+            width: 100%;
+            padding: 0;
+            border: none;
+            line-height: 2;
+            background: transparent !important;
+
+            > svg {
+              fill: #777;
+            }
+
+            &:hover > svg {
+              fill: black;
+            }
+          }
+        }
+      }
+
+      tr._childIsExpanded > .ChildRowToggle > button > svg {
+        fill: black;
       }
     }
   }

--- a/packages/libs/coreui/src/components/Mesa/style/Ui/HeadingCell.scss
+++ b/packages/libs/coreui/src/components/Mesa/style/Ui/HeadingCell.scss
@@ -10,7 +10,6 @@
       z-index: 1;
 
       .HeadingCell-Content-Aside {
-        flex-basis: 0 1 30px;
         &:last-of-type {
           text-align: right;
         }

--- a/packages/libs/wdk-client/src/Views/Question/Params/FilterParamNew/FilterParam.css
+++ b/packages/libs/wdk-client/src/Views/Question/Params/FilterParamNew/FilterParam.css
@@ -273,14 +273,11 @@
   top: 0;
   right: 1em;
 }
-.filter-param .membership-filter .HeadingRow:first-child {
+.filter-param .membership-filter .HeadingRow:first-child > th {
   border-top: 1px solid #ccc;
 }
-.filter-param .membership-filter .HeadingRow:last-child {
+.filter-param .membership-filter .HeadingRow:last-child > th {
   border-bottom: 1px solid #ccc;
-}
-.filter-param .membership-filter .DataTable table {
-  border-collapse: collapse;
 }
 .filter-param .membership-filter .DataRow,
 .filter-param .membership-filter .HeadingRow {

--- a/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.css
+++ b/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.css
@@ -17,14 +17,14 @@
   width: 300px;
 }
 
-.wdk-RecordTable > .Mesa.MesaComponent > .MesaComponent > .DataTable > table {
-  width: auto;
-}
-
-.MesaComponent > .DataTable {
+.wdk-RecordTable > .Mesa.MesaComponent > .MesaComponent > .DataTable {
   position: relative;
   max-width: 100%;
   overflow-x: auto;
+}
+
+.wdk-RecordTable > .Mesa.MesaComponent > .MesaComponent > .DataTable > table {
+  width: auto;
 }
 
 .wdk-RecordTable__Orthologs

--- a/packages/libs/web-common/src/styles/client.scss
+++ b/packages/libs/web-common/src/styles/client.scss
@@ -2,8 +2,6 @@
 @import './AllSites.scss';
 @import './question-wizard.css';
 
-$expand-child-row-toggle-width: 3em;
-
 dialog {
   border: none;
   border-radius: 0.25em;
@@ -109,42 +107,6 @@ h4 {
 
 .wdk-UserDatasetSectionHeading {
   font-size: 1.4em;
-}
-
-.wdk-DataTableCellExpand > svg {
-  fill: #777;
-}
-
-tr._childIsExpanded
-  > .wdk-DataTableCell__childRowToggle
-  > .wdk-DataTableCellExpand
-  > svg {
-  fill: black;
-}
-
-.wdk-DataTableCellExpand:hover > svg {
-  fill: black;
-}
-
-.wdk-DataTableCellExpand {
-  width: $expand-child-row-toggle-width;
-  padding: 0;
-  border: none;
-  line-height: 2;
-  background: transparent !important;
-}
-
-.wdk-DataTableCell.wdk-DataTableCell__childRowToggle {
-  width: $expand-child-row-toggle-width;
-}
-
-th > .wdk-DataTableCellExpand {
-  display: flex;
-  justify-content: center;
-}
-
-td.wdk-DataTable.wdk-DataTableCell__childRowToggle {
-  vertical-align: middle;
 }
 
 td.wdk-DataTableCell__thumbnail {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss
@@ -47,7 +47,7 @@
       .membership-filter {
         margin-top: 1.5em;
       }
-      .DataTable-Body {
+      .DataTable--Sticky {
         height: 14em;
       }
       .field-list > * {

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
@@ -35,6 +35,11 @@
         max-width: unset;
         width: unset;
         overflow-x: unset;
+        width: 100%;
+
+        table {
+          width: 100%;
+        }
 
         // Set background-color of selected rows
         tr:has(> td.SelectionCell > div > input:checked) > td {


### PR DESCRIPTION
This PR addresses some recently introduced layout issues with Mesa table, specifically when rows are either selectable or expandable.

With the relatively recently `position: sticky` css value, we can dramatically simplify the html and remove a decent amount of runtime javascript.

These changes impact all uses of Mesa table:
- Dataset and study pages
- Strategy results
- Record page tables
- EDA categorical filters
- TreeTable (ortho group record's protein table)

Seeing as this is an urgent fix (the bug is on production), I would appreciate a quick review. I'm happy to go over changes in more detail, after this is merged.