### PR TITLE
Fix aspect ratio of new ortho help image and add flex-wrap layout

### DIFF
--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/GroupStats.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/records/GroupStats.tsx
@@ -13,19 +13,21 @@ export function RecordTable_GroupStats(
     <div
       style={{
         display: 'flex',
-        flexDirection: 'column',
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        columnGap: '2em', // only separate when side-by-side (no rowGap)
       }}
     >
       {regularRecordTable}
       <figure
         style={{
-          width: 390,
+          width: 400,
         }}
       >
         <img
           alt="The histogram shows the distribution of the median percent identity cohesiveness indicator across all orthologous groups. There is a skewed distribution with a peak at 0-5% identity."
-          width={390}
-          height={336}
+          width={400}
+          height={400}
           src={MGD_hist_img}
         />
         <figcaption


### PR DESCRIPTION
Image was a little squashed in one direction. I made it square and slightly bigger.

I also changed the layout to side-by-side unless narrow browser makes it wrap below.

![image](https://github.com/user-attachments/assets/a18cb8dd-f812-48d6-b1d7-30ecbc9497c2)
