### PR TITLE
AI expression - buttons for Was this helpful? 

### DIFF
--- a/packages/libs/coreui/src/components/buttons/SwissArmyButton/index.tsx
+++ b/packages/libs/coreui/src/components/buttons/SwissArmyButton/index.tsx
@@ -39,11 +39,25 @@ export default function SwissArmyButton({
     [buttonState, disabled]
   );
 
-  const calculatedFontSize = size === 'large' ? '1rem' : '.80rem';
+  const calculatedFontSize =
+    size === 'xlarge' ? '1.5rem' : size === 'large' ? '1rem' : '.80rem';
   const calculatedIconSize =
-    size === 'large' ? '1.5rem' : size === 'medium' ? '1.25rem' : '1rem';
-  const horizontalPadding = size === 'large' ? 15 : 15;
-  const buttonHeight = size === 'large' ? 50 : size === 'medium' ? 35 : 25;
+    size === 'xlarge'
+      ? '2rem'
+      : size === 'large'
+      ? '1.5rem'
+      : size === 'medium'
+      ? '1.25rem'
+      : '1rem';
+  const horizontalPadding = size === 'xlarge' ? 20 : size === 'large' ? 15 : 15;
+  const buttonHeight =
+    size === 'xlarge'
+      ? 65
+      : size === 'large'
+      ? 50
+      : size === 'medium'
+      ? 35
+      : 25;
 
   const Icon = icon;
 

--- a/packages/libs/coreui/src/components/buttons/index.ts
+++ b/packages/libs/coreui/src/components/buttons/index.ts
@@ -71,7 +71,7 @@ type CoreProps = {
    * pick up styling options from the theme. */
   themeRole?: keyof UITheme['palette'];
   /** The size of the button. */
-  size?: 'small' | 'medium' | 'large';
+  size?: 'small' | 'medium' | 'large' | 'xlarge';
   /** Additional styles to apply to the button container. */
   styleOverrides?: PartialButtonStyleSpec;
   /** Icon can be to the left or to the right of the button's text. Defaults to left. */

--- a/packages/libs/web-common/src/config.ts
+++ b/packages/libs/web-common/src/config.ts
@@ -39,6 +39,7 @@ export const {
   userDatasetsUploadTypes = '',
   communityDatasetsEnabled = false,
   showExtraMetadata = false,
+  aiExpressionQualtricsId = '',
 } = window.__SITE_CONFIG__;
 
 export const edaExampleAnalysesAuthors = !window.__SITE_CONFIG__

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.scss
@@ -23,7 +23,7 @@ div.ai-summary {
   }
 }
 
-div.ai-disclaimer {
+div.ai-floating-extras {
   flex: 1 1 15em;
   min-width: 15em;
   max-width: 50em;
@@ -36,6 +36,43 @@ div.ai-disclaimer {
       cursor: pointer;
       padding: 0.2em 0.4em;
       font-weight: bold;
+    }
+  }
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.5em;
+
+  div.ai-feedback-buttons-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    gap: 1em;
+
+    a {
+      /* remove the underline by default */
+      text-decoration: none;
+
+      /* ensure it stays gone on hover/focus/active */
+      &:hover,
+      &:focus,
+      &:active {
+        text-decoration: none;
+      }
+    }
+  }
+
+  div.ai-feedback {
+    margin: 1em;
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 1em;
+    font-style: italic;
+
+    .ai-feedback-help {
+      font-size: 0.9em;
     }
   }
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
@@ -30,6 +30,10 @@ import { ServiceError } from '@veupathdb/wdk-client/lib/Service/ServiceError';
 import './AiExpressionSummary.scss';
 import { warning } from '@veupathdb/coreui/lib/definitions/colors';
 import { FloatingButton } from '@veupathdb/coreui/lib';
+import {
+  aiExpressionQualtricsId,
+  projectId,
+} from '@veupathdb/web-common/lib/config';
 
 const MIN_DATASETS_FOR_AI_SUMMARY = 5;
 const POLL_TIME_MS = 5000;
@@ -337,6 +341,8 @@ const AiExpressionResult = (props: AiExpressionResultProps) => {
     },
   };
 
+  const shouldGatherFeedback = aiExpressionQualtricsId !== '';
+
   return (
     <div className="ai-generated">
       <ExpressionGraphFloater
@@ -381,43 +387,47 @@ const AiExpressionResult = (props: AiExpressionResultProps) => {
               </strong>
             </p>
           </details>
-          <div className="ai-feedback">
-            <span>
-              Was this AI expression summary for {record.displayName} helpful?
-            </span>
-            <div className="ai-feedback-buttons-container">
-              <a
-                href={`https://google.com?q=Yay for ${
-                  record.displayName
-                }&UserId=${currentUser?.id ?? 'NA'}`}
-                target="_blank"
-              >
-                <FloatingButton
-                  text="👍"
-                  size="large"
-                  tooltip="Yes"
-                  onPress={
-                    () => {} /* can potentially add client-side deduplication logic here */
-                  }
-                />
-              </a>
-              <a
-                href={`https://google.com?q=Boo to ${record.displayName}`}
-                target="_blank"
-              >
-                <FloatingButton
-                  text="👎"
-                  size="large"
-                  tooltip="No"
-                  onPress={() => {}}
-                />
-              </a>
+          {shouldGatherFeedback && (
+            <div className="ai-feedback">
+              <span>
+                Was this AI expression summary for {record.displayName} helpful?
+              </span>
+              <div className="ai-feedback-buttons-container">
+                <a
+                  href={`https://upenn.co1.qualtrics.com/jfe/form/${aiExpressionQualtricsId}?IsHelpful=Yes&GeneID=${
+                    record.displayName
+                  }&ProjectID=${projectId}&UserId=${currentUser?.id ?? 'NA'}`}
+                  target="_blank"
+                >
+                  <FloatingButton
+                    text="👍"
+                    size="xlarge"
+                    tooltip="Yes"
+                    onPress={
+                      () => {} /* can potentially add client-side deduplication logic here */
+                    }
+                  />
+                </a>
+                <a
+                  href={`https://upenn.co1.qualtrics.com/jfe/form/${aiExpressionQualtricsId}?IsHelpful=No&GeneID=${
+                    record.displayName
+                  }&ProjectID=${projectId}&UserId=${currentUser?.id ?? 'NA'}`}
+                  target="_blank"
+                >
+                  <FloatingButton
+                    text="👎"
+                    size="xlarge"
+                    tooltip="No"
+                    onPress={() => {}}
+                  />
+                </a>
+              </div>
+              <span className="ai-feedback-help">
+                (Opens a short Qualtrics survey in a new tab. All questions are
+                optional.)
+              </span>
             </div>
-            <span className="ai-feedback-help">
-              (Opens a short Qualtrics survey in a new tab. All questions are
-              optional.)
-            </span>
-          </div>
+          )}
         </div>
       </div>
       <Mesa state={mainTableState} />

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
@@ -29,7 +29,7 @@ import { ServiceError } from '@veupathdb/wdk-client/lib/Service/ServiceError';
 // Styles
 import './AiExpressionSummary.scss';
 import { warning } from '@veupathdb/coreui/lib/definitions/colors';
-import { FloatingButton } from '../../../../../../../../libs/coreui/lib';
+import { FloatingButton } from '@veupathdb/coreui/lib';
 
 const MIN_DATASETS_FOR_AI_SUMMARY = 5;
 const POLL_TIME_MS = 5000;
@@ -387,6 +387,7 @@ const AiExpressionResult = (props: AiExpressionResultProps) => {
               >
                 <FloatingButton
                   text="👍"
+                  size="large"
                   tooltip="Yes"
                   onPress={
                     () => {} /* can potentially add client-side deduplication logic here */
@@ -397,7 +398,12 @@ const AiExpressionResult = (props: AiExpressionResultProps) => {
                 href={`https://google.com?q=Boo to ${record.displayName}`}
                 target="_blank"
               >
-                <FloatingButton text="👎" tooltip="No" onPress={() => {}} />
+                <FloatingButton
+                  text="👎"
+                  size="large"
+                  tooltip="No"
+                  onPress={() => {}}
+                />
               </a>
             </div>
             <span className="ai-feedback-help">

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
@@ -225,6 +225,11 @@ const AiExpressionResult = (props: AiExpressionResultProps) => {
   // floater management
   const [floaterDatasetId, setFloaterDatasetId] = useState<string>();
 
+  const currentUser = useWdkService(
+    (wdkService) => wdkService.getCurrentUser(),
+    []
+  );
+
   // Note that `safeHtml()` does NOT sanitise dangerous HTML elements and attributes.
   // for example, this would render and the JavaScript will execute:
   // const danger = `<img src="x" onerror="alert('XSS!')" />`;
@@ -382,7 +387,9 @@ const AiExpressionResult = (props: AiExpressionResultProps) => {
             </span>
             <div className="ai-feedback-buttons-container">
               <a
-                href={`https://google.com?q=Yay for ${record.displayName}`}
+                href={`https://google.com?q=Yay for ${
+                  record.displayName
+                }&UserId=${currentUser?.id ?? 'NA'}`}
                 target="_blank"
               >
                 <FloatingButton

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
@@ -29,6 +29,7 @@ import { ServiceError } from '@veupathdb/wdk-client/lib/Service/ServiceError';
 // Styles
 import './AiExpressionSummary.scss';
 import { warning } from '@veupathdb/coreui/lib/definitions/colors';
+import { FloatingButton } from '../../../../../../../../libs/coreui/lib';
 
 const MIN_DATASETS_FOR_AI_SUMMARY = 5;
 const POLL_TIME_MS = 5000;
@@ -354,7 +355,7 @@ const AiExpressionResult = (props: AiExpressionResultProps) => {
             </i>
           </p>
         </div>
-        <div className="ai-disclaimer">
+        <div className="ai-floating-extras">
           <details
             style={{
               background: warning[100],
@@ -375,6 +376,35 @@ const AiExpressionResult = (props: AiExpressionResultProps) => {
               </strong>
             </p>
           </details>
+          <div className="ai-feedback">
+            <span>
+              Was this AI expression summary for {record.displayName} helpful?
+            </span>
+            <div className="ai-feedback-buttons-container">
+              <a
+                href={`https://google.com?q=Yay for ${record.displayName}`}
+                target="_blank"
+              >
+                <FloatingButton
+                  text="👍"
+                  tooltip="Yes"
+                  onPress={
+                    () => {} /* can potentially add client-side deduplication logic here */
+                  }
+                />
+              </a>
+              <a
+                href={`https://google.com?q=Boo to ${record.displayName}`}
+                target="_blank"
+              >
+                <FloatingButton text="👎" tooltip="No" onPress={() => {}} />
+              </a>
+            </div>
+            <span className="ai-feedback-help">
+              (Opens a short Qualtrics survey in a new tab. All questions are
+              optional.)
+            </span>
+          </div>
         </div>
       </div>
       <Mesa state={mainTableState} />

--- a/packages/sites/genomics-site/webpack.config.local.mjs
+++ b/packages/sites/genomics-site/webpack.config.local.mjs
@@ -59,6 +59,7 @@ export default configure({
         showUnreleasedData: process.env.SHOW_UNRELEASED_DATA === 'true',
 	communityDatasetsEnabled: process.env.COMMUNITY_DATASETS_ENABLED === 'true',
         showExtraMetadata: process.env.SHOW_EXTRA_METADATA === 'true',
+	aiExpressionQualtricsId: process.env.AI_EXPRESSION_QUALTRICS_ID,
 })
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Targets `ai-expression-cost-limit` at the moment!

The :+1: :-1: buttons are regular links to a Qualtrics survey with a couple of fields auto-filled from URL parameter values (hopefully!), but we can add client-side JavaScript too, if needed.

Wide browser:
![image](https://github.com/user-attachments/assets/3bc91b48-c973-4670-ba09-0e58edb3fe91)

Narrow browser:
![image](https://github.com/user-attachments/assets/377149e6-10c3-4b0f-b2f6-55bab406e622)
