### PR TITLE
Draft/experimental user dataset upload tab UX improvements

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/UploadFormMenu.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UploadFormMenu.tsx
@@ -20,7 +20,7 @@ export function UploadFormMenu(props: Props) {
           const datasetUploadType = datasetUploadTypes[type];
           return (
             datasetUploadType && (
-              <li>
+              <li key={type}>
                 <Link to={url + '/' + type} className="btn">
                   <div className="title">
                     <i className="fa fa-file-text" />{' '}

--- a/packages/libs/user-datasets/src/lib/Components/UserDatasetsWorkspace.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UserDatasetsWorkspace.tsx
@@ -1,6 +1,11 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
-import { Switch, Redirect, RouteComponentProps } from 'react-router-dom';
+import {
+  Switch,
+  Redirect,
+  RouteComponentProps,
+  useRouteMatch,
+} from 'react-router-dom';
 
 import WorkspaceNavigation from '@veupathdb/wdk-client/lib/Components/Workspace/WorkspaceNavigation';
 import WdkRoute from '@veupathdb/wdk-client/lib/Core/WdkRoute';
@@ -19,6 +24,8 @@ interface Props {
   helpTabContents?: ReactNode;
   dataNoun: DataNoun;
   enablePublicUserDatasets: boolean;
+  activeUploadType?: string;
+  setActiveUploadType?: (newType?: string) => void;
 }
 
 function UserDatasetsWorkspace(props: Props) {
@@ -30,7 +37,20 @@ function UserDatasetsWorkspace(props: Props) {
     helpTabContents,
     dataNoun,
     enablePublicUserDatasets,
+    activeUploadType,
+    setActiveUploadType,
   } = props;
+
+  const {
+    path,
+    params: { type: currentUploadType },
+  } = useRouteMatch<{ type?: string }>();
+
+  useEffect(() => {
+    if (setActiveUploadType && path.match('/new/')) {
+      setActiveUploadType(currentUploadType);
+    }
+  }, [currentUploadType, path, setActiveUploadType]);
 
   return (
     <div>
@@ -48,7 +68,8 @@ function UserDatasetsWorkspace(props: Props) {
             ? [
                 {
                   display: 'New upload',
-                  route: '/new',
+                  route:
+                    '/new' + (activeUploadType ? '/' + activeUploadType : ''),
                   exact: false,
                 },
               ]

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetNewUploadController.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetNewUploadController.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
+import { Link, useRouteMatch } from 'react-router-dom';
 
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
@@ -36,6 +37,7 @@ interface Props {
 export default function UserDatasetUploadSelector(props: Props) {
   const { baseUrl, type, availableTypes, datasetUploadTypes, urlParams } =
     props;
+  const { url } = useRouteMatch();
 
   if (type == null && availableTypes.length !== 1) {
     return (
@@ -50,12 +52,18 @@ export default function UserDatasetUploadSelector(props: Props) {
   if (datasetUploadType == null) {
     return <NotFoundController />;
   }
+
   return (
-    <InnerUserDatasetUploadController
-      baseUrl={baseUrl}
-      datasetUploadType={datasetUploadType}
-      urlParams={urlParams}
-    />
+    <>
+      <Link to={url.replace(/\/[^/]+$/, '')}>
+        Back to choose an upload type
+      </Link>
+      <InnerUserDatasetUploadController
+        baseUrl={baseUrl}
+        datasetUploadType={datasetUploadType}
+        urlParams={urlParams}
+      />
+    </>
   );
 }
 
@@ -157,6 +165,7 @@ function InnerUserDatasetUploadController({
   ) : (
     <div className="stack">
       <UploadForm
+        key={'upload-form-' + datasetUploadType.type}
         baseUrl={baseUrl}
         datasetUploadType={datasetUploadType}
         projectId={projectId}

--- a/packages/libs/user-datasets/src/lib/Controllers/UserDatasetRouter.tsx
+++ b/packages/libs/user-datasets/src/lib/Controllers/UserDatasetRouter.tsx
@@ -1,5 +1,4 @@
-import { ComponentType, ReactNode, useMemo } from 'react';
-
+import { ComponentType, ReactNode, useMemo, useState } from 'react';
 import { RouteComponentProps, Switch, useRouteMatch } from 'react-router-dom';
 
 import WdkRoute from '@veupathdb/wdk-client/lib/Core/WdkRoute';
@@ -46,6 +45,8 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
     [availableUploadTypes, uploadTypeConfig]
   );
 
+  const [activeUploadType, setActiveUploadType] = useState<string>();
+
   return (
     <Switch>
       <WdkRoute
@@ -73,6 +74,8 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
               helpTabContents={helpTabContents}
               dataNoun={dataNoun}
               enablePublicUserDatasets={enablePublicUserDatasets}
+              activeUploadType={activeUploadType}
+              setActiveUploadType={setActiveUploadType}
             />
           );
         }}
@@ -102,6 +105,8 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
               helpTabContents={helpTabContents}
               dataNoun={dataNoun}
               enablePublicUserDatasets={enablePublicUserDatasets}
+              activeUploadType={activeUploadType}
+              setActiveUploadType={setActiveUploadType}
             />
           );
         }}
@@ -159,6 +164,8 @@ export function UserDatasetRouter<T1 extends string, T2 extends string>({
               helpTabContents={helpTabContents}
               dataNoun={dataNoun}
               enablePublicUserDatasets={enablePublicUserDatasets}
+              activeUploadType={activeUploadType}
+              setActiveUploadType={setActiveUploadType}
             />
           );
         }}


### PR DESCRIPTION
Something to discuss in our meeting.

If the user navigates to the phenotype upload form, then the help tab, and then back to the upload form, it should 
a) remember that they were on the phenotype form
b) remember anything they filled in

This PR achieves a) but I have tried several things for b) and couldn't get them to work. 

1. `keepalive-for-react` - just couldn't get the basic version to work. The `react-router-dom` version requires an upgrade to `react-router-dom` and looks like it would require a major rewrite
2. `react-keepalive` - 6 years old and didn't work

One solution would be to have the tabs all rendered but not visible, but this would require a major rewrite also.

Another solution is to keep saving the upload form state via redux.