### PR TITLE
Make it easier to read the numbers from the phyletic distribution component

### DIFF
--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.scss
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.scss
@@ -17,6 +17,10 @@
     &__species {
       font-weight: normal;
     }
+
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.05); /* subtle grey */
+    }
   }
 
   .wdk-CheckboxTreeItem .wdk-CheckboxTreeNodeWrapper:hover {

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.scss
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.scss
@@ -10,6 +10,7 @@
   &--Node {
     display: flex;
     justify-content: space-between;
+    column-gap: 1em;
     width: calc(100% - 2em);
 
     font-weight: bold;

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -3,7 +3,10 @@ import React, { useMemo, useState } from 'react';
 import { orderBy } from 'lodash';
 
 import { Checkbox } from '@veupathdb/wdk-client/lib/Components';
-import { LinksPosition } from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
+import {
+  CheckboxTreeStyleSpec,
+  LinksPosition,
+} from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
 import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { makeSearchHelpText } from '@veupathdb/wdk-client/lib/Utils/SearchUtils';
 import {
@@ -31,6 +34,7 @@ interface Props {
   selectionConfig: SelectionConfig;
   speciesCounts: Record<string, number>;
   taxonTree: TaxonTree;
+  styleOverrides?: CheckboxTreeStyleSpec;
 }
 
 type SelectionConfig =
@@ -49,6 +53,7 @@ export function PhyleticDistributionCheckbox({
   selectionConfig,
   speciesCounts,
   taxonTree,
+  styleOverrides,
 }: Props) {
   const phyleticDistributionUiTree = useMemo(
     () => makePhyleticDistributionUiTree(speciesCounts, taxonTree),
@@ -115,6 +120,7 @@ export function PhyleticDistributionCheckbox({
           &nbsp; Hide zero counts
         </label>,
       ]}
+      styleOverrides={styleOverrides}
     />
   );
 }

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.tsx
@@ -24,7 +24,6 @@ import {
 
 import './PhyleticDistributionCheckbox.scss';
 import { SelectTree } from '@veupathdb/coreui';
-import { PopoverButtonProps } from '@veupathdb/coreui/lib/components/buttons/PopoverButton/PopoverButton';
 
 const cx = makeClassNameHelper('PhyleticDistributionCheckbox');
 

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -285,6 +285,21 @@ function RecordTable_TaxonCounts({
       selectionConfig={selectionConfig}
       speciesCounts={speciesCounts}
       taxonTree={taxonUiMetadata.taxonTree}
+      styleOverrides={{
+        searchAndFilterWrapper: {
+          justifyContent: 'flex-start',
+        },
+        searchBox: {
+          container: {
+            width: '300px',
+          },
+        },
+        treeSection: {
+          container: {
+            width: '50%',
+          },
+        },
+      }}
     />
   );
 }


### PR DESCRIPTION
Fixes #1379 

Check out the video for the component at the top of the orthogroup table.

The highlighting is also there on the "taxon filter" on the main ortho "list of proteins" table.


https://github.com/user-attachments/assets/1e909326-c243-4741-9152-4bb68212c2aa

