### PR TITLE
Add ability to highlight points to scatterplot

### DIFF
--- a/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
@@ -474,7 +474,8 @@ const { dataSetProcess: dataSetCategoricalOverlayHighlight } = processInputData(
   dependentValueType,
   false,
   highlightPointIdsStyled,
-  highlightStyleOverride
+  highlightStyleOverride,
+  'My Highlight Trace'
 );
 
 export const HighlightPointsWithStyleOverride: Story<ScatterPlotProps> =

--- a/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
@@ -453,7 +453,11 @@ HighlightPoints.args = {
   displayLegend: true,
 };
 
-// Highlight points with a specialized style
+// Highlight points with a specialized style.
+// This story uses data that's already been broken up by an overlay variable. The result
+// currently looks a bit ridiculuous - we have a bunch of gray Data rows in the legend. However, this is actually
+// the desired behavior. In practice each of those gray Data traces would have a name, so we'd see helpful group names. Additionally,
+// we want to be sure we can highlight points from any of the traces, even if they're split up like in an overlay.
 const highlightStyleOverride = {
   line: {
     color: 'red',

--- a/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
@@ -14,7 +14,9 @@ import {
   dataSetSequentialGradient,
   dataSet,
   processInputData,
+  dataSetCategoricalOverlay,
 } from './ScatterPlot.storyData';
+import { symbol } from 'd3';
 
 export default {
   title: 'Plots/ScatterPlot',
@@ -433,10 +435,7 @@ PlotAnnotations.args = {
 
 // Highlighting points
 // use dataSetProcessSequentialGradient
-const TestTemplate = (args: any) => {
-  console.log(args.data);
-  return <ScatterPlot {...args} />;
-};
+
 // At this point, raw data has been processed, colored, etc.
 // Now is the time to split highlighted from non-highlighted. This timing retains
 // the ability to later allow different types of highlighting and keeping the underlying
@@ -467,10 +466,42 @@ const { dataSetProcess: dataSetProcessSequentialGradientHighlight } =
     false,
     highlightedPointIds
   );
-console.log(dataSetProcessSequentialGradientHighlight);
-export const HighlightPoints: Story<ScatterPlotProps> = TestTemplate.bind({});
+
+export const HighlightPoints: Story<ScatterPlotProps> = Template.bind({});
 HighlightPoints.args = {
   data: dataSetProcessSequentialGradientHighlight,
+  interactive: true,
+  displayLegend: true,
+};
+
+// Highlight points with a specialized input
+const highlightStyleOverride = {
+  line: {
+    color: 'red',
+    width: 2,
+  },
+  color: 'blue',
+  size: 15,
+  symbol: 'star',
+};
+
+const highlightPointIds2 =
+  dataSetCategoricalOverlay.scatterplot.data[0]?.pointIds?.slice(0, 10) ?? [];
+const { dataSetProcess: dataSetCategoricalOverlayHighlight } = processInputData(
+  dataSetCategoricalOverlay,
+  'scatterplot',
+  'markers',
+  independentValueType,
+  dependentValueType,
+  false,
+  highlightPointIds2,
+  highlightStyleOverride
+);
+
+export const HighlightPointsWithStyleOverride: Story<ScatterPlotProps> =
+  Template.bind({});
+HighlightPointsWithStyleOverride.args = {
+  data: dataSetCategoricalOverlayHighlight,
   interactive: true,
   displayLegend: true,
 };

--- a/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import ScatterPlot, { ScatterPlotProps } from '../../plots/ScatterPlot';
 import { Story, Meta } from '@storybook/react/types-6-0';
-import { PlotParams } from 'react-plotly.js';
 // test to use RadioButtonGroup directly instead of ScatterPlotControls
 import RadioButtonGroup from '../../components/widgets/RadioButtonGroup';
 import { FacetedData, ScatterPlotData } from '../../types/plots';
@@ -14,10 +13,8 @@ import SliderWidget, {
 import {
   dataSetSequentialGradient,
   dataSet,
-  dateStringDataSet,
   processInputData,
 } from './ScatterPlot.storyData';
-import { Annotations } from 'plotly.js';
 
 export default {
   title: 'Plots/ScatterPlot',
@@ -432,4 +429,48 @@ PlotAnnotations.args = {
   interactive: true,
   displayLegend: true,
   plotAnnotations,
+};
+
+// Highlighting points
+// use dataSetProcessSequentialGradient
+const TestTemplate = (args: any) => {
+  console.log(args.data);
+  return <ScatterPlot {...args} />;
+};
+// At this point, raw data has been processed, colored, etc.
+// Now is the time to split highlighted from non-highlighted. This timing retains
+// the ability to later allow different types of highlighting and keeping the underlying
+// data color information. For example, highlighted points get a different shape but
+// all points retain their normal color.
+
+// Why not have the backend do it? Because then we'd have the backend handling logic for
+// overlay vs highlighted. Let's say highlighted becomes another "facet", basically. Then we still
+// also have to have logic in processInputData that's ugly and deals with overlay color + highlight status.
+// Not a great option either.
+// Having its own funciton is absolutely ugly, but it seems the least awful. It has the advantage
+// of keeping the logic all in one place.
+
+// Some thoughts about the highlighted points (just trying to brain dump and hope it provides some clarity)
+// We want to see highlighted points in the legend, so we need a new trace/series.
+// Should the original traces retain the highlighted points? Or should they get removed?
+// No. We’ll pluck the highlighted points out of the original traces. That way when we click the legend to turn off the highlighted points, they’d disappear. Seems reasonable.
+// But, that means we’re separating points from their original grouping. If a user changed their highlighted points and we didn’t want to have to re-request the data,
+// Make a new trace for highlighted points. Set opacity of points in the original trace to 0. Best-ish of both worlds
+const highlightedPointIds = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+const { dataSetProcess: dataSetProcessSequentialGradientHighlight } =
+  processInputData(
+    dataSetSequentialGradient,
+    'scatterplot',
+    'markers',
+    independentValueType,
+    dependentValueType,
+    false,
+    highlightedPointIds
+  );
+console.log(dataSetProcessSequentialGradientHighlight);
+export const HighlightPoints: Story<ScatterPlotProps> = TestTemplate.bind({});
+HighlightPoints.args = {
+  data: dataSetProcessSequentialGradientHighlight,
+  interactive: true,
+  displayLegend: true,
 };

--- a/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.stories.tsx
@@ -433,28 +433,7 @@ PlotAnnotations.args = {
   plotAnnotations,
 };
 
-// Highlighting points
-// use dataSetProcessSequentialGradient
-
-// At this point, raw data has been processed, colored, etc.
-// Now is the time to split highlighted from non-highlighted. This timing retains
-// the ability to later allow different types of highlighting and keeping the underlying
-// data color information. For example, highlighted points get a different shape but
-// all points retain their normal color.
-
-// Why not have the backend do it? Because then we'd have the backend handling logic for
-// overlay vs highlighted. Let's say highlighted becomes another "facet", basically. Then we still
-// also have to have logic in processInputData that's ugly and deals with overlay color + highlight status.
-// Not a great option either.
-// Having its own funciton is absolutely ugly, but it seems the least awful. It has the advantage
-// of keeping the logic all in one place.
-
-// Some thoughts about the highlighted points (just trying to brain dump and hope it provides some clarity)
-// We want to see highlighted points in the legend, so we need a new trace/series.
-// Should the original traces retain the highlighted points? Or should they get removed?
-// No. We’ll pluck the highlighted points out of the original traces. That way when we click the legend to turn off the highlighted points, they’d disappear. Seems reasonable.
-// But, that means we’re separating points from their original grouping. If a user changed their highlighted points and we didn’t want to have to re-request the data,
-// Make a new trace for highlighted points. Set opacity of points in the original trace to 0. Best-ish of both worlds
+// Highlight specific points in the scatterplot
 const highlightedPointIds = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
 const { dataSetProcess: dataSetProcessSequentialGradientHighlight } =
   processInputData(
@@ -474,7 +453,7 @@ HighlightPoints.args = {
   displayLegend: true,
 };
 
-// Highlight points with a specialized input
+// Highlight points with a specialized style
 const highlightStyleOverride = {
   line: {
     color: 'red',
@@ -485,7 +464,7 @@ const highlightStyleOverride = {
   symbol: 'star',
 };
 
-const highlightPointIds2 =
+const highlightPointIdsStyled =
   dataSetCategoricalOverlay.scatterplot.data[0]?.pointIds?.slice(0, 10) ?? [];
 const { dataSetProcess: dataSetCategoricalOverlayHighlight } = processInputData(
   dataSetCategoricalOverlay,
@@ -494,7 +473,7 @@ const { dataSetProcess: dataSetCategoricalOverlayHighlight } = processInputData(
   independentValueType,
   dependentValueType,
   false,
-  highlightPointIds2,
+  highlightPointIdsStyled,
   highlightStyleOverride
 );
 

--- a/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
@@ -593,6 +593,7 @@ export function processInputData<T extends number | string>(
   defineColors: boolean,
   highlightIds?: string[],
   highlightMarkerStyleOverride?: ScatterPlotDataSeries['marker'],
+  highlightTraceName?: string,
   colorPaletteOverride?: string[]
 ) {
   // set fillAreaValue for densityplot
@@ -637,7 +638,7 @@ export function processInputData<T extends number | string>(
   let highlightTrace: any = {
     x: [],
     y: [],
-    name: 'highlight',
+    name: highlightTraceName ?? 'highlight',
     mode: 'markers',
     type: 'scatter',
     marker: highlightMarkerStyleOverride ?? DefaultHighlightMarkerStyle,
@@ -808,7 +809,6 @@ export function processInputData<T extends number | string>(
             ? 'scatter'
             : 'scattergl', // for the raw data of the scatterplot
         fill: fillAreaValue,
-        size: 12,
         marker: {
           color:
             highlightIds && highlightIds.length > 0
@@ -818,6 +818,7 @@ export function processInputData<T extends number | string>(
               : seriesGradientColorscale?.length > 0
               ? markerColorsGradient
               : undefined,
+          size: 12,
           line: {
             color:
               highlightIds && highlightIds.length > 0

--- a/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
@@ -640,7 +640,7 @@ export function processInputData<T extends number | string>(
     y: [],
     name: highlightTraceName ?? 'highlight',
     mode: 'markers',
-    type: 'scatter',
+    type: 'scattergl',
     marker: highlightMarkerStyleOverride ?? DefaultHighlightMarkerStyle,
     pointIds: [],
   };
@@ -818,7 +818,6 @@ export function processInputData<T extends number | string>(
               : seriesGradientColorscale?.length > 0
               ? markerColorsGradient
               : undefined,
-          size: 12,
           line: {
             color:
               highlightIds && highlightIds.length > 0

--- a/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
@@ -857,15 +857,15 @@ export function processInputData<T extends number | string>(
           .filter((index: number) => index !== -1);
         if (highlightIndices && highlightIndices.length !== 0) {
           highlightTrace.x.push(
-            ...(highlightIndices.map((index: string) => el.seriesX[index]) ||
+            ...(highlightIndices.map((index: number) => el.seriesX[index]) ||
               [])
           );
           highlightTrace.y.push(
-            ...(highlightIndices.map((index: string) => el.seriesY[index]) ||
+            ...(highlightIndices.map((index: number) => el.seriesY[index]) ||
               [])
           );
           highlightTrace.pointIds.push(
-            ...(highlightIndices.map((index: string) => el.pointIds[index]) ||
+            ...(highlightIndices.map((index: number) => el.pointIds[index]) ||
               [])
           );
         }

--- a/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
@@ -1,13 +1,16 @@
 import { NumberOrDateRange } from '../../types/general';
-import { ScatterPlotData } from '../../types/plots';
+import { ScatterPlotData, ScatterPlotDataSeries } from '../../types/plots';
 import { min, max, lte, gte } from 'lodash';
 import {
   gradientSequentialColorscaleMap,
   gradientDivergingColorscaleMap,
   DefaultHighlightColor,
   DefaultNonHighlightColor,
+  DefaultHighlightMarkerStyle,
 } from '../../types/plots/addOns';
 import { scaleLinear } from 'd3-scale';
+import { Default } from '../AnimatedMarkers.stories';
+import { PlotParams } from 'react-plotly.js';
 
 // set data array types for VEuPathDB scatter plot: https://redmine.apidb.org/issues/41310
 // but changed to new format: most likely x & y data are row/column vector format; also standardError is not a single value but vector
@@ -101,48 +104,72 @@ export const dataSetCategoricalOverlay: VEuPathDBScatterPlotData = {
         seriesY: sequentialIntegers
           .slice(nPoints / 2)
           .map((i) => Math.random()),
+        pointIds: sequentialIntegers
+          .slice(nPoints / 2)
+          .map((i) => i.toString()),
       },
       {
         seriesX: sequentialIntegers.slice(nPoints / 2),
         seriesY: sequentialIntegers
           .slice(nPoints / 2)
           .map((i) => Math.random()),
+        pointIds: sequentialIntegers
+          .slice(nPoints / 2)
+          .map((i) => (i + nPoints / 2).toString()),
       },
       {
         seriesX: sequentialIntegers.slice(nPoints / 2),
         seriesY: sequentialIntegers
           .slice(nPoints / 2)
           .map((i) => Math.random()),
+        pointIds: sequentialIntegers
+          .slice(nPoints / 2)
+          .map((i) => (i + nPoints).toString()),
       },
       {
         seriesX: sequentialIntegers.slice(nPoints / 2),
         seriesY: sequentialIntegers
           .slice(nPoints / 2)
           .map((i) => Math.random()),
+        pointIds: sequentialIntegers
+          .slice(nPoints / 2)
+          .map((i) => (i + (3 * nPoints) / 2).toString()),
       },
       {
         seriesX: sequentialIntegers.slice(nPoints / 2),
         seriesY: sequentialIntegers
           .slice(nPoints / 2)
           .map((i) => Math.random()),
+        pointIds: sequentialIntegers
+          .slice(nPoints / 2)
+          .map((i) => (i + 2 * nPoints).toString()),
       },
       {
         seriesX: sequentialIntegers.slice(nPoints / 2),
         seriesY: sequentialIntegers
           .slice(nPoints / 2)
           .map((i) => Math.random()),
+        pointIds: sequentialIntegers
+          .slice(nPoints / 2)
+          .map((i) => (i + (5 * nPoints) / 2).toString()),
       },
       {
         seriesX: sequentialIntegers.slice(nPoints / 2),
         seriesY: sequentialIntegers
           .slice(nPoints / 2)
           .map((i) => Math.random()),
+        pointIds: sequentialIntegers
+          .slice(nPoints / 2)
+          .map((i) => (i + 3 * nPoints).toString()),
       },
       {
         seriesX: sequentialIntegers.slice(nPoints / 2),
         seriesY: sequentialIntegers
           .slice(nPoints / 2)
           .map((i) => Math.random()),
+        pointIds: sequentialIntegers
+          .slice(nPoints / 2)
+          .map((i) => (i + (7 * nPoints) / 2).toString()),
       },
     ],
   },
@@ -569,6 +596,7 @@ export function processInputData<T extends number | string>(
   dependentValueType: string,
   defineColors: boolean,
   highlightIds?: string[],
+  highlightMarkerStyleOverride?: ScatterPlotDataSeries['marker'],
   colorPaletteOverride?: string[]
 ) {
   // set fillAreaValue for densityplot
@@ -588,6 +616,8 @@ export function processInputData<T extends number | string>(
   // set variables for x- and yaxis ranges
   let yMin: number | string | undefined = 0;
   let yMax: number | string | undefined = 0;
+
+  console.log('the data', plotDataSet.data);
 
   // coloring: using plotly.js default colors instead of web-components default palette
   const markerColors = colorPaletteOverride ?? [
@@ -616,13 +646,10 @@ export function processInputData<T extends number | string>(
     name: 'highlight',
     mode: 'markers',
     type: 'scattergl',
-    marker: {
-      color: DefaultHighlightColor,
-      size: 30,
-      symbol: 'circle',
-    },
+    marker: highlightMarkerStyleOverride ?? DefaultHighlightMarkerStyle,
     pointIds: [],
   };
+  console.log('highlightTrace', highlightTrace);
 
   // drawing raw data (markers) at first
   plotDataSet.data.forEach(function (el: any, index: number) {
@@ -822,6 +849,7 @@ export function processInputData<T extends number | string>(
         highlightIds.some((id) => el.pointIds.includes(id))
       ) {
         // Extract the indices of highlighted points.
+        console.log('adding highlight points');
         const highlightIndices = el.pointIds
           .map((id: string, index: number) =>
             highlightIds.includes(id) ? index : -1

--- a/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
+++ b/packages/libs/components/src/stories/plots/ScatterPlot.storyData.ts
@@ -4,6 +4,8 @@ import { min, max, lte, gte } from 'lodash';
 import {
   gradientSequentialColorscaleMap,
   gradientDivergingColorscaleMap,
+  DefaultHighlightColor,
+  DefaultNonHighlightColor,
 } from '../../types/plots/addOns';
 import { scaleLinear } from 'd3-scale';
 
@@ -605,6 +607,9 @@ export function processInputData<T extends number | string>(
   let dataSetProcess: any = [];
 
   // Set empty highlightTrace. Will be populated if there are any highlighted points.
+  // Currently we import the defalut highlight styling, but in the future the marker styling could
+  // also be passed as a prop. Highlighting is currently limited to points, though it could extend
+  // similarly to lines, boxes, etc.
   let highlightTrace: any = {
     x: [],
     y: [],
@@ -612,7 +617,7 @@ export function processInputData<T extends number | string>(
     mode: 'markers',
     type: 'scattergl',
     marker: {
-      color: 'rgb(255, 0, 0)',
+      color: DefaultHighlightColor,
       size: 30,
       symbol: 'circle',
     },
@@ -756,7 +761,7 @@ export function processInputData<T extends number | string>(
       const markerSizes =
         el.pointIds && highlightIds
           ? el.pointIds.map((id: string) =>
-              highlightIds.includes(id) ? 30 : 12
+              highlightIds.includes(id) ? 0 : 12
             )
           : 12;
 
@@ -778,7 +783,9 @@ export function processInputData<T extends number | string>(
         fill: fillAreaValue,
         marker: {
           color:
-            defineColors || colorPaletteOverride
+            highlightIds && highlightIds.length > 0
+              ? DefaultNonHighlightColor
+              : defineColors || colorPaletteOverride
               ? markerColors[index]
               : seriesGradientColorscale?.length > 0
               ? markerColorsGradient
@@ -786,7 +793,9 @@ export function processInputData<T extends number | string>(
           size: markerSizes,
           line: {
             color:
-              defineColors || colorPaletteOverride
+              highlightIds && highlightIds.length > 0
+                ? DefaultNonHighlightColor
+                : defineColors || colorPaletteOverride
                 ? markerColors[index]
                 : seriesGradientColorscale?.length > 0
                 ? markerColorsGradient
@@ -812,7 +821,7 @@ export function processInputData<T extends number | string>(
         el.pointIds &&
         highlightIds.some((id) => el.pointIds.includes(id))
       ) {
-        // Extract the appropriate indices of highlighted points.
+        // Extract the indices of highlighted points.
         const highlightIndices = el.pointIds
           .map((id: string, index: number) =>
             highlightIds.includes(id) ? index : -1

--- a/packages/libs/components/src/types/plots/addOns.ts
+++ b/packages/libs/components/src/types/plots/addOns.ts
@@ -242,6 +242,12 @@ const Berlin = [
   'rgb(255, 173, 173)',
 ];
 
+/**
+ * Highlighting colors for points
+ */
+export const DefaultHighlightColor = 'rgb(10, 222, 81)';
+export const DefaultNonHighlightColor = 'rgb(160, 160, 157)';
+
 export const getValueToGradientColorMapper = (
   minValue: number,
   maxValue: number

--- a/packages/libs/components/src/types/plots/addOns.ts
+++ b/packages/libs/components/src/types/plots/addOns.ts
@@ -249,7 +249,6 @@ export const DefaultHighlightColor = '#D246FF';
 export const DefaultNonHighlightColor = '#95929C';
 export const DefaultHighlightMarkerStyle = {
   color: DefaultHighlightColor,
-  size: 12,
   symbol: 'circle',
   line: {
     color: DefaultHighlightColor,

--- a/packages/libs/components/src/types/plots/addOns.ts
+++ b/packages/libs/components/src/types/plots/addOns.ts
@@ -245,8 +245,17 @@ const Berlin = [
 /**
  * Highlighting colors for points
  */
-export const DefaultHighlightColor = 'rgb(10, 222, 81)';
-export const DefaultNonHighlightColor = 'rgb(160, 160, 157)';
+export const DefaultHighlightColor = '#D246FF';
+export const DefaultNonHighlightColor = '#95929C';
+export const DefaultHighlightMarkerStyle = {
+  color: DefaultHighlightColor,
+  size: 12,
+  symbol: 'circle',
+  line: {
+    color: DefaultHighlightColor,
+    width: 1,
+  },
+};
 
 export const getValueToGradientColorMapper = (
   minValue: number,

--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -324,6 +324,7 @@ export const ScatterplotResponseData = array(
       tuple([StringVariableValue]),
       tuple([StringVariableValue, StringVariableValue]),
     ]),
+    pointIds: array(string),
   })
 );
 

--- a/packages/libs/eda/src/lib/core/api/DataClient/types.ts
+++ b/packages/libs/eda/src/lib/core/api/DataClient/types.ts
@@ -295,6 +295,7 @@ export interface ScatterplotRequestParams {
     facetVariable?: ZeroToTwoVariables;
     showMissingness?: 'TRUE' | 'FALSE';
     maxAllowedDataPoints?: number;
+    returnPointIds?: boolean;
   };
 }
 

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -825,7 +825,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
         entities,
         colorPaletteOverride
       );
-      console.log('returned data', returnData);
+
       return {
         ...returnData,
         overlayValueToColorMapper,

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -2369,7 +2369,7 @@ function processInputData(
     y: [],
     name: 'highlight',
     mode: 'markers',
-    type: 'scatter', // 'scatter' not 'scattergl' or hovering doesn't work correctly.
+    type: 'scattergl',
     marker: highlightMarkerStyleOverride ?? DefaultHighlightMarkerStyle,
     pointIds: [],
   };


### PR DESCRIPTION
Resolves #1322 

This was a little funky because plotly already allows for highlighting - we just have to set the color appropriately in the trace! So this PR is more of a hijack of our current processing of scatterplot data to recolor the points.

A few considerations:
- Should the backend just break up the data into highlight and non-highlight for us? It could, and would basically add another "overlay"-type column, but the issue is when we highlight a scatterplot with anything that we have calculated. Smoothed means, best fit line, etc. Breaking up the data for highlgihting would move these points to a place that doesn't correspond with their place in a calculation. We don't want a highlight-smoothed mean and a non-highlight-smoothed mean, we would just want one smoothed mean with a few points highlighted. But we still want to know those highlighted points contributed to the calculation of the smoothed mean. This gets extra complicated with overlays and facets.
- On the frontend, should we recolor in place or make a new trace? Make a new trace so that there's an extra line in the legend that we can click on and off
- Where should the highlighting go on the frontend? Ideally in `Scatterplot` but that means we have to traverse the entire dataset _again_. We already traverse the dataset in `processInputData`, so we can add it there. Also we want to do it _after_ the points get their normal color (given by overlay, etc), so that in the case where we want the highlighted points to be a different shape instead of color (for example), we still have the opportunity to keep the points' original colors. 


I ran into a bit of trouble with tooltips. Despite my best efforts, I couldn't hide the tooltips of the original data. I tried changing marker sizes, colors, lines, everything, but the tooltips still appeared. I finally found [an option](https://codepen.io/etpinard/pen/VwZgjom?editors=1010) that I don't like because it removes some data, but at least the whole point isn't deleted from the trace. 

Remaining To Dos:

- [ ] General scatterplot testing to make sure nothing broke
- [x] Add prop that gives the highlight trace a specific name (would show up in the legend and hover text)