### PR TITLE
Fix: WDK popup auto-center on async content load

### DIFF
--- a/packages/libs/wdk-client/src/Components/Overlays/Dialog.tsx
+++ b/packages/libs/wdk-client/src/Components/Overlays/Dialog.tsx
@@ -73,7 +73,7 @@ function Dialog(props: Props) {
       setPopupWidth(rect.width);
       setPopupHeight(rect.height);
       // Only set position offsets (from center of window)
-      // if the haven't been set yet:
+      // if they haven't been set yet:
       setX((x) => (x == null ? -rect.width / 2 : x));
       setY((y) => (y == null ? -rect.height / 2 : y));
 

--- a/packages/libs/wdk-client/src/Components/Overlays/Dialog.tsx
+++ b/packages/libs/wdk-client/src/Components/Overlays/Dialog.tsx
@@ -63,14 +63,41 @@ function Dialog(props: Props) {
   const [y, setY] = useState<number>();
   const [popupWidth, setPopupWidth] = useState<number>();
   const [popupHeight, setPopupHeight] = useState<number>();
+  const [hasMoved, setHasMoved] = useState(false);
+  const [hasAutoCentered, setHasAutoCentered] = useState(false);
+  const didSkipInitialResize = useRef(false);
 
-  const handlePopupReady = (node: HTMLElement) => {
-    const rect = node.getBoundingClientRect();
-    setPopupWidth(rect.width);
-    setPopupHeight(rect.height);
-    setX((x) => (x == null ? -rect.width / 2 : x));
-    setY((y) => (y == null ? -rect.height / 2 : y));
-  };
+  const handlePopupReady = useCallback(
+    (node: HTMLElement) => {
+      const rect = node.getBoundingClientRect();
+      setPopupWidth(rect.width);
+      setPopupHeight(rect.height);
+      // Only set position offsets (from center of window)
+      // if the haven't been set yet:
+      setX((x) => (x == null ? -rect.width / 2 : x));
+      setY((y) => (y == null ? -rect.height / 2 : y));
+
+      // Only install our observer if the user hasn’t already
+      // moved the popup, and we haven’t yet auto-centered once:
+      if (!hasMoved && !hasAutoCentered) {
+        const observer = new ResizeObserver(([entry]) => {
+          if (!didSkipInitialResize.current) {
+            // This is the "initial" callback. Not really a resize. Ignore it.
+            didSkipInitialResize.current = true;
+            return;
+          }
+          const { width, height } = entry.contentRect;
+          setX(-width / 2);
+          setY(-height / 2);
+          setHasAutoCentered(true);
+          // stop observing after first resize
+          observer.disconnect();
+        });
+        observer.observe(node);
+      }
+    },
+    [hasMoved, hasAutoCentered]
+  );
 
   useEffect(() => {
     if (!isMoving) return;
@@ -91,18 +118,22 @@ function Dialog(props: Props) {
       switch (e.key) {
         case 'ArrowUp':
           setY((y) => (y == null ? y : clampY(y - moveAmount)));
+          setHasMoved(true);
           handled = true;
           break;
         case 'ArrowDown':
           setY((y) => (y == null ? y : clampY(y + moveAmount)));
+          setHasMoved(true);
           handled = true;
           break;
         case 'ArrowLeft':
           setX((x) => (x == null ? x : clampX(x - moveAmount)));
+          setHasMoved(true);
           handled = true;
           break;
         case 'ArrowRight':
           setX((x) => (x == null ? x : clampX(x + moveAmount)));
+          setHasMoved(true);
           handled = true;
           break;
         case 'Escape':
@@ -302,6 +333,7 @@ function Dialog(props: Props) {
       onMove={(x, y) => {
         setX(x);
         setY(y);
+        setHasMoved(true);
       }}
       onReady={handlePopupReady}
     >


### PR DESCRIPTION
### Context
In PR #1354 (“popup keyboard accessibility enhancements related to AI expression summary work”), we added keyboard-based dragging and bounds-checking—but uncovered a new issue: popups (e.g. the strategy step edit/revise popup) with content that renders or resizes after initial mount no longer stayed centered.

### What’s Changed
- In `handlePopupReady`, install a one-shot `ResizeObserver` on the popup node:
  - Skip the observer’s very first callback (which always fires immediately).
  - On the first *real* resize (e.g. data or images finish loading), recalculate `x` and `y` to center the popup.
  - Disconnect the observer immediately to prevent further auto-centering.
- Use two flags—`hasMoved` and `hasAutoCentered`—to ensure:
  1. We never auto-center *after* the user has manually moved the popup.
  2. We only auto-center once, before any manual adjustments.

### How to Verify
1. Open a dialog whose content loads asynchronously (e.g. an image or fetched data).
2. Confirm the popup starts centered.
3. When content finishes loading, observe a single recentering.
4. After manually dragging the popup, confirm no further auto-centering occurs.

This resolves the uncentered popup behavior introduced in PR #1354.
