### PR TITLE
Remove the `white-space: break-spaces` styling from Mesa table cells

### DIFF
--- a/packages/libs/coreui/src/components/Mesa/style/Cells.scss
+++ b/packages/libs/coreui/src/components/Mesa/style/Cells.scss
@@ -2,7 +2,10 @@ $StickyColumnBorderColor: rgb(204, 204, 204);
 
 .MesaComponent {
   tr {
-    white-space: break-spaces;
+    /* white-space: break-spaces; */
+    /* introduced in https://github.com/VEuPathDB/web-monorepo/pull/1298 */
+    /* can't figure out why - gene and ortho record tables seem fine without */
+    /* so do strategy search result tables */
   }
   th {
     background-color: #e2e2e2;


### PR DESCRIPTION
Fixes #1377 

Tested many gene page tables, ortho group tables and gene query results tables. Nothing seems broken by this.

We should try to test everything touched in https://github.com/VEuPathDB/web-monorepo/pull/1298

* packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.css (these are general tables on gene/ortho pages)
* packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/Downloads/Downloads.scss (? where to test this?)