### PR TITLE
Add BETA badge to the navigation menu too

### DIFF
--- a/packages/libs/wdk-client/src/Views/Records/RecordNavigation/RecordNavigationItem.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordNavigation/RecordNavigationItem.jsx
@@ -23,7 +23,7 @@ let RecordNavigationItem = ({ node, activeSection, onSectionToggle }) => {
         isActive ? 'active' : 'inactive',
         isField ? 'field' : 'category'
       )}
-      id={id}
+      id={'nav-' + id}
       href={'#' + id}
       onClick={(event) => {
         if (isField) {

--- a/packages/libs/wdk-client/src/Views/Records/RecordNavigation/RecordNavigationItem.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordNavigation/RecordNavigationItem.jsx
@@ -23,6 +23,7 @@ let RecordNavigationItem = ({ node, activeSection, onSectionToggle }) => {
         isActive ? 'active' : 'inactive',
         isField ? 'field' : 'category'
       )}
+      id={id}
       href={'#' + id}
       onClick={(event) => {
         if (isField) {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/record-page-new-feature.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/record-page-new-feature.scss
@@ -1,4 +1,4 @@
-// This CSS adds the NEW icon next to the attribute name on record pages
+/* This CSS adds the NEW icon next to the attribute name on record pages */
 #Cellxgene {
   .wdk-CollapsibleSectionHeader:after {
     content: url('~@veupathdb/wdk-client/lib/Core/Style/images/new-feature.png');
@@ -12,4 +12,16 @@
     margin-left: 1em;
     content: url('~@veupathdb/wdk-client/lib/Core/Style/images/beta2-30.png');
   }
+}
+
+/* add a badge to the left hand navigation ai_expression item */
+a.wdk-RecordNavigationItem#ai_expression:after,
+/* also add beta badge to the unexpanded parent 'Transcriptomics' item */
+li:not(:has(ul)) a.wdk-RecordNavigationItem#category\:transcriptomics:after {
+  position: absolute;
+  transform: translateY(-70%);
+  width: 38px;
+  height: 22px;
+  margin-left: 1em;
+  content: url('~@veupathdb/wdk-client/lib/Core/Style/images/beta2-30.png');
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/record-page-new-feature.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/record-page-new-feature.scss
@@ -1,27 +1,31 @@
 /* This CSS adds the NEW icon next to the attribute name on record pages */
+
+/* page item */
 #Cellxgene {
   .wdk-CollapsibleSectionHeader:after {
     content: url('~@veupathdb/wdk-client/lib/Core/Style/images/new-feature.png');
     margin-left: 0.5ch;
   }
 }
+/* navigation item */
+a.wdk-RecordNavigationItem#nav-Cellxgene:after {
+  vertical-align: sub;
+  margin-left: 0.5ch;
+  content: url('~@veupathdb/wdk-client/lib/Core/Style/images/new-feature.png');
+}
+
+/* page item */
 #ai_expression {
   .wdk-CollapsibleSectionHeader:after {
     width: 38px;
     height: 22px;
-    margin-left: 1em;
+    margin-left: 1ch;
     content: url('~@veupathdb/wdk-client/lib/Core/Style/images/beta2-30.png');
   }
 }
-
-/* add a badge to the left hand navigation ai_expression item */
-a.wdk-RecordNavigationItem#ai_expression:after,
-/* also add beta badge to the unexpanded parent 'Transcriptomics' item */
-li:not(:has(ul)) a.wdk-RecordNavigationItem#category\:transcriptomics:after {
-  position: absolute;
-  transform: translateY(-70%);
-  width: 38px;
-  height: 22px;
-  margin-left: 1em;
+/* navigation item */
+a.wdk-RecordNavigationItem#nav-ai_expression:after {
+  vertical-align: sub;
+  margin-left: 0.5ch;
   content: url('~@veupathdb/wdk-client/lib/Core/Style/images/beta2-30.png');
 }


### PR DESCRIPTION
Added badges to the navigation panel too
![image](https://github.com/user-attachments/assets/b10bf78e-f87f-4409-a1cd-a5640173c76a)

This required adding element IDs to the `<a>` elements which was straightforward.

I also investigated adding a badge to the unexpanded parent navigation item. I gave up on this for various reasons. The main one being that the `<li>` tree is dynamically rendered (not toggled with CSS visibility) so we don't know what children a list item has until it has been expanded. If we did know, it could all be done with CSS. But we don't!