### PR TITLE
Make links searchable in tables, and sort out search on paged tables

### DIFF
--- a/packages/libs/eda/src/lib/core/components/filter/TableFilter.tsx
+++ b/packages/libs/eda/src/lib/core/components/filter/TableFilter.tsx
@@ -232,13 +232,13 @@ export function TableFilter({
       analysisState.setVariableUISettings((currentState) => ({
         ...currentState,
         [uiStateKey]: {
-          ...uiState,
+          ...currentState[uiStateKey],
           sort,
           currentPage: 1,
         },
       }));
     },
-    [analysisState, uiStateKey, uiState]
+    [analysisState, uiStateKey]
   );
 
   const handleSearch = useCallback(
@@ -254,13 +254,13 @@ export function TableFilter({
       analysisState.setVariableUISettings((currentState) => ({
         ...currentState,
         [uiStateKey]: {
-          ...uiState,
+          ...currentState[uiStateKey],
           searchTerm,
           ...(shouldResetPaging ? { currentPage: 1 } : {}),
         },
       }));
     },
-    [analysisState, uiStateKey, uiState]
+    [analysisState, uiStateKey]
   );
 
   const handlePagination = useCallback(
@@ -268,12 +268,12 @@ export function TableFilter({
       analysisState.setVariableUISettings((currentState) => ({
         ...currentState,
         [uiStateKey]: {
-          ...uiState,
+          ...currentState[uiStateKey],
           currentPage,
         },
       }));
     },
-    [analysisState, uiStateKey, uiState]
+    [analysisState, uiStateKey]
   );
 
   const handleRowsPerPage = useCallback(
@@ -281,12 +281,12 @@ export function TableFilter({
       analysisState.setVariableUISettings((currentState) => ({
         ...currentState,
         [uiStateKey]: {
-          ...uiState,
+          ...currentState[uiStateKey],
           rowsPerPage,
         },
       }));
     },
-    [analysisState, uiStateKey, uiState]
+    [analysisState, uiStateKey]
   );
 
   const allValues = useMemo(() => {

--- a/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
@@ -264,7 +264,9 @@ class RecordTable extends Component {
         )
       : displayableAttributes;
     const filteredRows = sortedMesaRows.filter((row) => {
-      return searchableAttributes.some((attr) => regex.test(row[attr.name]));
+      return searchableAttributes.some((attr) =>
+        regex.test(row[attr.name].text ?? row[attr.name])
+      );
     });
 
     const tableState = {

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/Sequences.tsx
@@ -339,6 +339,11 @@ export function RecordTable_Sequences(
     [mesaColumns]
   );
 
+  const handleSearchQueryChange = useCallback((query: string) => {
+    setSearchQuery(query);
+    setTablePageNumber(1);
+  }, []);
+
   const handleSpeciesSelection = useCallback((species: string[]) => {
     setSelectedSpecies(species);
     setTablePageNumber(1);
@@ -742,7 +747,7 @@ export function RecordTable_Sequences(
         <RecordFilter
           key={`text-search-${resetCounter}`}
           searchTerm={searchQuery}
-          onSearchTermChange={setSearchQuery}
+          onSearchTermChange={handleSearchQueryChange}
           recordDisplayName="Proteins"
           filterAttributes={filterAttributes}
           selectedColumnFilters={volatileSelectedColumnFilters}


### PR DESCRIPTION
Fixes #1395 
Fixes #1306 

- [x] fix link search
- [x] fix paging bug in ortho
- [x] fix paging bug in EDA


The paging bug was [reported in EDA](https://github.com/VEuPathDB/web-monorepo/issues/1306)

However it's also a problem in orthogroup pages:
- https://qa.orthomcl.org/orthomcl.b7_1/app/record/group/OG7_0000011#Sequences
- jump to page 2 and then search for `trsc`

Is there any paging on regular wdk RecordTables? Source code says no.