### PR TITLE
Add extra padding to phyletic tree mouseover highlighting as per Ann's suggestion

### DIFF
--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.scss
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/phyletic-distribution/PhyleticDistributionCheckbox.scss
@@ -12,6 +12,9 @@
     justify-content: space-between;
     column-gap: 1em;
     width: calc(100% - 2em);
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    border-radius: 0.5em;
 
     font-weight: bold;
 


### PR DESCRIPTION
Oops I didn't realise the [old PR](https://github.com/VEuPathDB/web-monorepo/pull/1380) had been merged.

Addressing the feedback here: https://github.com/VEuPathDB/web-monorepo/pull/1380#issuecomment-2842102725

Not at all urgent - can go out any time at all!
