### PR TITLE
App scatterplots should not return point Ids

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/abundance.tsx
@@ -89,6 +89,7 @@ export const plugin: ComputationPlugin = {
         }
       },
       hideShowMissingnessToggle: true,
+      returnPointIds: false,
     }),
   },
   isEnabledInPicker: isEnabledInPicker,

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/alphaDiv.tsx
@@ -61,6 +61,7 @@ export const plugin: ComputationPlugin = {
         }
       },
       hideShowMissingnessToggle: true,
+      returnPointIds: false,
     }),
   },
   isEnabledInPicker: isEnabledInPicker,

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/betadiv.tsx
@@ -62,6 +62,7 @@ export const plugin: ComputationPlugin = {
         hideTrendlines: true,
         hideFacetInputs: true,
         hideLogScale: true,
+        returnPointIds: false,
       })
       .withSelectorIcon(ScatterBetadivSVG),
   },

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -286,6 +286,7 @@ interface Options
   ): VariableDescriptor | VariableCollectionDescriptor | undefined;
   hideTrendlines?: boolean;
   hideLogScale?: boolean;
+  returnPointIds?: boolean; // for ScatterplotRequestParams
 }
 
 function ScatterplotViz(props: VisualizationProps<Options>) {
@@ -752,7 +753,8 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
             ? [vizConfig.facetVariable]
             : undefined,
           showMissingness: vizConfig.showMissingness ? 'TRUE' : 'FALSE',
-          returnPointIds: vizConfig.returnPointIds ?? true,
+          returnPointIds:
+            options?.returnPointIds ?? vizConfig.returnPointIds ?? true,
         },
         computeConfig: copmutationAppOverview.computeName
           ? computationDescriptor.configuration

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -754,7 +754,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
             : undefined,
           showMissingness: vizConfig.showMissingness ? 'TRUE' : 'FALSE',
           returnPointIds:
-            options?.returnPointIds ?? vizConfig.returnPointIds ?? true,
+            options?.returnPointIds ?? true,
         },
         computeConfig: copmutationAppOverview.computeName
           ? computationDescriptor.configuration

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -240,7 +240,6 @@ function createDefaultConfig(): ScatterplotConfig {
     independentAxisValueSpec: 'Full',
     dependentAxisValueSpec: 'Full',
     markerBodyOpacity: 0.5,
-    returnPointIds: true,
   };
 }
 
@@ -263,7 +262,6 @@ export const ScatterplotConfig = t.partial({
   independentAxisValueSpec: t.string,
   dependentAxisValueSpec: t.string,
   markerBodyOpacity: t.number,
-  returnPointIds: t.boolean,
 });
 
 interface Options
@@ -286,7 +284,7 @@ interface Options
   ): VariableDescriptor | VariableCollectionDescriptor | undefined;
   hideTrendlines?: boolean;
   hideLogScale?: boolean;
-  returnPointIds?: boolean; // for ScatterplotRequestParams
+  returnPointIds?: boolean; // Determines whether the backend should return the ids of each point in the scatterplot
 }
 
 function ScatterplotViz(props: VisualizationProps<Options>) {
@@ -753,8 +751,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
             ? [vizConfig.facetVariable]
             : undefined,
           showMissingness: vizConfig.showMissingness ? 'TRUE' : 'FALSE',
-          returnPointIds:
-            options?.returnPointIds ?? true,
+          returnPointIds: options?.returnPointIds ?? true,
         },
         computeConfig: copmutationAppOverview.computeName
           ? computationDescriptor.configuration


### PR DESCRIPTION
With https://github.com/VEuPathDB/service-eda/pull/87, fixes the issue seen on QA with scatterplots.

Uses `options` to have apps tell the scatterplot viz not to request point Ids. Tested with the local backend on the above branch.