### PR TITLE
Payment page: disable submit button while contacting our back end and further tweaks

### DIFF
--- a/packages/libs/web-common/src/controllers/PaymentController.tsx
+++ b/packages/libs/web-common/src/controllers/PaymentController.tsx
@@ -60,13 +60,13 @@ export default function PaymentController() {
       setErrorMessage('');
       amountNum = Math.floor(amountNum * 100) / 100;
       setAmount(amountNum.toString());
-      console.log('Submitting form with payment amount $' + amountNum);
+      // console.log('Submitting form with payment amount $' + amountNum);
       getFormData(amountNum)
         .then((formData) => {
           setFormData(formData);
         })
         .catch((error) => {
-          console.log(error);
+          console.error(error);
           setErrorMessage(
             <>
               Cannot connect to payment system. <br />

--- a/packages/libs/web-common/src/styles/Payment.scss
+++ b/packages/libs/web-common/src/styles/Payment.scss
@@ -38,6 +38,7 @@ div.payment-form {
     }
   }
   div.error-message {
+    text-align: center;
     color: red;
   }
 }


### PR DESCRIPTION
I moved the error message into the form area (it was below the info text before)

![image](https://github.com/user-attachments/assets/d604018c-0b10-4344-9372-4a226a648689)

The "let us know" doesn't appear for every error/warning:

![image](https://github.com/user-attachments/assets/f32336c9-ca63-4c94-8c05-89cb48598edf)
