### PR TITLE
add routes that guests can access

### DIFF
--- a/packages/libs/wdk-client/src/Core/routes.tsx
+++ b/packages/libs/wdk-client/src/Core/routes.tsx
@@ -230,6 +230,7 @@ const routes: RouteEntry[] = [
         {...props.match.params}
       />
     ),
+    requiresLogin: false,
   },
 
   {
@@ -290,16 +291,19 @@ const routes: RouteEntry[] = [
   {
     path: '/401',
     component: PermissionDenied,
+    requiresLogin: false,
   },
 
   {
     path: '/404',
     component: NotFound,
+    requiresLogin: false,
   },
 
   {
     path: '/500',
     component: Error,
+    requiresLogin: false,
   },
 
   {


### PR DESCRIPTION
This PR prevents a "login loop" by allowing guests to access the login-error page. I also added some other routes related to http status codes that tomcat redirects to.