### PR TITLE
Fix UD upload form via URL - added colons to protocol strings

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
@@ -663,7 +663,7 @@ function isValidUrl(string: string) {
   } catch (_) {
     return false;
   }
-  return url.protocol === 'http' || url.protocol === 'https';
+  return url.protocol === 'http:' || url.protocol === 'https:';
 }
 
 export default UploadForm;


### PR DESCRIPTION
Uploads via URLs were broken in MBio - [slack thread](https://epvb.slack.com/archives/CBLPK9ZD3/p1741789394225579) 

Fix seems likely to work.  See https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol