### PR TITLE
Ortho ghost overlay fixes

### DIFF
--- a/packages/libs/coreui/src/components/buttons/PopoverButton/PopoverButton.tsx
+++ b/packages/libs/coreui/src/components/buttons/PopoverButton/PopoverButton.tsx
@@ -7,7 +7,7 @@ import {
   useImperativeHandle,
   useCallback,
 } from 'react';
-import { Popover } from '@material-ui/core';
+import { Popover, PopoverProps } from '@material-ui/core';
 import SwissArmyButton from '../SwissArmyButton';
 import { gray } from '../../../definitions/colors';
 import { ButtonStyleSpec, PartialButtonStyleSpec } from '..';
@@ -95,6 +95,12 @@ export interface PopoverButtonProps {
   isDisabled?: boolean;
 
   styleOverrides?: PartialButtonStyleSpec;
+
+  /** Optional to provide animated appear/disappear
+   * provide either an integer milliseconds (appear and disappear)
+   * or an object with separate timings: { enter: 300, exit: 600 }
+   */
+  transitionDuration?: PopoverProps['transitionDuration'];
 }
 
 /**
@@ -110,6 +116,7 @@ const PopoverButton = forwardRef<PopoverButtonHandle, PopoverButtonProps>(
       setIsPopoverOpen,
       isDisabled = false,
       styleOverrides = {},
+      transitionDuration,
     } = props;
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
@@ -160,6 +167,7 @@ const PopoverButton = forwardRef<PopoverButtonHandle, PopoverButtonProps>(
           horizontal: 'left',
         }}
         keepMounted
+        transitionDuration={transitionDuration}
       >
         {children}
       </Popover>

--- a/packages/libs/coreui/src/components/containers/Dimmable.tsx
+++ b/packages/libs/coreui/src/components/containers/Dimmable.tsx
@@ -10,6 +10,9 @@ export interface DimmableProps {
   blocking?: boolean;
   /** z-index of the overlay (useful if you nest multiple layers) */
   overlayZIndex?: number;
+  /** optional spinner component */
+  spinner?: React.ReactNode;
+  /** contents for the dimmable container */
   children: React.ReactNode;
 }
 
@@ -19,6 +22,7 @@ export default function Dimmable({
   overlayZIndex = 1,
   children,
   fullscreen = false,
+  spinner = null,
 }: DimmableProps) {
   return (
     <div
@@ -27,18 +31,42 @@ export default function Dimmable({
       `}
     >
       {dimmed && (
-        <div
-          css={css`
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background-color: rgba(0, 0, 0, 0.1);
-            z-index: ${overlayZIndex};
-            pointer-events: ${blocking ? 'all' : 'none'};
-          `}
-        />
+        <>
+          {/* The grey overlay */}
+          <div
+            css={css`
+              position: absolute;
+              top: 0;
+              left: 0;
+              width: 100%;
+              height: 100%;
+              background-color: rgba(0, 0, 0, 0.1);
+              z-index: ${overlayZIndex};
+              pointer-events: ${blocking ? 'all' : 'none'};
+            `}
+          />
+
+          {/* Spinner container, centered */}
+          {spinner && (
+            <div
+              css={css`
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                z-index: ${overlayZIndex + 1};
+                /* spinner shouldn’t block clicks itself */
+                pointer-events: none;
+              `}
+            >
+              {spinner}
+            </div>
+          )}
+        </>
       )}
       {children}
     </div>

--- a/packages/libs/coreui/src/components/containers/Dimmable.tsx
+++ b/packages/libs/coreui/src/components/containers/Dimmable.tsx
@@ -1,0 +1,46 @@
+import { css } from '@emotion/react';
+import React from 'react';
+
+export interface DimmableProps {
+  /** When true, show the semi-transparent overlay */
+  dimmed: boolean;
+  /** if true, overlay covers the entire screen (for portal/modal content) */
+  fullscreen?: boolean;
+  /** If true, overlay will block clicks; otherwise clicks pass through */
+  blocking?: boolean;
+  /** z-index of the overlay (useful if you nest multiple layers) */
+  overlayZIndex?: number;
+  children: React.ReactNode;
+}
+
+export default function Dimmable({
+  dimmed,
+  blocking = false,
+  overlayZIndex = 1,
+  children,
+  fullscreen = false,
+}: DimmableProps) {
+  return (
+    <div
+      css={css`
+        position: ${fullscreen ? `static` : `relative`};
+      `}
+    >
+      {dimmed && (
+        <div
+          css={css`
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.1);
+            z-index: ${overlayZIndex};
+            pointer-events: ${blocking ? 'all' : 'none'};
+          `}
+        />
+      )}
+      {children}
+    </div>
+  );
+}

--- a/packages/libs/coreui/src/components/containers/index.ts
+++ b/packages/libs/coreui/src/components/containers/index.ts
@@ -2,3 +2,4 @@ export { default as Card } from './Card';
 export { default as Modal } from './Modal';
 export { default as ExpandablePanel } from './ExpandablePanel';
 export { default as DraggablePanel } from './DraggablePanel';
+export { default as Dimmable } from './Dimmable';

--- a/packages/libs/coreui/src/components/inputs/SelectList.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectList.tsx
@@ -37,12 +37,19 @@ export default function SelectList<T extends string>({
     getDisplayContent(value, items, defaultButtonDisplayContent)
   );
 
-  const onClose = () => {
-    onChange(selected);
+  const onClose = useCallback(() => {
+    if (!instantUpdate) onChange(selected);
     setButtonDisplayContent(
       getDisplayContent(selected, items, defaultButtonDisplayContent)
     );
-  };
+  }, [
+    instantUpdate,
+    selected,
+    items,
+    defaultButtonDisplayContent,
+    onChange,
+    setButtonDisplayContent,
+  ]);
 
   /**
    * Keep caller up to date with any selection changes, if required by `instantUpdate`

--- a/packages/libs/coreui/src/components/inputs/SelectList.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectList.tsx
@@ -39,7 +39,6 @@ export default function SelectList<T extends string>({
   const [buttonDisplayContent, setButtonDisplayContent] = useState<ReactNode>(
     getDisplayContent(value, items, defaultButtonDisplayContent)
   );
-  const [isOpen, setIsOpen] = useState(false);
 
   const onClose = useCallback(() => {
     if (!instantUpdate) onChange(selected);
@@ -53,15 +52,12 @@ export default function SelectList<T extends string>({
    */
   const handleCheckboxListUpdate = useCallback(
     (newSelection: SelectListProps<T>['value']) => {
-      // only allow updates while open
-      // seems obvious, but animated transitions blur the lines
-      if (!isOpen) return;
       setSelected(newSelection);
       if (instantUpdate) {
         onChange(newSelection);
       }
     },
-    [instantUpdate, onChange, isOpen]
+    [instantUpdate, onChange]
   );
 
   /**
@@ -94,7 +90,6 @@ export default function SelectList<T extends string>({
       buttonDisplayContent={buttonLabel}
       onClose={onClose}
       isDisabled={isDisabled}
-      setIsPopoverOpen={setIsOpen}
       deferClosing={deferPopoverClosing}
     >
       <div

--- a/packages/libs/coreui/src/components/inputs/SelectList.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectList.tsx
@@ -44,6 +44,7 @@ export default function SelectList<T extends string>({
   const [buttonDisplayContent, setButtonDisplayContent] = useState<ReactNode>(
     getDisplayContent(value, items, defaultButtonDisplayContent)
   );
+  const [isOpen, setIsOpen] = useState(false);
 
   const onClose = useCallback(() => {
     if (!instantUpdate) onChange(selected);
@@ -57,12 +58,15 @@ export default function SelectList<T extends string>({
    */
   const handleCheckboxListUpdate = useCallback(
     (newSelection: SelectListProps<T>['value']) => {
+      // only allow updates while open
+      // seems obvious, but animated transitions blur the lines
+      if (!isOpen) return;
       setSelected(newSelection);
       if (instantUpdate) {
         onChange(newSelection);
       }
     },
-    [instantUpdate, setSelected, onChange]
+    [instantUpdate, onChange, isOpen]
   );
 
   /**
@@ -96,6 +100,7 @@ export default function SelectList<T extends string>({
       onClose={onClose}
       isDisabled={isDisabled}
       transitionDuration={transitionDuration}
+      setIsPopoverOpen={setIsOpen}
     >
       <div
         css={{

--- a/packages/libs/coreui/src/components/inputs/SelectList.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectList.tsx
@@ -1,7 +1,5 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
-import PopoverButton, {
-  PopoverButtonProps,
-} from '../buttons/PopoverButton/PopoverButton';
+import PopoverButton from '../buttons/PopoverButton/PopoverButton';
 import CheckboxList, {
   CheckboxListProps,
   Item,
@@ -19,11 +17,8 @@ export interface SelectListProps<T extends string>
    *  with latest selection.
    */
   instantUpdate?: boolean;
-  /** Optional to provide animated appear/disappear
-   * provide either an integer milliseconds (appear and disappear)
-   * or an object with separate timings: { enter: 300, exit: 600 }
-   */
-  transitionDuration?: PopoverButtonProps['transitionDuration'];
+  /** Optional. When true, popover closing will be deferred until this becomes false */
+  deferPopoverClosing?: boolean;
 }
 
 export default function SelectList<T extends string>({
@@ -37,7 +32,7 @@ export default function SelectList<T extends string>({
   isDisabled = false,
   isLoading = false,
   instantUpdate = false,
-  transitionDuration,
+  deferPopoverClosing = false,
   ...props
 }: SelectListProps<T>) {
   const [selected, setSelected] = useState<SelectListProps<T>['value']>(value);
@@ -99,8 +94,8 @@ export default function SelectList<T extends string>({
       buttonDisplayContent={buttonLabel}
       onClose={onClose}
       isDisabled={isDisabled}
-      transitionDuration={transitionDuration}
       setIsPopoverOpen={setIsOpen}
+      deferClosing={deferPopoverClosing}
     >
       <div
         css={{

--- a/packages/libs/coreui/src/components/inputs/SelectList.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectList.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
-import PopoverButton from '../buttons/PopoverButton/PopoverButton';
+import PopoverButton, {
+  PopoverButtonProps,
+} from '../buttons/PopoverButton/PopoverButton';
 import CheckboxList, {
   CheckboxListProps,
   Item,
@@ -17,6 +19,11 @@ export interface SelectListProps<T extends string>
    *  with latest selection.
    */
   instantUpdate?: boolean;
+  /** Optional to provide animated appear/disappear
+   * provide either an integer milliseconds (appear and disappear)
+   * or an object with separate timings: { enter: 300, exit: 600 }
+   */
+  transitionDuration?: PopoverButtonProps['transitionDuration'];
 }
 
 export default function SelectList<T extends string>({
@@ -30,6 +37,7 @@ export default function SelectList<T extends string>({
   isDisabled = false,
   isLoading = false,
   instantUpdate = false,
+  transitionDuration,
   ...props
 }: SelectListProps<T>) {
   const [selected, setSelected] = useState<SelectListProps<T>['value']>(value);
@@ -87,6 +95,7 @@ export default function SelectList<T extends string>({
       buttonDisplayContent={buttonLabel}
       onClose={onClose}
       isDisabled={isDisabled}
+      transitionDuration={transitionDuration}
     >
       <div
         css={{

--- a/packages/libs/coreui/src/components/inputs/SelectList.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectList.tsx
@@ -42,14 +42,7 @@ export default function SelectList<T extends string>({
     setButtonDisplayContent(
       getDisplayContent(selected, items, defaultButtonDisplayContent)
     );
-  }, [
-    instantUpdate,
-    selected,
-    items,
-    defaultButtonDisplayContent,
-    onChange,
-    setButtonDisplayContent,
-  ]);
+  }, [instantUpdate, selected, items, defaultButtonDisplayContent, onChange]);
 
   /**
    * Keep caller up to date with any selection changes, if required by `instantUpdate`

--- a/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useState } from 'react';
 import PopoverButton, {
   PopoverButtonProps,
 } from '../../buttons/PopoverButton/PopoverButton';
@@ -37,12 +37,14 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
     hasPopoverButton = true,
     instantUpdate = true,
     wrapPopover,
+    transitionDuration,
   } = props;
 
   // This local state is updated whenever a checkbox is clicked in the species tree.
   // When `instantUpdate` is false, pass the final value to `onSelectionChange` when the popover closes.
   // When it is true we call `onSelectionChange` whenever `localSelectedList` changes
   const [localSelectedList, setLocalSelectedList] = useState(selectedList);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   /** Used as a hack to "auto close" the popover when shouldCloseOnSelection is true */
   const [key, setKey] = useState('');
@@ -58,6 +60,15 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
     if (!instantUpdate) return;
     onSelectionChange(localSelectedList);
   }, [onSelectionChange, localSelectedList]);
+
+  // only used when there's a popover
+  // prevents selections being made while popover is transitioning away
+  const handleUpdateWithPopover = useCallback(
+    (update: string[]) => {
+      if (isPopoverOpen) setLocalSelectedList(update);
+    },
+    [isPopoverOpen]
+  );
 
   function truncatedButtonContent(selectedList: string[]) {
     return (
@@ -103,7 +114,9 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
       customCheckboxes={props.customCheckboxes}
       isMultiPick={props.isMultiPick}
       name={props.name}
-      onSelectionChange={setLocalSelectedList}
+      onSelectionChange={
+        hasPopoverButton ? handleUpdateWithPopover : setLocalSelectedList
+      }
       currentList={props.currentList}
       defaultList={props.defaultList}
       isSearchable={props.isSearchable}
@@ -132,6 +145,8 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
       buttonDisplayContent={buttonDisplayContent}
       onClose={onClose}
       isDisabled={props.isDisabled}
+      transitionDuration={transitionDuration}
+      setIsPopoverOpen={setIsPopoverOpen}
     >
       <div
         style={{

--- a/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import PopoverButton from '../../buttons/PopoverButton/PopoverButton';
 import CheckboxTree, {
   CheckboxTreeProps,
@@ -37,7 +37,6 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
   // When `instantUpdate` is false, pass the final value to `onSelectionChange` when the popover closes.
   // When it is true we call `onSelectionChange` whenever `localSelectedList` changes
   const [localSelectedList, setLocalSelectedList] = useState(selectedList);
-  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   /** Used as a hack to "auto close" the popover when shouldCloseOnSelection is true */
   const [key, setKey] = useState('');
@@ -53,15 +52,6 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
     if (!instantUpdate) return;
     onSelectionChange(localSelectedList);
   }, [onSelectionChange, localSelectedList]);
-
-  // only used when there's a popover
-  // prevents selections being made while popover is transitioning away
-  const handleUpdateWithPopover = useCallback(
-    (update: string[]) => {
-      if (isPopoverOpen) setLocalSelectedList(update);
-    },
-    [isPopoverOpen]
-  );
 
   function truncatedButtonContent(selectedList: string[]) {
     return (
@@ -107,9 +97,7 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
       customCheckboxes={props.customCheckboxes}
       isMultiPick={props.isMultiPick}
       name={props.name}
-      onSelectionChange={
-        hasPopoverButton ? handleUpdateWithPopover : setLocalSelectedList
-      }
+      onSelectionChange={setLocalSelectedList}
       currentList={props.currentList}
       defaultList={props.defaultList}
       isSearchable={props.isSearchable}
@@ -139,7 +127,6 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
       onClose={onClose}
       isDisabled={props.isDisabled}
       deferClosing={deferPopoverClosing}
-      setIsPopoverOpen={setIsPopoverOpen}
     >
       <div
         style={{

--- a/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, useEffect, useState } from 'react';
-import PopoverButton from '../../buttons/PopoverButton/PopoverButton';
+import PopoverButton, {
+  PopoverButtonProps,
+} from '../../buttons/PopoverButton/PopoverButton';
 import CheckboxTree, {
   CheckboxTreeProps,
   LinksPosition,
@@ -13,6 +15,13 @@ export interface SelectTreeProps<T> extends CheckboxTreeProps<T> {
   isDisabled?: boolean;
   /** update `selectedList` state instantly when a selection is made (default: true) */
   instantUpdate?: boolean;
+
+  /** Optional to provide animated appear/disappear
+   * provide either an integer milliseconds (appear and disappear)
+   * or an object with separate timings: { enter: 300, exit: 600 }
+   * Only relevant in popover mode.
+   */
+  transitionDuration?: PopoverButtonProps['transitionDuration'];
 }
 
 function SelectTree<T>(props: SelectTreeProps<T>) {

--- a/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
@@ -1,7 +1,5 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
-import PopoverButton, {
-  PopoverButtonProps,
-} from '../../buttons/PopoverButton/PopoverButton';
+import PopoverButton from '../../buttons/PopoverButton/PopoverButton';
 import CheckboxTree, {
   CheckboxTreeProps,
   LinksPosition,
@@ -15,13 +13,8 @@ export interface SelectTreeProps<T> extends CheckboxTreeProps<T> {
   isDisabled?: boolean;
   /** update `selectedList` state instantly when a selection is made (default: true) */
   instantUpdate?: boolean;
-
-  /** Optional to provide animated appear/disappear
-   * provide either an integer milliseconds (appear and disappear)
-   * or an object with separate timings: { enter: 300, exit: 600 }
-   * Only relevant in popover mode.
-   */
-  transitionDuration?: PopoverButtonProps['transitionDuration'];
+  /** Optional. When true, popover (if using) closing will be deferred until this becomes false */
+  deferPopoverClosing?: boolean;
 }
 
 function SelectTree<T>(props: SelectTreeProps<T>) {
@@ -37,7 +30,7 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
     hasPopoverButton = true,
     instantUpdate = true,
     wrapPopover,
-    transitionDuration,
+    deferPopoverClosing = false,
   } = props;
 
   // This local state is updated whenever a checkbox is clicked in the species tree.
@@ -145,7 +138,7 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
       buttonDisplayContent={buttonDisplayContent}
       onClose={onClose}
       isDisabled={props.isDisabled}
-      transitionDuration={transitionDuration}
+      deferClosing={deferPopoverClosing}
       setIsPopoverOpen={setIsPopoverOpen}
     >
       <div

--- a/packages/libs/coreui/src/index.ts
+++ b/packages/libs/coreui/src/index.ts
@@ -15,7 +15,12 @@ export { Checkbox, Chip } from './components/widgets';
 export { default as Toggle } from './components/widgets/Toggle';
 
 // Containers
-export { Card, ExpandablePanel, Modal } from './components/containers';
+export {
+  Card,
+  ExpandablePanel,
+  Modal,
+  Dimmable,
+} from './components/containers';
 
 // Grids
 export { DataGrid, TabbedDisplay } from './components/grids';

--- a/packages/libs/wdk-client/src/Views/Records/RecordNotFoundPage.tsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordNotFoundPage.tsx
@@ -15,7 +15,6 @@ export function RecordNotFoundPage({ sourceID }: Props) {
       <p>
         <strong>{sourceID}</strong> is not a current identifier.
       </p>
-      <p>It may be outdated but still retrievable via search.</p>
       <p>
         <a href={searchUrl}>
           <i className="fa fa-search"></i> Search our site for{' '}

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -3,10 +3,7 @@ import React, { useMemo, useState } from 'react';
 import { orderBy } from 'lodash';
 
 import { Checkbox } from '@veupathdb/wdk-client/lib/Components';
-import {
-  CheckboxTreeStyleSpec,
-  LinksPosition,
-} from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
+import { LinksPosition } from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { makeSearchHelpText } from '@veupathdb/wdk-client/lib/Utils/SearchUtils';
 import {
@@ -27,6 +24,7 @@ import {
 
 import './PhyleticDistributionCheckbox.scss';
 import { SelectTree } from '@veupathdb/coreui';
+import { PopoverButtonProps } from '@veupathdb/coreui/lib/components/buttons/PopoverButton/PopoverButton';
 
 const cx = makeClassNameHelper('PhyleticDistributionCheckbox');
 
@@ -44,6 +42,11 @@ type SelectionConfig =
       selectable: true;
       onSpeciesSelected: (selection: string[]) => void;
       selectedSpecies: string[];
+      /** Optional to provide animated appear/disappear for popover button
+       * provide either an integer milliseconds (appear and disappear)
+       * or an object with separate timings: { enter: 300, exit: 600 }
+       */
+      transitionDuration?: PopoverButtonProps['transitionDuration'];
     };
 
 export function PhyleticDistributionCheckbox({
@@ -76,6 +79,11 @@ export function PhyleticDistributionCheckbox({
   return (
     <SelectTree
       hasPopoverButton={selectionConfig.selectable}
+      transitionDuration={
+        selectionConfig.selectable
+          ? selectionConfig.transitionDuration
+          : undefined
+      }
       buttonDisplayContent="Organism"
       tree={prunedPhyleticDistributionUiTree}
       getNodeId={getTaxonNodeId}

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -42,11 +42,8 @@ type SelectionConfig =
       selectable: true;
       onSpeciesSelected: (selection: string[]) => void;
       selectedSpecies: string[];
-      /** Optional to provide animated appear/disappear for popover button
-       * provide either an integer milliseconds (appear and disappear)
-       * or an object with separate timings: { enter: 300, exit: 600 }
-       */
-      transitionDuration?: PopoverButtonProps['transitionDuration'];
+      /** Optional. When true, popover closing will be deferred until this becomes false */
+      deferPopoverClosing?: boolean;
     };
 
 export function PhyleticDistributionCheckbox({
@@ -79,9 +76,9 @@ export function PhyleticDistributionCheckbox({
   return (
     <SelectTree
       hasPopoverButton={selectionConfig.selectable}
-      transitionDuration={
+      deferPopoverClosing={
         selectionConfig.selectable
-          ? selectionConfig.transitionDuration
+          ? selectionConfig.deferPopoverClosing
           : undefined
       }
       buttonDisplayContent="Organism"

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/RecordTable_TaxonCounts_Filter.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/RecordTable_TaxonCounts_Filter.tsx
@@ -4,16 +4,23 @@ import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { PhyleticDistributionCheckbox } from 'ortho-client/components/phyletic-distribution/PhyleticDistributionCheckbox';
 import { taxonCountsTableValueToMap } from './utils';
 import { useTaxonUiMetadata } from 'ortho-client/hooks/taxons';
+import { PopoverButtonProps } from '@veupathdb/coreui/lib/components/buttons/PopoverButton/PopoverButton';
 
 export interface Props extends WrappedComponentProps<RecordTableProps> {
   selectedSpecies: string[];
   onSpeciesSelected: (taxons: string[]) => void;
+  /** Optional to provide animated appear/disappear for popover button
+   * provide either an integer milliseconds (appear and disappear)
+   * or an object with separate timings: { enter: 300, exit: 600 }
+   */
+  transitionDuration?: PopoverButtonProps['transitionDuration'];
 }
 
 export function RecordTable_TaxonCounts_Filter({
   value,
   selectedSpecies,
   onSpeciesSelected,
+  transitionDuration,
 }: Props) {
   const selectionConfig = useMemo(
     () =>
@@ -21,8 +28,9 @@ export function RecordTable_TaxonCounts_Filter({
         selectable: true,
         onSpeciesSelected,
         selectedSpecies,
+        transitionDuration,
       } as const),
-    [onSpeciesSelected, selectedSpecies]
+    [onSpeciesSelected, selectedSpecies, transitionDuration]
   );
 
   const speciesCounts = useMemo(

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/RecordTable_TaxonCounts_Filter.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/RecordTable_TaxonCounts_Filter.tsx
@@ -4,23 +4,19 @@ import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { PhyleticDistributionCheckbox } from 'ortho-client/components/phyletic-distribution/PhyleticDistributionCheckbox';
 import { taxonCountsTableValueToMap } from './utils';
 import { useTaxonUiMetadata } from 'ortho-client/hooks/taxons';
-import { PopoverButtonProps } from '@veupathdb/coreui/lib/components/buttons/PopoverButton/PopoverButton';
 
 export interface Props extends WrappedComponentProps<RecordTableProps> {
   selectedSpecies: string[];
   onSpeciesSelected: (taxons: string[]) => void;
-  /** Optional to provide animated appear/disappear for popover button
-   * provide either an integer milliseconds (appear and disappear)
-   * or an object with separate timings: { enter: 300, exit: 600 }
-   */
-  transitionDuration?: PopoverButtonProps['transitionDuration'];
+  /** Optional. When true, popover (if using) closing will be deferred until this becomes false */
+  deferPopoverClosing?: boolean;
 }
 
 export function RecordTable_TaxonCounts_Filter({
   value,
   selectedSpecies,
   onSpeciesSelected,
-  transitionDuration,
+  deferPopoverClosing,
 }: Props) {
   const selectionConfig = useMemo(
     () =>
@@ -28,9 +24,9 @@ export function RecordTable_TaxonCounts_Filter({
         selectable: true,
         onSpeciesSelected,
         selectedSpecies,
-        transitionDuration,
+        deferPopoverClosing,
       } as const),
-    [onSpeciesSelected, selectedSpecies, transitionDuration]
+    [onSpeciesSelected, selectedSpecies, deferPopoverClosing]
   );
 
   const speciesCounts = useMemo(

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -397,6 +397,11 @@ export function RecordTable_Sequences(
 
   const proteinFilterButtonRef = useRef<PopoverButtonHandle>(null);
 
+  const handleOnChange = useCallback((ids: string[]) => {
+    setPfamFilterIds(ids);
+    setTablePageNumber(1);
+  }, []);
+
   // None shall pass! (hooks, at least)
 
   if (
@@ -480,10 +485,7 @@ export function RecordTable_Sequences(
         altDisplay: formatAttributeValue(row.accession),
       }))}
       value={volatilePfamFilterIds}
-      onChange={(ids) => {
-        setPfamFilterIds(ids);
-        setTablePageNumber(1);
-      }}
+      onChange={handleOnChange}
       instantUpdate={true}
     />
   );

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -397,7 +397,7 @@ export function RecordTable_Sequences(
 
   const proteinFilterButtonRef = useRef<PopoverButtonHandle>(null);
 
-  const handleOnChange = useCallback((ids: string[]) => {
+  const handleOnChangePfamFilterIds = useCallback((ids: string[]) => {
     setPfamFilterIds(ids);
     setTablePageNumber(1);
   }, []);
@@ -485,7 +485,7 @@ export function RecordTable_Sequences(
         altDisplay: formatAttributeValue(row.accession),
       }))}
       value={volatilePfamFilterIds}
-      onChange={handleOnChange}
+      onChange={handleOnChangePfamFilterIds}
       instantUpdate={true}
     />
   );

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -286,14 +286,16 @@ export function RecordTable_Sequences(
       leaves == null ||
       tree == null ||
       filteredRows == null ||
-      filteredRows.length === 0 ||
+      filteredRows.length < MIN_SEQUENCES_FOR_TREE ||
       filteredRows.length > MAX_SEQUENCES_FOR_TREE
     )
       return;
 
     if (filteredRows.length < leaves.length) {
       const filteredRowIds = new Set(
-        filteredRows.map(({ full_id }) => full_id as string)
+        filteredRows.map(({ full_id }) =>
+          truncate_full_id_for_tree_comparison(full_id as string)
+        )
       );
 
       // must work on a copy of the tree because it's destructive
@@ -860,7 +862,7 @@ function logIdMismatches(A: string[], B: string[]) {
 }
 
 function truncate_full_id_for_tree_comparison(full_id: string): string {
-  const truncated_id = (full_id as string).split(':')[0];
+  const truncated_id = full_id.split(':')[0];
   return truncated_id;
 }
 

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -1,7 +1,6 @@
 import React, {
   CSSProperties,
   useCallback,
-  useDeferredValue,
   useMemo,
   useRef,
   useState,
@@ -687,6 +686,23 @@ export function RecordTable_Sequences(
       </span>
     ) : undefined;
 
+  // We tried using a `<Loading />` spinner but its hardcoded 200ms delay
+  // was causing problems. This looks great on top of the greyed out table though.
+  const LOADING = (
+    <span
+      style={{
+        fontSize: '3rem',
+        fontWeight: '700',
+        color: 'rgba(0, 0, 0, 0.25)',
+        textShadow: '0 1px 2px rgba(255, 255, 255, 0.8)',
+        pointerEvents: 'none',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      LOADING
+    </span>
+  );
+
   return (
     <div
       style={
@@ -767,7 +783,7 @@ export function RecordTable_Sequences(
           up to {MAX_SEQUENCES_FOR_TREE.toLocaleString()}
         </div>
       ) : (
-        <Dimmable dimmed={isFiltering}>
+        <Dimmable dimmed={isFiltering} spinner={LOADING}>
           <TreeTable
             rowHeight={rowHeight}
             treeProps={treeProps}


### PR DESCRIPTION
# Ready for review

Resolves https://github.com/VEuPathDB/web-monorepo/issues/1303

Resolves #1280

Resolves #1370 

<s>Implement dynamic Popover transition durations—enter fixed at 300 ms, exit set to Math.max(300, numSequences/10)—so that even with very large groups (e.g. 2.6 s for 26,000 sequences) the popover buttons go away cleanly without leaving behind ghost overlays that block the UI. (Main thread compute was disrupting the animation event processing. The extra animation time effectively waits for the compute to be done.) Groups <= 3,000 proteins won't see any UI behaviour differences at all.</s>

NEW APPROACH: figure out when the component `isFiltering` from `(realState !== volatileState)` and then do several things:
1. grey out the main table and overlay some LOADING text (our default `Loading` spinner doesn't work due to hardcoded 200ms delay)
2. tell the Popover components that they should `deferClosing` while `isFiltering`
   - while Popovers are deferring closing they are greyed out and unclickable

Amazingly it works very nicely.

Filtering logic was also optimized by using Sets for membership checks, ensuring responsive performance on large groups.

Note that the ClinEpi popover behaviour should be unchanged but I need to 

- [x] test ClinEpi

Here is the fix evidence for #1370

![image](https://github.com/user-attachments/assets/7dc607aa-e6d1-4e38-b30f-de5c324cb089)
