### PR TITLE
Add new fields to My user dataset page (AKA control page)

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -762,14 +762,14 @@ class UserDatasetDetail extends React.Component {
     const attributes = this.getAttributes();
     return (
       <div className={classify('AttributeList')}>
-        {attributes.map(({ attribute, value, className }, index) => (
+        {attributes.map(({ attribute, value, className }) => (
           <div
             className={
               classify('AttributeRow') +
               ' ' +
               (className ?? classify(attribute))
             }
-            key={index}
+            key={attribute}
           >
             <div className={classify('AttributeName')}>
               {typeof attribute === 'string' ? (

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -7,6 +7,7 @@ import Link from '@veupathdb/wdk-client/lib/Components/Link';
 import { Mesa, MesaState } from '@veupathdb/coreui/lib/components/Mesa';
 import { WdkDependenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
 import { bytesToHuman } from '@veupathdb/wdk-client/lib/Utils/Converters';
+import RadioList from '@veupathdb/wdk-client/lib/Components/InputControls/RadioList';
 
 import NotFound from '@veupathdb/wdk-client/lib/Views/NotFound/NotFound';
 
@@ -96,9 +97,9 @@ class UserDatasetDetail extends React.Component {
     this.validateKey(key);
 
     return (value) => {
-      if (value && typeof value !== 'string') {
+      if (typeof value !== 'string' && typeof value !== 'boolean') {
         throw new TypeError(
-          `onMetaSave: expected input value to be string; got ${typeof value}`
+          `onMetaSave: expected input value to be string or boolean; got ${typeof value}`
         );
       }
       if (nestedKey && typeof nestedKey !== 'string') {
@@ -516,12 +517,21 @@ class UserDatasetDetail extends React.Component {
                       emptyText="No Contact Address"
                     />
                     <span>Is Primary: </span>
-                    <SaveableTextEditor
-                      value={contact.state || ''}
-                      multiLine={false}
-                      readOnly={!isOwner}
-                      onSave={this.onMetaSave('contacts', 'isPrimary', index)}
-                      emptyText="How do we do this??"
+                    <RadioList
+                      name={`isPrimary-${index}`}
+                      className="horizontal"
+                      value={contact.isPrimary === true ? 'true' : 'false'}
+                      onChange={(value) => {
+                        this.onMetaSave(
+                          'contacts',
+                          'isPrimary', // this is the key in the hyperlink object
+                          index // the index of the hyperlink in the array
+                        )(value === 'true' ? true : false);
+                      }}
+                      items={[
+                        { value: 'true', display: 'Yes' },
+                        { value: 'false', display: 'No' },
+                      ]}
                     />
                   </div>
                 </div>
@@ -544,6 +554,7 @@ class UserDatasetDetail extends React.Component {
                     state: '',
                     country: '',
                     address: '',
+                    isPrimary: false,
                   }
                 )();
               }}
@@ -592,12 +603,23 @@ class UserDatasetDetail extends React.Component {
                       emptyText="No Hyperlink Description"
                     />
                     <span>Is Publication: </span>
-                    <SaveableTextEditor
-                      value={hyperlink.isPublication || ''}
-                      multiLine={false}
-                      readOnly={!isOwner}
-                      onSave={this.onMetaSave('description')}
-                      emptyText="How do we do this??"
+                    <RadioList
+                      name={`isPublication-${index}`}
+                      className="horizontal"
+                      value={
+                        hyperlink.isPublication === true ? 'true' : 'false'
+                      }
+                      onChange={(value) => {
+                        this.onMetaSave(
+                          'hyperlinks',
+                          'isPublication', // this is the key in the hyperlink object
+                          index // the index of the hyperlink in the array
+                        )(value === 'true' ? true : false);
+                      }}
+                      items={[
+                        { value: 'true', display: 'Yes' },
+                        { value: 'false', display: 'No' },
+                      ]}
                     />
                   </div>
                 </div>

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -141,9 +141,6 @@ class UserDatasetDetail extends React.Component {
         updatedMeta = { ...userDataset.meta, [key]: value };
       }
 
-      // FOR TESTSING ONLY
-      console.log('updatedMeta', updatedMeta);
-
       return updateUserDatasetDetail(userDataset, updatedMeta);
     };
   }

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -214,49 +214,6 @@ class UserDatasetDetail extends React.Component {
         'userDatasetType' in q.properties &&
         q.properties.userDatasetType.includes(type.name)
     );
-    // FOR TESTING ONLY
-    meta.publications = [
-      {
-        pubMedId: 'id1',
-        citation: 'citation1',
-      },
-      {
-        pubMedId: 'id2',
-        citation: 'citation2',
-      },
-    ];
-    meta.contacts = [
-      {
-        name: 'Kay',
-        email: 'buzz.com',
-      },
-      {
-        name: 'Ray',
-        city: 'Pizza place',
-      },
-      {
-        name: 'Fey',
-        affiliation: 'A hundred and 3 University',
-      },
-    ];
-    meta.hyperlinks = [
-      {
-        url: 'abc.com',
-        text: 'abc',
-        description: 'abc description',
-        isPublication: false, // this is optional, default is false
-      },
-    ];
-    meta.organisms = ['E coli', 'Staph', 'Beavers'];
-    meta.publications = [
-      {
-        pubMedId: 'id1',
-        citation: 'citation1',
-      },
-      {
-        pubMedId: 'id2',
-      },
-    ];
 
     return [
       this.props.includeNameHeader

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -521,6 +521,40 @@ class UserDatasetDetail extends React.Component {
           </div>
         ),
       },
+      {
+        attribute: 'Organisms',
+        value: (
+          <div>
+            <br></br>
+            <div>
+              {meta.organisms.map((organism, index) => {
+                return (
+                  <div className={classify('NestedFieldValues-Organisms')}>
+                    <span>Organism {index + 1}: </span>
+                    <SaveableTextEditor
+                      value={organism || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Organism"
+                    />
+                  </div>
+                );
+              })}
+            </div>
+            <OutlinedButton
+              text="Add Organism"
+              onPress={(event) => {
+                event.preventDefault();
+                console.log('Adding new organism');
+                // Logic to add a new organism entry
+              }}
+              icon={AddIcon}
+            />
+            <br></br>
+          </div>
+        ),
+      },
     ].filter((attr) => attr);
   }
 

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -21,6 +21,9 @@ import { DateTime } from '../DateTime';
 
 import '../UserDatasets.scss';
 import './UserDatasetDetail.scss';
+import { PublicationInput } from '../UploadForm';
+import OutlinedButton from '@veupathdb/coreui/lib/components/buttons/OutlinedButton';
+import AddIcon from '@material-ui/icons/Add';
 
 const classify = makeClassifier('UserDatasetDetail');
 
@@ -142,6 +145,7 @@ class UserDatasetDetail extends React.Component {
     const { onMetaSave } = this;
     const { id, type, meta, size, owner, created, sharedWith, status } =
       userDataset;
+    console.log('userDataset', userDataset);
     const { display, name, version } = type;
     const isOwner = this.isMyDataset();
     const isInstalled = this.isInstalled();
@@ -150,6 +154,49 @@ class UserDatasetDetail extends React.Component {
         'userDatasetType' in q.properties &&
         q.properties.userDatasetType.includes(type.name)
     );
+    // FOR TESTING ONLY
+    meta.publications = [
+      {
+        pubMedId: 'id1',
+        citation: 'citation1',
+      },
+      {
+        pubMedId: 'id2',
+        citation: 'citation2',
+      },
+    ];
+    meta.contacts = [
+      {
+        name: 'Kay',
+        email: 'buzz.com',
+      },
+      {
+        name: 'Ray',
+        city: 'Pizza place',
+      },
+      {
+        name: 'Fey',
+        affiliation: 'A hundred and 3 University',
+      },
+    ];
+    meta.hyperlinks = [
+      {
+        url: 'abc.com',
+        text: 'abc',
+        description: 'abc description',
+        isPublication: false, // this is optional, default is false
+      },
+    ];
+    meta.organisms = ['E coli', 'Staph', 'Beavers'];
+    meta.publications = [
+      {
+        pubMedId: 'id1',
+        citation: 'citation1',
+      },
+      {
+        pubMedId: 'id2',
+      },
+    ];
 
     return [
       this.props.includeNameHeader
@@ -281,6 +328,197 @@ class UserDatasetDetail extends React.Component {
           <span>
             {display} ({name} {version})
           </span>
+        ),
+      },
+      {
+        attribute: 'Publications',
+        value: (
+          <div>
+            <br></br>
+            {meta.publications.map((publication, index) => {
+              return (
+                <div className={classify('NestedField')}>
+                  <span>Publication {index + 1}</span>
+                  <div className={classify('NestedFieldValues')}>
+                    <span>PubMed ID: </span>
+                    <SaveableTextEditor
+                      value={publication.pubMedId || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No PubMed ID"
+                    />
+                    <span>Citation : </span>
+                    <SaveableTextEditor
+                      value={publication.citation || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Citation"
+                    />
+                  </div>
+                </div>
+              );
+            })}
+            <OutlinedButton
+              text="Add Publication"
+              onPress={(event) => {
+                event.preventDefault();
+                console.log('Adding new publication');
+                // Logic to add a new publication entry
+              }}
+              icon={AddIcon}
+            />
+            <br></br>
+          </div>
+        ),
+      },
+      {
+        attribute: 'Contacts',
+        value: (
+          <div>
+            <br></br>
+            {meta.contacts.map((contact, index) => {
+              return (
+                <div className={classify('NestedField')}>
+                  <span>Contact {index + 1}</span>
+                  <div className={classify('NestedFieldValues')}>
+                    <span>Name: </span>
+                    <SaveableTextEditor
+                      value={contact.name || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Contact Name"
+                    />
+                    <span>Email: </span>
+                    <SaveableTextEditor
+                      value={contact.email || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Contact Email"
+                    />
+                    <span>Affiliation: </span>
+                    <SaveableTextEditor
+                      value={contact.affiliation || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Contact Affiliation"
+                    />
+                    <span>City: </span>
+                    <SaveableTextEditor
+                      value={contact.city || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Contact City"
+                    />
+                    <span>State: </span>
+                    <SaveableTextEditor
+                      value={contact.state || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Contact State"
+                    />
+                    <span>Country: </span>
+                    <SaveableTextEditor
+                      value={contact.country || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Contact Country"
+                    />
+                    <span>Address: </span>
+                    <SaveableTextEditor
+                      value={contact.address || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Contact Address"
+                    />
+                    <span>Is Primary: </span>
+                    <SaveableTextEditor
+                      value={contact.state || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="How do we do this??"
+                    />
+                  </div>
+                </div>
+              );
+            })}
+            <OutlinedButton
+              text="Add Contact"
+              onPress={(event) => {
+                event.preventDefault();
+                console.log('Adding new contact');
+              }}
+              icon={AddIcon}
+            />
+            <br></br>
+          </div>
+        ),
+      },
+      {
+        attribute: 'Hyperlinks',
+        value: (
+          <div>
+            <br></br>
+            {meta.hyperlinks.map((hyperlink, index) => {
+              return (
+                <div className={classify('NestedField')}>
+                  <span>Hyperlink {index + 1}</span>
+                  <div className={classify('NestedFieldValues')}>
+                    <span>URL: </span>
+                    <SaveableTextEditor
+                      value={hyperlink.url || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Hyperlink URL"
+                    />
+                    <span>Text: </span>
+                    <SaveableTextEditor
+                      value={hyperlink.text || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Hyperlink Text"
+                    />
+                    <span>Description: </span>
+                    <SaveableTextEditor
+                      value={hyperlink.description || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="No Hyperlink Description"
+                    />
+                    <span>Is Publication: </span>
+                    <SaveableTextEditor
+                      value={hyperlink.isPublication || ''}
+                      multiLine={false}
+                      readOnly={!isOwner}
+                      onSave={this.onMetaSave('description')}
+                      emptyText="How do we do this??"
+                    />
+                  </div>
+                </div>
+              );
+            })}
+            <OutlinedButton
+              text="Add Hyperlink"
+              onPress={(event) => {
+                event.preventDefault();
+                console.log('Adding new hyperlink');
+              }}
+              icon={AddIcon}
+            />
+            <br></br>
+          </div>
         ),
       },
     ].filter((attr) => attr);

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -89,18 +89,17 @@ class UserDatasetDetail extends React.Component {
   // First, the easy key-value example. this.onMetaSave('name')('my new name');
   // Second, for fields that are arrays of objects, like meta.publications[index].name, specify the nestedKey and index. this.onMetaSave('publications', 'pubMedId', 0)('new pubMedId value');
   // Third, for arrays of strings, like meta.organisms[index], just specify the index. this.onMetaSave('organisms', undefined, 0)('new organism value');
-  onMetaSave(
-    key,
-    nestedKey = undefined,
-    index = undefined,
-    emptyObject = undefined
-  ) {
+  onMetaSave(key, nestedKey = undefined, index = undefined) {
     this.validateKey(key);
 
     return (value) => {
-      if (typeof value !== 'string' && typeof value !== 'boolean') {
+      if (
+        typeof value !== 'string' &&
+        typeof value !== 'boolean' &&
+        typeof value !== 'object'
+      ) {
         throw new TypeError(
-          `onMetaSave: expected input value to be string or boolean; got ${typeof value}`
+          `onMetaSave: expected input value to be string or boolean or object; got ${typeof value}`
         );
       }
       if (nestedKey && typeof nestedKey !== 'string') {
@@ -111,11 +110,6 @@ class UserDatasetDetail extends React.Component {
       if (index && !Number.isInteger(index)) {
         throw new TypeError(
           `onMetaSave: expected index to be an integer; got ${typeof index} with value ${index}`
-        );
-      }
-      if (emptyObject && typeof emptyObject !== 'object') {
-        throw new TypeError(
-          `onMetaSave: expected emptyObject to be an object; got ${typeof emptyObject}`
         );
       }
 
@@ -138,7 +132,8 @@ class UserDatasetDetail extends React.Component {
           updatedMeta = { ...userDataset.meta, [key]: arrayField };
         } else {
           // Add new entry to the array
-          arrayField.push(emptyObject);
+          // We use this case to add new empty objects to the array.
+          arrayField.push(value);
           updatedMeta = { ...userDataset.meta, [key]: arrayField };
         }
       } else {
@@ -456,9 +451,8 @@ class UserDatasetDetail extends React.Component {
                 this.onMetaSave(
                   'publications',
                   undefined,
-                  meta.publications.length,
-                  { pubMedId: '', citation: '' }
-                )();
+                  meta.publications.length
+                )({ pubMedId: '', citation: '' });
               }}
               icon={AddIcon}
             />
@@ -575,19 +569,18 @@ class UserDatasetDetail extends React.Component {
                 this.onMetaSave(
                   'contacts',
                   undefined, // no nested key since we're adding a new contact
-                  meta.contacts.length, // add to the end of the array
-                  {
-                    // new contact entry
-                    name: '',
-                    email: '',
-                    affiliation: '',
-                    city: '',
-                    state: '',
-                    country: '',
-                    address: '',
-                    isPrimary: false,
-                  }
-                )();
+                  meta.contacts.length // add to the end of the array
+                )({
+                  // new contact entry
+                  name: '',
+                  email: '',
+                  affiliation: '',
+                  city: '',
+                  state: '',
+                  country: '',
+                  address: '',
+                  isPrimary: false,
+                });
               }}
               icon={AddIcon}
             />
@@ -678,15 +671,14 @@ class UserDatasetDetail extends React.Component {
                 this.onMetaSave(
                   'hyperlinks',
                   undefined, // no nested key since we're adding a new hyperlink
-                  meta.hyperlinks.length, // add to the end of the array
-                  {
-                    // new hyperlink entry
-                    url: '',
-                    text: '',
-                    description: '',
-                    isPublication: false, // default to false unless specified
-                  }
-                )();
+                  meta.hyperlinks.length // add to the end of the array
+                )({
+                  // new hyperlink entry
+                  url: '',
+                  text: '',
+                  description: '',
+                  isPublication: false, // default to false unless specified
+                });
               }}
               icon={AddIcon}
             />
@@ -735,9 +727,8 @@ class UserDatasetDetail extends React.Component {
                 this.onMetaSave(
                   'organisms',
                   undefined, // no nested key since we're adding a new organism
-                  meta.organisms.length ?? 0, // add to the end of the array
-                  '' // default value for new organism entry
-                )();
+                  meta.organisms.length ?? 0 // add to the end of the array
+                )('');
               }}
               icon={AddIcon}
             />

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.jsx
@@ -25,6 +25,7 @@ import './UserDatasetDetail.scss';
 import { PublicationInput } from '../UploadForm';
 import OutlinedButton from '@veupathdb/coreui/lib/components/buttons/OutlinedButton';
 import AddIcon from '@material-ui/icons/Add';
+import { FloatingButton, Trash } from '@veupathdb/coreui';
 
 const classify = makeClassifier('UserDatasetDetail');
 
@@ -210,7 +211,6 @@ class UserDatasetDetail extends React.Component {
     const { onMetaSave } = this;
     const { id, type, meta, size, owner, created, sharedWith, status } =
       userDataset;
-    console.log('userDataset', userDataset);
     const { display, name, version } = type;
     const isOwner = this.isMyDataset();
     const isInstalled = this.isInstalled();
@@ -397,13 +397,29 @@ class UserDatasetDetail extends React.Component {
       },
       {
         attribute: 'Publications',
+        className: 'NestedFieldsSection',
         value: (
-          <div>
-            <br></br>
+          <div className={classify('NestedFields')}>
             {meta.publications.map((publication, index) => {
               return (
                 <div className={classify('NestedField')}>
-                  <span>Publication {index + 1}</span>
+                  <div className={classify('NestedFieldHeader')}>
+                    <span>Publication {index + 1}</span>
+                    <FloatingButton
+                      text="Remove"
+                      icon={Trash}
+                      onPress={(event) => {
+                        event.preventDefault();
+                        // Remove the organism from the array
+                        const newPublications = [...meta.publications];
+                        newPublications.splice(index, 1); // remove the item at index
+                        this.props.updateUserDatasetDetail(userDataset, {
+                          ...userDataset.meta,
+                          publications: newPublications,
+                        });
+                      }}
+                    />
+                  </div>
                   <div className={classify('NestedFieldValues')}>
                     <span>PubMed ID: </span>
                     <SaveableTextEditor
@@ -446,19 +462,34 @@ class UserDatasetDetail extends React.Component {
               }}
               icon={AddIcon}
             />
-            <br></br>
           </div>
         ),
       },
       {
         attribute: 'Contacts',
+        className: 'NestedFieldsSection',
         value: (
-          <div>
-            <br></br>
+          <div className={classify('NestedFields')}>
             {meta.contacts.map((contact, index) => {
               return (
                 <div className={classify('NestedField')}>
-                  <span>Contact {index + 1}</span>
+                  <div className={classify('NestedFieldHeader')}>
+                    <span>Contact {index + 1}</span>
+                    <FloatingButton
+                      text="Remove"
+                      icon={Trash}
+                      onPress={(event) => {
+                        event.preventDefault();
+                        // Remove the organism from the array
+                        const newContacts = [...meta.contacts];
+                        newContacts.splice(index, 1); // remove the item at index
+                        this.props.updateUserDatasetDetail(userDataset, {
+                          ...userDataset.meta,
+                          contacts: newContacts,
+                        });
+                      }}
+                    />
+                  </div>
                   <div className={classify('NestedFieldValues')}>
                     <span>Name: </span>
                     <SaveableTextEditor
@@ -560,19 +591,34 @@ class UserDatasetDetail extends React.Component {
               }}
               icon={AddIcon}
             />
-            <br></br>
           </div>
         ),
       },
       {
         attribute: 'Hyperlinks',
+        className: 'NestedFieldsSection',
         value: (
-          <div>
-            <br></br>
+          <div className={classify('NestedFields')}>
             {meta.hyperlinks.map((hyperlink, index) => {
               return (
                 <div className={classify('NestedField')}>
-                  <span>Hyperlink {index + 1}</span>
+                  <div className={classify('NestedFieldHeader')}>
+                    <span>Hyperlink {index + 1}</span>
+                    <FloatingButton
+                      text="Remove"
+                      icon={Trash}
+                      onPress={(event) => {
+                        event.preventDefault();
+                        // Remove the organism from the array
+                        const newHyperlinks = [...meta.hyperlinks];
+                        newHyperlinks.splice(index, 1); // remove the item at index
+                        this.props.updateUserDatasetDetail(userDataset, {
+                          ...userDataset.meta,
+                          hyperlinks: newHyperlinks,
+                        });
+                      }}
+                    />
+                  </div>
                   <div className={classify('NestedFieldValues')}>
                     <span>URL: </span>
                     <SaveableTextEditor
@@ -644,15 +690,14 @@ class UserDatasetDetail extends React.Component {
               }}
               icon={AddIcon}
             />
-            <br></br>
           </div>
         ),
       },
       {
         attribute: 'Organisms',
+        className: 'NestedFieldsSection',
         value: (
-          <div>
-            <br></br>
+          <div className={classify('NestedFields')}>
             <div>
               {meta.organisms.map((organism, index) => {
                 return (
@@ -664,6 +709,20 @@ class UserDatasetDetail extends React.Component {
                       readOnly={!isOwner}
                       onSave={this.onMetaSave('organisms', undefined, index)}
                       emptyText="No Organism"
+                    />
+                    <FloatingButton
+                      text="Remove"
+                      icon={Trash}
+                      onPress={(event) => {
+                        event.preventDefault();
+                        // Remove the organism from the array
+                        const newOrganisms = [...meta.organisms];
+                        newOrganisms.splice(index, 1); // remove the item at index
+                        this.props.updateUserDatasetDetail(userDataset, {
+                          ...userDataset.meta,
+                          organisms: newOrganisms,
+                        });
+                      }}
                     />
                   </div>
                 );
@@ -682,7 +741,6 @@ class UserDatasetDetail extends React.Component {
               }}
               icon={AddIcon}
             />
-            <br></br>
           </div>
         ),
       },

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
@@ -110,6 +110,20 @@
         }
       }
 
+      &.NestedFieldsSection {
+        flex: auto;
+        flex-direction: column;
+        margin-bottom: 1.5em;
+      }
+
+      .UserDatasetDetail-NestedFields {
+        margin-left: 1em;
+      }
+
+      // .UserDatasetDetail-NestedField {
+      //   margin-left: 2em;
+      // }
+
       .UserDatasetDetail-AttributeName {
         flex: 0 0 auto;
         padding-right: 10px;
@@ -126,22 +140,25 @@
           }
         }
       }
-      // .UserDatasetDetail-NestedField {
-      //   margin-left: -3em;
-      // }
       .UserDatasetDetail-NestedFieldValues {
         display: grid;
         grid-template-columns: 7em 20em;
         align-items: baseline;
-        padding-left: 2em;
+        padding-left: 1em;
         margin-bottom: 1em;
         margin-top: 0.3em;
       }
       .UserDatasetDetail-NestedFieldValues-Organisms {
         display: grid;
-        grid-template-columns: 7em 20em;
-        align-items: baseline;
+        grid-template-columns: 7em 20em 5em;
+        align-items: center;
         margin-bottom: 0.3em;
+      }
+      .UserDatasetDetail-NestedFieldHeader {
+        display: flex;
+        gap: 45px;
+        align-items: center;
+        font-weight: bolder;
       }
     }
     .UserDatasetDetail {

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
@@ -126,9 +126,9 @@
           }
         }
       }
-      .UserDatasetDetail-NestedField {
-        margin-left: -3em;
-      }
+      // .UserDatasetDetail-NestedField {
+      //   margin-left: -3em;
+      // }
       .UserDatasetDetail-NestedFieldValues {
         display: grid;
         grid-template-columns: 7em 20em;
@@ -141,7 +141,7 @@
         display: grid;
         grid-template-columns: 7em 20em;
         align-items: baseline;
-        margin-bottom: 0.1em;
+        margin-bottom: 0.3em;
       }
     }
     .UserDatasetDetail {

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
@@ -126,6 +126,17 @@
           }
         }
       }
+      .UserDatasetDetail-NestedField {
+        margin-left: -3em;
+      }
+      .UserDatasetDetail-NestedFieldValues {
+        display: grid;
+        grid-template-columns: 7em 20em;
+        align-items: baseline;
+        padding-left: 2em;
+        margin-bottom: 1em;
+        margin-top: 0.3em;
+      }
     }
     .UserDatasetDetail {
       &-Owner,

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.scss
@@ -137,6 +137,12 @@
         margin-bottom: 1em;
         margin-top: 0.3em;
       }
+      .UserDatasetDetail-NestedFieldValues-Organisms {
+        display: grid;
+        grid-template-columns: 7em 20em;
+        align-items: baseline;
+        margin-bottom: 0.1em;
+      }
     }
     .UserDatasetDetail {
       &-Owner,

--- a/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UploadForm.tsx
@@ -981,7 +981,7 @@ interface PublicationInputProps {
   citation?: string;
 }
 
-function PublicationInput(props: PublicationInputProps): JSX.Element {
+export function PublicationInput(props: PublicationInputProps): JSX.Element {
   const {
     n,
     pubMedId = '',

--- a/packages/libs/web-common/src/App/UserMenu/UserMenu.jsx
+++ b/packages/libs/web-common/src/App/UserMenu/UserMenu.jsx
@@ -42,23 +42,28 @@ class UserMenu extends React.Component {
 
     return (
       <div className="UserMenu-Pane">
-        {items.map((item, key) => {
-          const { route, target, onClick } = item;
+        {items.map(({ route, target, onClick, icon, text }) => {
+          const key = icon; // previously we used the index but this was creating a warning
           const className = 'UserMenu-Pane-Item';
 
           if (onClick) {
             return (
-              <button type="button" className={className} onClick={onClick}>
-                <Icon fa={item.icon + ' UserMenu-Pane-Item-Icon'} />
-                {item.text}
+              <button
+                key={key}
+                type="button"
+                className={className}
+                onClick={onClick}
+              >
+                <Icon fa={icon + ' UserMenu-Pane-Item-Icon'} />
+                {text}
               </button>
             );
           }
 
           return (
             <Link key={key} className={className} to={route} target={target}>
-              <Icon fa={item.icon + ' UserMenu-Pane-Item-Icon'} />
-              {item.text}
+              <Icon fa={icon + ' UserMenu-Pane-Item-Icon'} />
+              {text}
             </Link>
           );
         })}


### PR DESCRIPTION
Resolves #1359 

Adds places for users to input and edit any of the newest fields for their user datasets.

Note: Can't really submit because vdi isn't working yet. But can check using the test code i have in the PR (all marked as test)

To Dos:

- [x] Figure out how it all works
- [x] Add placeholders for all nested structures
- [x] Add inputs for organisms
- [x] Adjust `onMetaSave` or make similar method that saves nested updates
- [x] Figure our what to do with the boolean inputs
- [x] Add remove buttons


Testing:
Since the VDI plugin isn't set up yet, I've just hardcoded some examples, and put a console.log so you can see that the appropriate fields are getting updated.