### PR TITLE
Use alphabetic ordering when displaying a flattened list of eda entities

### DIFF
--- a/packages/libs/eda/src/lib/core/utils/study-metadata.ts
+++ b/packages/libs/eda/src/lib/core/utils/study-metadata.ts
@@ -1,5 +1,5 @@
 import { keyBy } from 'lodash';
-import { find } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
+import { find, Seq } from '@veupathdb/wdk-client/lib/Utils/IterableUtils';
 import {
   CollectionVariableTreeNode,
   MultiFilterVariable,
@@ -13,7 +13,9 @@ import {
 import { preorder } from '@veupathdb/wdk-client/lib/Utils/TreeUtils';
 
 export function entityTreeToArray(rootEntity: StudyEntity): StudyEntity[] {
-  return Array.from(preorder(rootEntity, (e) => e.children ?? []));
+  return Seq.from(preorder(rootEntity, (e) => e.children ?? []))
+    .orderBy((node) => node.displayName)
+    .toArray();
 }
 
 export interface EntityAndVariable {


### PR DESCRIPTION
closes #1317

Here is a screenshot showing that the variable tree entities are now ordered alphabetically. I included the entity diagram so that it is easier to see how the order differs in the two displays.

![image](https://github.com/user-attachments/assets/327e5c79-ea19-4bd3-a480-6b346b9af6a4)
