### PR TITLE
Conditionally disable AI expression summary and nav menu item if no WDK reporter available

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
@@ -37,6 +37,13 @@ export function AiExpressionSummary(props: Props) {
   const { attribute, record, isCollapsed, onCollapsedChange, title } = props;
   const { displayName, help, name } = attribute;
 
+  // No gene page section at all if there's no reporter available on the back end
+  if (
+    !props.recordClass.formats.some((format) => format.name === 'aiExpression')
+  ) {
+    return null;
+  }
+
   const headerContent = title ?? (
     <DefaultSectionTitle displayName={displayName} help={help} />
   );

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
@@ -37,13 +37,6 @@ export function AiExpressionSummary(props: Props) {
   const { attribute, record, isCollapsed, onCollapsedChange, title } = props;
   const { displayName, help, name } = attribute;
 
-  // No gene page section at all if there's no reporter available on the back end
-  if (
-    !props.recordClass.formats.some((format) => format.name === 'aiExpression')
-  ) {
-    return null;
-  }
-
   const headerContent = title ?? (
     <DefaultSectionTitle displayName={displayName} help={help} />
   );
@@ -67,7 +60,7 @@ export function AiExpressionSummary(props: Props) {
       onCollapsedChange={onCollapsedChange}
     >
       <ErrorBoundary>
-        {record.attributes['ai_expression'] == 'YES' ? (
+        {record.attributes['ai_expression'] === 'YES' ? (
           datasetCount < MIN_DATASETS_FOR_AI_SUMMARY ? (
             <div>
               The AI Expression Summary feature is not available for genes with


### PR DESCRIPTION
Hi @dmfalke - would you mind taking a look at this?

We decided not to have a front end feature flag, but instead switch the feature on/off based on the availability of the back end Reporter.

I found a reasonably elegant way to disable the left hand navigation item. <s>Is the `return null` the only way to disable the actual section?</s> Both disabled by recordStoreModule upon loading.
