### PR TITLE
add plot title

### DIFF
--- a/packages/libs/web-common/src/components/EdaDatasetGraph.tsx
+++ b/packages/libs/web-common/src/components/EdaDatasetGraph.tsx
@@ -137,6 +137,7 @@ export function EdaDatasetGraph(props: Props) {
                     traceName: source_id?.toString(),
                   }
                 }
+                plotTitle={plotConfig.plotName}
               />
             </div>
           );

--- a/packages/libs/web-common/src/components/eda/EdaScatterPlot.tsx
+++ b/packages/libs/web-common/src/components/eda/EdaScatterPlot.tsx
@@ -25,6 +25,7 @@ interface Props {
   xAxisVariable: VariableDescriptor;
   yAxisVariable: VariableDescriptor;
   highlightSpec?: HighlightSpec;
+  plotTitle?: string;
 }
 
 /**
@@ -51,10 +52,11 @@ interface AdapterProps {
   xAxisVariable: VariableDescriptor;
   yAxisVariable: VariableDescriptor;
   highlightSpec?: HighlightSpec;
+  plotTitle?: string;
 }
 
 function ScatterPlotAdapter(props: AdapterProps) {
-  const { xAxisVariable, yAxisVariable, highlightSpec } = props;
+  const { xAxisVariable, yAxisVariable, highlightSpec, plotTitle } = props;
   const { id: studyId } = useStudyMetadata();
   const dataClient = useDataClient();
   const subsettingClient = useSubsettingClient();
@@ -136,6 +138,7 @@ function ScatterPlotAdapter(props: AdapterProps) {
       data={data.value}
       dependentAxisLabel={yAxisEntityAndVariable?.variable.displayName}
       independentAxisLabel={xAxisEntityAndVariable?.variable.displayName}
+      title={plotTitle}
     />
   );
 }


### PR DESCRIPTION
Adds a plot title to the EDA scatter adaptor. The plot title nicely comes from the model, and thanks to plotly we just send it along and it shows up nicely.

<img width="1274" alt="Screen Shot 2025-03-24 at 4 45 07 PM" src="https://github.com/user-attachments/assets/7cc17f69-1757-44a8-9fb0-8659b8b58153" />

