### PR TITLE
Fix volcano plot thumbnail out of sync

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -136,6 +136,9 @@ function VolcanoPlotViz(props: VisualizationProps<Options>) {
     plotContainerStyleOverrides,
   } = props;
 
+  // If no filters applied, the currentPlotFilters will be undefined. It should be an empty array.
+  visualization.descriptor.currentPlotFilters =
+    visualization.descriptor.currentPlotFilters ?? [];
   const studyMetadata = useStudyMetadata();
   const { id: studyId } = studyMetadata;
   const entities = useStudyEntities(filters);


### PR DESCRIPTION
Resolves #1297 

From the start the `visualization.descriptor.currentPlotFilters = undefined` if there are no filters. It works fine if we do have filters. In the other visualizations it initializes to `[]` as it should if the analysis has no filters. 

This PR has a fix, but I doubt it's really the direction we should go. I'd like to ask if folks have any other ideas!