### PR TITLE
Another approach to fixing the long decimals in the histogram filter

### DIFF
--- a/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
+++ b/packages/libs/eda/src/lib/core/components/filter/HistogramFilter.tsx
@@ -47,6 +47,7 @@ import { useDebounce } from '../../hooks/debouncing';
 import { useDeepValue } from '../../hooks/immutability';
 // reset to defaults button
 import { ResetButtonCoreUI } from '../ResetButton';
+import { numberSignificantFigures } from '../../utils/number-significant-figures';
 
 type Props = {
   studyMetadata: StudyMetadata;
@@ -96,8 +97,10 @@ export function HistogramFilter(props: Props) {
       return {
         binWidth:
           variable.distributionDefaults.binWidthOverride ??
-          variable.distributionDefaults.binWidth ??
-          0.1,
+          numberSignificantFigures(
+            variable.distributionDefaults.binWidth ?? 0.1,
+            2
+          ),
         binWidthTimeUnit: undefined,
         independentAxisRange: defaultIndependentRange as NumberRange,
         ...otherDefaults,


### PR DESCRIPTION
This isn't a full fix, because let's say the binWidth is a reasonable `2.34` - the back end eventually suffers from "precision errors" and returns long decimal bin boundaries. The bin boundaries are what are selected as filter values when you "brush" a range across the histogram.

```
{
	"histogram": [
		{
			"value": 0,
			"binStart": "0.0",
			"binEnd": "2.34",
			"binLabel": "[0.0,2.34)"
		},
		{
			"value": 0,
			"binStart": "2.34",
			"binEnd": "4.68",
			"binLabel": "[2.34,4.68)"
		},
		{
			"value": 0,
			"binStart": "4.68",
			"binEnd": "7.02",
			"binLabel": "[4.68,7.02)"
		},
		{
			"value": 0,
			"binStart": "7.02",
			"binEnd": "9.36",
			"binLabel": "[7.02,9.36)"
		},
		{
			"value": 0,
			"binStart": "9.36",
			"binEnd": "11.7",
			"binLabel": "[9.36,11.7)"
		},
		{
			"value": 0,
			"binStart": "11.7",
			"binEnd": "14.04",
			"binLabel": "[11.7,14.04)"
		},
		{
			"value": 0,
			"binStart": "14.04",
			"binEnd": "16.38",
			"binLabel": "[14.04,16.38)"
		},
		{
			"value": 0,
			"binStart": "16.38",
			"binEnd": "18.72",
			"binLabel": "[16.38,18.72)"
		},
		{
			"value": 0,
			"binStart": "18.72",
			"binEnd": "21.06",
			"binLabel": "[18.72,21.06)"
		},
		{
			"value": 0,
			"binStart": "21.06",
			"binEnd": "23.4",
			"binLabel": "[21.06,23.4)"
		},
		{
			"value": 0,
			"binStart": "23.4",
			"binEnd": "25.74",
			"binLabel": "[23.4,25.74)"
		},
		{
			"value": 0,
			"binStart": "25.74",
			"binEnd": "28.08",
			"binLabel": "[25.74,28.08)"
		},
		{
			"value": 0,
			"binStart": "28.08",
			"binEnd": "30.419999999999998",
			"binLabel": "[28.08,30.419999999999998)"
		},
		{
			"value": 0,
			"binStart": "30.419999999999998",
			"binEnd": "32.76",
			"binLabel": "[30.419999999999998,32.76)"
		},
		{
			"value": 40,
			"binStart": "32.76",
			"binEnd": "35.099999999999994",
			"binLabel": "[32.76,35.099999999999994)"
		},
		{
			"value": 943,
			"binStart": "35.099999999999994",
			"binEnd": "37.44",
			"binLabel": "[35.099999999999994,37.44)"
		},
		{
			"value": 3,
			"binStart": "37.44",
			"binEnd": "39.78",
			"binLabel": "[37.44,39.78)"
		}
	],
	"statistics": {
		"subsetSize": 986,
		"subsetMin": 34,
		"subsetMax": 37.7999992370605,
		"subsetMean": 36.26034483222884,
		"numVarValues": 986,
		"numDistinctValues": 35,
		"numDistinctEntityRecords": 986,
		"numMissingCases": 0
	}
}
```