### PR TITLE
Eda notebook bm

### DIFF
--- a/packages/libs/eda/src/lib/core/types/visualization.ts
+++ b/packages/libs/eda/src/lib/core/types/visualization.ts
@@ -63,26 +63,41 @@ export interface Computation<ConfigType = unknown>
   };
 }
 
-export const Computation = t.type({
-  computationId: string,
-  displayName: t.union([t.string, t.undefined]),
-  descriptor: type({
-    type: string,
-    configuration: unknown,
-  }),
-  visualizations: array(Visualization),
-});
-
-export function makeComputationWithConfigDecoder<T>(
-  configDecoder: t.Type<T>
-): t.Type<Computation<T>> {
-  return t.type({
-    ...Computation.props,
-    descriptor: t.type({
-      ...Computation.props.descriptor.props,
-      configuration: configDecoder,
+export const Computation = intersection([
+  type({
+    computationId: string,
+    descriptor: type({
+      type: string,
+      configuration: unknown,
     }),
-  });
+    visualizations: array(Visualization),
+  }),
+  partial({
+    displayName: string,
+  }),
+]);
+
+export function makeComputationWithConfigDecoder<A>(
+  configDecoder: t.Type<A>
+): t.Type<{
+  computationId: string;
+  descriptor: { type: string; configuration: A };
+  visualizations: Visualization[];
+  displayName?: string;
+}> {
+  return t.intersection([
+    t.type({
+      computationId: t.string,
+      descriptor: t.type({
+        type: t.string,
+        configuration: configDecoder,
+      }),
+      visualizations: t.array(Visualization),
+    }),
+    t.partial({
+      displayName: t.string,
+    }),
+  ]);
 }
 
 const Thing = intersection([

--- a/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
@@ -110,29 +110,6 @@ export function ComputeNotebookCell(
       </details>
       {cells &&
         cells.map((subCell, index) => {
-          // TO DO: reinstate this, although the visualization cell knows about its compute jobStatus
-          //        so we can probably handle it there instead
-          //
-          //  // Add extra flair for subCell titles
-          //  const subTitle = (
-          //    <div className="subCellTitle">
-          //      <span>{subCell.title}</span>
-          //      <span
-          //        style={{ color: gray[600], fontWeight: 400, marginLeft: '1em' }}
-          //      >
-          //        {cell.title}
-          //      </span>
-          //      {jobStatus && <StatusIcon status={jobStatus} showLabel={false} />}
-          //    </div>
-          //  );
-          //  const subCellWithTitle = {
-          //    ...subCell,
-          //    title: subTitle,
-          //  };
-          //  if (isVisualizationCell(subCellWithTitle)) {
-          //    subCellWithTitle.computeJobStatus = jobStatus;
-          //  }
-          //
           const isSubCellDisabled =
             jobStatus !== 'complete' && subCell.type !== 'text';
 

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -86,9 +86,9 @@ export function EdaNotebookAnalysis(props: Props) {
         const computation = createComputation(
           cell.computationName,
           {},
+          [], // not passing potentially stale previous computations (used to prevent ID clash)
           [],
-          [],
-          computationId
+          computationId // use uuid instead
         );
         setComputations((prev: Computation[]) => [...prev, computation]);
         // recurse into child cells (only from compute cells?)

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -27,11 +27,13 @@ import {
   NotebookCellDescriptorBase,
   presetNotebooks,
   ComputeCellDescriptor,
+  NotebookCellDescriptor,
 } from './NotebookPresets';
 import {
   Computation,
   ComputationAppOverview,
 } from '../core/types/visualization';
+import { plugins } from '../core/components/computations/plugins';
 
 interface NotebookSettings {
   /** Ordered array of notebook cells */
@@ -44,66 +46,82 @@ const NOTEBOOK_UI_SETTINGS_KEY = '@@NOTEBOOK@@';
 const NOTEBOOK_PRESET_TEST = presetNotebooks['wgcnaCorrelationNotebook'];
 
 interface Props {
-  analysis: Analysis | NewAnalysis | undefined;
-  studyId: string;
-  onAnalysisChange: (value: Analysis | NewAnalysis | undefined) => void;
+  analysisState: AnalysisState;
+  notebookType: string;
 }
 
 export function EdaNotebookAnalysis(props: Props) {
-  const { studyId, onAnalysisChange } = props;
-  const studyRecord = useStudyRecord();
+  const { analysisState, notebookType } = props;
+  const { analysis, setComputations, addVisualization } = analysisState;
 
+  const studyRecord = useStudyRecord();
   const dataClient = useDataClient();
 
   const fetchApps = async () => {
     let { apps } = await dataClient.getApps();
     return { apps };
   };
+  const apps = useCachedPromise(fetchApps, ['fetchApps']);
 
-  const apps = useCachedPromise(fetchApps, [studyId]);
-
-  const wrappedOnAnalysisChange = useSetterWithCallback<
-    Analysis | NewAnalysis | undefined
-  >(props.analysis, onAnalysisChange);
-
-  const analysisState = useAnalysisState(
-    props.analysis,
-    wrappedOnAnalysisChange
-  );
-
-  const { analysis } = analysisState;
   if (analysis == null) throw new Error('Cannot find analysis.');
 
-  const computationName =
-    (
-      NOTEBOOK_PRESET_TEST.cells.find((cell) =>
-        isComputeCellDescriptor(cell)
-      ) as ComputeCellDescriptor
-    )?.computationName ?? 'pass';
+  const notebookPreset = presetNotebooks[notebookType];
+  if (notebookPreset == null)
+    throw new Error(`Cannot find a notebook preset for ${notebookType}`);
 
-  const appOverview =
-    apps && apps.value?.apps.find((app) => app.name === computationName);
-  console.log('computationname:', computationName);
-
-  const computation = useMemo(() => {
-    console.log('making new computation');
-    return createComputation(computationName, {}, [], []);
-  }, [computationName]);
-
-  // Create the one computation for the analysis. Eventually
-  // we'll move this logic or improve it to handle multiple computations.
+  // Create computations and visualizations if needed using the notebookPreset as a guide
   useEffect(() => {
-    if (!computation) return;
+    if (analysis == null) return;
+    // if the analysis already has computations, then don't repeat this
+    if (analysis.descriptor.computations.length > 0) return;
 
-    // Avoid updating if the computation already exists
-    const existingComputation =
-      analysisState.analysis?.descriptor.computations.find(
-        (comp) => comp.computationId === computation.computationId
-      );
-    if (existingComputation) return;
+    // recursive function to handle computation and visualization creation
+    function processCell(
+      cell: NotebookCellDescriptor,
+      parentComputationType?: string,
+      parentComputationId?: string
+    ) {
+      if (cell.type === 'compute') {
+        const computation = createComputation(
+          cell.computationName,
+          {},
+          analysis?.descriptor.computations,
+          []
+        );
+        setComputations((prev: Computation[]) => [...prev, computation]);
+        // recurse into child cells (only from compute cells?)
+        cell.cells?.forEach((child) =>
+          processCell(child, cell.computationName, computation.computationId)
+        );
+      } else if (
+        cell.type === 'visualization' &&
+        parentComputationType != null &&
+        parentComputationId != null
+      ) {
+        const appPlugin = plugins[parentComputationType];
+        const vizPlugin =
+          appPlugin && appPlugin.visualizationPlugins[cell.visualizationName];
 
-    analysisState.setComputations([computation]);
-  }, [analysisState, computation]);
+        const visualizationId = uuid();
+        const visualization = {
+          visualizationId,
+          displayName: 'Unnamed visualization',
+          descriptor: {
+            type: cell.visualizationName,
+            configuration: vizPlugin?.createDefaultConfig() ?? {},
+          },
+        };
+
+        addVisualization(parentComputationId, visualization);
+      }
+    }
+
+    // The recursion and state updates here work as intended because both
+    // `setComputations` and `addVisualization` use the functional update form.
+    // This ensures that updates are queued and applied in order, even across
+    // multiple recursive calls.
+    notebookPreset.cells.forEach((cell) => processCell(cell));
+  }, [analysis, setComputations, addVisualization, notebookPreset]);
 
   // Use state for computed preset notebook cells. Using a memo or ref didn't work because of the dependencies, that it needs to be
   // called once, and because it is needed elsewhere to run other hooks.
@@ -115,6 +133,7 @@ export function EdaNotebookAnalysis(props: Props) {
     // Assume if this has run once, we don't need it again. The preset
     // notebook should not change on refresh or rerendering.
     if (presetNotebookCells.length > 0) return;
+    const foo = analysisState.analysis?.descriptor.computations;
     if (appOverview) {
       const newCells = NOTEBOOK_PRESET_TEST.cells.map((cellDescriptor) =>
         notebookDescriptorToCell(

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -1,15 +1,10 @@
-import { useCallback, useMemo, useEffect, useState } from 'react';
-import {
-  Analysis,
-  AnalysisState,
-  NewAnalysis,
-  useAnalysisState,
-  useSetterWithCallback,
-  useStudyRecord,
-  useDataClient,
-} from '../core';
+import { useEffect } from 'react';
+import { AnalysisState, useStudyRecord } from '../core';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
-import { SaveableTextEditor } from '@veupathdb/wdk-client/lib/Components';
+import {
+  Loading,
+  SaveableTextEditor,
+} from '@veupathdb/wdk-client/lib/Components';
 import {
   ComputeNotebookCell,
   NotebookCell as NotebookCellType,
@@ -20,13 +15,11 @@ import { v4 as uuid } from 'uuid';
 
 import './EdaNotebook.scss';
 import { createComputation } from '../core/components/computations/Utils';
-import { useCachedPromise } from '../core/hooks/cachedPromise';
 import {
   isComputeCellDescriptor,
   isVisualizationCellDescriptor,
   NotebookCellDescriptorBase,
   presetNotebooks,
-  ComputeCellDescriptor,
   NotebookCellDescriptor,
 } from './NotebookPresets';
 import {
@@ -35,15 +28,7 @@ import {
 } from '../core/types/visualization';
 import { plugins } from '../core/components/computations/plugins';
 
-interface NotebookSettings {
-  /** Ordered array of notebook cells */
-  cells: NotebookCellType[];
-}
-
-const NOTEBOOK_UI_SETTINGS_KEY = '@@NOTEBOOK@@';
-
-// TEMPORARY: Eventually this value should come from the wdk or whomever is creating the notebook.
-const NOTEBOOK_PRESET_TEST = presetNotebooks['wgcnaCorrelationNotebook'];
+// const NOTEBOOK_UI_SETTINGS_KEY = '@@NOTEBOOK@@';
 
 interface Props {
   analysisState: AnalysisState;
@@ -55,13 +40,6 @@ export function EdaNotebookAnalysis(props: Props) {
   const { analysis, setComputations, addVisualization } = analysisState;
 
   const studyRecord = useStudyRecord();
-  const dataClient = useDataClient();
-
-  const fetchApps = async () => {
-    let { apps } = await dataClient.getApps();
-    return { apps };
-  };
-  const apps = useCachedPromise(fetchApps, ['fetchApps']);
 
   if (analysis == null) throw new Error('Cannot find analysis.');
 
@@ -69,7 +47,8 @@ export function EdaNotebookAnalysis(props: Props) {
   if (notebookPreset == null)
     throw new Error(`Cannot find a notebook preset for ${notebookType}`);
 
-  // Create computations and visualizations if needed using the notebookPreset as a guide
+  // One-off, create computations and visualizations in the analysis
+  // (if needed) using the notebookPreset as a guide
   useEffect(() => {
     if (analysis == null) return;
     // if the analysis already has computations, then don't repeat this
@@ -82,18 +61,18 @@ export function EdaNotebookAnalysis(props: Props) {
       parentComputationId?: string
     ) {
       if (cell.type === 'compute') {
-        const computationId = uuid();
         const computation = createComputation(
           cell.computationName,
           {},
-          [], // not passing potentially stale previous computations (used to prevent ID clash)
           [],
-          computationId // use uuid instead
+          [],
+          cell.computationId
         );
         setComputations((prev: Computation[]) => [...prev, computation]);
+
         // recurse into child cells (only from compute cells?)
         cell.cells?.forEach((child) =>
-          processCell(child, cell.computationName, computationId)
+          processCell(child, cell.computationName, cell.computationId)
         );
       } else if (
         cell.type === 'visualization' &&
@@ -104,7 +83,7 @@ export function EdaNotebookAnalysis(props: Props) {
         const vizPlugin =
           appPlugin && appPlugin.visualizationPlugins[cell.visualizationName];
 
-        const visualizationId = uuid();
+        const visualizationId = cell.visualizationId;
         const visualization = {
           visualizationId,
           displayName: 'Unnamed visualization',
@@ -125,69 +104,15 @@ export function EdaNotebookAnalysis(props: Props) {
     notebookPreset.cells.forEach((cell) => processCell(cell));
   }, [analysis, setComputations, addVisualization, notebookPreset]);
 
-  // Use state for computed preset notebook cells. Using a memo or ref didn't work because of the dependencies, that it needs to be
-  // called once, and because it is needed elsewhere to run other hooks.
-  const [presetNotebookCells, setPresetNotebookCells] = useState<
-    NotebookCellType[]
-  >([]);
-
-  useEffect(() => {
-    // Assume if this has run once, we don't need it again. The preset
-    // notebook should not change on refresh or rerendering.
-    if (presetNotebookCells.length > 0) return;
-    const foo = analysisState.analysis?.descriptor.computations;
-    if (appOverview) {
-      const newCells = NOTEBOOK_PRESET_TEST.cells.map((cellDescriptor) =>
-        notebookDescriptorToCell(
-          cellDescriptor,
-          analysisState,
-          computation,
-          appOverview
-        )
-      );
-      setPresetNotebookCells(newCells);
-    }
-  }, [appOverview, analysisState, computation, presetNotebookCells]);
-
-  // The following is currently required for subsetting cells to function.
-  const notebookSettings = useMemo((): NotebookSettings => {
-    const storedSettings =
-      analysisState.analysis?.descriptor.subset.uiSettings[
-        NOTEBOOK_UI_SETTINGS_KEY
-      ];
-    if (storedSettings == null) {
-      return presetNotebookCells && presetNotebookCells.length > 0
-        ? {
-            cells: presetNotebookCells,
-          }
-        : {
-            cells: [],
-          };
-    } else {
-      return storedSettings as any as NotebookSettings;
-    }
-  }, [
-    analysisState.analysis?.descriptor.subset.uiSettings,
-    presetNotebookCells,
-  ]);
-
-  const updateCell = useCallback(
-    (cell: Partial<Omit<NotebookCellType, 'type'>>, cellIndex: number) => {
-      const oldCell = notebookSettings.cells[cellIndex];
-      const newCell = { ...oldCell, ...cell };
-      const nextCells = notebookSettings.cells.concat();
-      nextCells[cellIndex] = newCell;
-      const nextSettings = {
-        ...notebookSettings,
-        cells: nextCells,
-      };
-      analysisState.setVariableUISettings({
-        [NOTEBOOK_UI_SETTINGS_KEY]: nextSettings,
-      });
-    },
-    [analysisState, notebookSettings]
-  );
-
+  //
+  // Now we render the notebook directly from the read-only `notebookPreset`,
+  // fetching computations and visualizations from analysisState.analysis where needed.
+  //
+  // If we need `notebookPreset` to be dynamic state (e.g. user can add/remove new cells)
+  // or if we need to store cell configuration beyond what the computation and visualisation
+  // descriptors in analysisState.analysis can handle, then we can change this to persisted
+  // `notebookState` coming from analysisState.analysis.descriptor.subset.uiSettings[NOTEBOOK_UI_SETTINGS_KEY]
+  //
   return (
     <div className="EdaNotebook">
       <div className="Paper">
@@ -201,55 +126,18 @@ export function EdaNotebookAnalysis(props: Props) {
           </h1>
           <h2>{safeHtml(studyRecord.displayName)}</h2>
         </div>
-        {notebookSettings.cells.map((cell, index) => (
-          <NotebookCell
-            key={index}
-            analysisState={analysisState}
-            cell={cell}
-            updateCell={(update) => updateCell(update, index)}
-          />
-        ))}
+        {analysis.descriptor.computations.length > 0 ? (
+          notebookPreset.cells.map((cell, index) => (
+            <NotebookCell
+              key={index}
+              analysisState={analysisState}
+              cell={cell}
+            />
+          ))
+        ) : (
+          <Loading />
+        )}
       </div>
     </div>
   );
 }
-
-// The notebook descriptors just contain basic information about what the cell should become.
-// This function generates the ids and finds the appropriate plugins for the cells.
-const notebookDescriptorToCell = function (
-  cellDescriptor: NotebookCellDescriptorBase<string>,
-  analysisState: AnalysisState,
-  computation?: Computation,
-  appOverview?: ComputationAppOverview
-): NotebookCellType {
-  if (isComputeCellDescriptor(cellDescriptor) && computation && appOverview) {
-    return {
-      ...cellDescriptor,
-      computeId: computation.computationId,
-      computationAppOverview: appOverview,
-      subCells: cellDescriptor.cells?.map((subCell) =>
-        notebookDescriptorToCell(
-          subCell,
-          analysisState,
-          computation,
-          appOverview
-        )
-      ),
-    } as ComputeNotebookCell;
-  } else if (
-    isVisualizationCellDescriptor(cellDescriptor) &&
-    computation &&
-    appOverview
-  ) {
-    const visualizationId = uuid();
-
-    return {
-      ...cellDescriptor,
-      visualizationId: visualizationId,
-      computeId: computation.computationId,
-      computationAppOverview: appOverview,
-    } as VisualizationNotebookCell;
-  } else {
-    return cellDescriptor as NotebookCellType;
-  }
-};

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -82,16 +82,18 @@ export function EdaNotebookAnalysis(props: Props) {
       parentComputationId?: string
     ) {
       if (cell.type === 'compute') {
+        const computationId = uuid();
         const computation = createComputation(
           cell.computationName,
           {},
-          analysis?.descriptor.computations,
-          []
+          [],
+          [],
+          computationId
         );
         setComputations((prev: Computation[]) => [...prev, computation]);
         // recurse into child cells (only from compute cells?)
         cell.cells?.forEach((child) =>
-          processCell(child, cell.computationName, computation.computationId)
+          processCell(child, cell.computationName, computationId)
         );
       } else if (
         cell.type === 'visualization' &&
@@ -201,6 +203,7 @@ export function EdaNotebookAnalysis(props: Props) {
         </div>
         {notebookSettings.cells.map((cell, index) => (
           <NotebookCell
+            key={index}
             analysisState={analysisState}
             cell={cell}
             updateCell={(update) => updateCell(update, index)}

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -5,27 +5,12 @@ import {
   Loading,
   SaveableTextEditor,
 } from '@veupathdb/wdk-client/lib/Components';
-import {
-  ComputeNotebookCell,
-  NotebookCell as NotebookCellType,
-  VisualizationNotebookCell,
-} from './Types';
 import { NotebookCell } from './NotebookCell';
-import { v4 as uuid } from 'uuid';
 
 import './EdaNotebook.scss';
 import { createComputation } from '../core/components/computations/Utils';
-import {
-  isComputeCellDescriptor,
-  isVisualizationCellDescriptor,
-  NotebookCellDescriptorBase,
-  presetNotebooks,
-  NotebookCellDescriptor,
-} from './NotebookPresets';
-import {
-  Computation,
-  ComputationAppOverview,
-} from '../core/types/visualization';
+import { presetNotebooks, NotebookCellDescriptor } from './NotebookPresets';
+import { Computation } from '../core/types/visualization';
 import { plugins } from '../core/components/computations/plugins';
 
 // const NOTEBOOK_UI_SETTINGS_KEY = '@@NOTEBOOK@@';

--- a/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
@@ -1,14 +1,13 @@
 import { AnalysisState } from '../core';
-import { NotebookCell as NotebookCellType } from './Types';
 import { SubsettingNotebookCell } from './SubsettingNotebookCell';
 import { TextNotebookCell } from './TextNotebookCell';
 import { VisualizationNotebookCell } from './VisualizationNotebookCell';
 import { ComputeNotebookCell } from './ComputeNotebookCell';
+import { NotebookCellDescriptor } from './NotebookPresets';
 
-interface Props {
+export interface NotebookCellProps<T extends NotebookCellDescriptor> {
   analysisState: AnalysisState;
-  cell: NotebookCellType;
-  updateCell: (cell: Partial<Omit<NotebookCellType, 'type'>>) => void;
+  cell: T;
   isSubCell?: boolean; // Indicates if this cell is a sub-cell of another cell. Affects styling.
   isDisabled?: boolean; // Indicates if the cell is disabled (e.g., before a computation is complete).
 }
@@ -16,49 +15,17 @@ interface Props {
 /**
  * Top-level component that delegates to imeplementations of NotebookCell variants.
  */
-export function NotebookCell(props: Props) {
-  const { cell, analysisState, updateCell, isSubCell, isDisabled } = props;
+export function NotebookCell(props: NotebookCellProps<NotebookCellDescriptor>) {
+  const { cell } = props;
   switch (cell.type) {
     case 'subset':
-      return (
-        <SubsettingNotebookCell
-          cell={cell}
-          analysisState={analysisState}
-          updateCell={updateCell}
-          isSubCell={isSubCell ?? false}
-          isDisabled={isDisabled ?? false}
-        />
-      );
+      return <SubsettingNotebookCell {...props} cell={cell} />;
     case 'text':
-      return (
-        <TextNotebookCell
-          cell={cell}
-          analysisState={analysisState}
-          updateCell={updateCell}
-          isSubCell={isSubCell ?? false}
-          isDisabled={isDisabled ?? false}
-        />
-      );
+      return <TextNotebookCell {...props} cell={cell} />;
     case 'visualization':
-      return (
-        <VisualizationNotebookCell
-          cell={cell}
-          analysisState={analysisState}
-          updateCell={updateCell}
-          isSubCell={isSubCell ?? false}
-          isDisabled={isDisabled ?? false}
-        />
-      );
+      return <VisualizationNotebookCell {...props} cell={cell} />;
     case 'compute':
-      return (
-        <ComputeNotebookCell
-          cell={cell}
-          analysisState={analysisState}
-          updateCell={updateCell}
-          isSubCell={isSubCell ?? false}
-          isDisabled={isDisabled ?? false}
-        />
-      );
+      return <ComputeNotebookCell {...props} cell={cell} />;
     default:
       return null;
   }

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -4,20 +4,21 @@
 // appropriate context, such as analysis state. In EdaNotebookAnalysis, these
 // descriptors get converted into cells using the ids and such generated in
 // the particular analysis.
+
+export type NotebookCellDescriptor =
+  | VisualizationCellDescriptor
+  | ComputeCellDescriptor
+  | TextCellDescriptor;
+
 export interface NotebookCellDescriptorBase<T extends string> {
   type: T;
   title: string;
-  cells?: (
-    | VisualizationCellDescriptor
-    | ComputeCellDescriptor
-    | TextCellDescriptor
-  )[];
+  cells?: NotebookCellDescriptor[];
 }
 
 export interface VisualizationCellDescriptor
   extends NotebookCellDescriptorBase<'visualization'> {
   visualizationName: string;
-  computationName: string;
 }
 
 export interface ComputeCellDescriptor
@@ -33,11 +34,7 @@ type PresetNotebook = {
   name: string;
   displayName: string;
   projects: string[];
-  cells: (
-    | VisualizationCellDescriptor
-    | ComputeCellDescriptor
-    | TextCellDescriptor
-  )[];
+  cells: NotebookCellDescriptor[];
 };
 
 // Preset notebooks
@@ -58,7 +55,6 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
             type: 'visualization',
             title: 'Volcano Plot',
             visualizationName: 'volcanoplot',
-            computationName: 'differentialabundance',
           },
           {
             type: 'text',
@@ -100,7 +96,6 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
             type: 'visualization',
             title: 'Correlation Plot',
             visualizationName: 'bipartitenetwork',
-            computationName: 'correlation',
           },
         ],
       },
@@ -115,7 +110,6 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
         type: 'visualization',
         title: 'Boxplot Visualization',
         visualizationName: 'boxplot',
-        computationName: 'pass',
       },
     ],
   },

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -1,5 +1,7 @@
 // Notebook presets
 
+import { ReactNode } from 'react';
+
 // The descriptors contain just enough information to render the cells when given the
 // appropriate context, such as analysis state. In EdaNotebookAnalysis, these
 // descriptors get converted into cells using the ids and such generated in
@@ -8,7 +10,8 @@
 export type NotebookCellDescriptor =
   | VisualizationCellDescriptor
   | ComputeCellDescriptor
-  | TextCellDescriptor;
+  | TextCellDescriptor
+  | SubsetCellDescriptor;
 
 export interface NotebookCellDescriptorBase<T extends string> {
   type: T;
@@ -19,16 +22,21 @@ export interface NotebookCellDescriptorBase<T extends string> {
 export interface VisualizationCellDescriptor
   extends NotebookCellDescriptorBase<'visualization'> {
   visualizationName: string;
+  visualizationId: string;
 }
 
 export interface ComputeCellDescriptor
   extends NotebookCellDescriptorBase<'compute'> {
   computationName: string;
+  computationId: string;
 }
 
 export interface TextCellDescriptor extends NotebookCellDescriptorBase<'text'> {
-  text: string;
+  text: ReactNode;
 }
+
+export interface SubsetCellDescriptor
+  extends NotebookCellDescriptorBase<'subset'> {}
 
 type PresetNotebook = {
   name: string;
@@ -50,11 +58,13 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
         type: 'compute',
         title: 'Differential Abundance',
         computationName: 'differentialabundance',
+        computationId: 'diff_1',
         cells: [
           {
             type: 'visualization',
             title: 'Volcano Plot',
             visualizationName: 'volcanoplot',
+            visualizationId: 'volcano_1',
           },
           {
             type: 'text',
@@ -86,6 +96,7 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
         type: 'compute',
         title: 'WGCNA Correlation',
         computationName: 'correlation',
+        computationId: 'correlation_1',
         cells: [
           {
             type: 'text',
@@ -96,6 +107,7 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
             type: 'visualization',
             title: 'Correlation Plot',
             visualizationName: 'bipartitenetwork',
+            visualizationId: 'bipartite_1',
           },
         ],
       },
@@ -110,6 +122,7 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
         type: 'visualization',
         title: 'Boxplot Visualization',
         visualizationName: 'boxplot',
+        visualizationId: 'boxplot_1',
       },
     ],
   },
@@ -132,4 +145,10 @@ export function isComputeCellDescriptor(
   cellDescriptor: NotebookCellDescriptorBase<string>
 ): cellDescriptor is ComputeCellDescriptor {
   return cellDescriptor.type === 'compute';
+}
+
+export function isSubsetCellDescriptor(
+  cellDescriptor: NotebookCellDescriptorBase<string>
+): cellDescriptor is SubsetCellDescriptor {
+  return cellDescriptor.type === 'subset';
 }

--- a/packages/libs/eda/src/lib/notebook/NotebookRoute.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookRoute.tsx
@@ -68,7 +68,10 @@ export default function NotebookRoute(props: Props) {
                 dataClient={dataClient}
                 computeClient={computeClient}
               >
-                <EdaNotebookAnalysis analysisState={analysisState} />
+                <EdaNotebookAnalysis
+                  analysisState={analysisState}
+                  notebookType="wgcnaCorrelationNotebook"
+                />
               </EDAWorkspaceContainer>
             )}
           />

--- a/packages/libs/eda/src/lib/notebook/NotebookRoute.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookRoute.tsx
@@ -10,6 +10,7 @@ import {
   useConfiguredDownloadClient,
   useConfiguredSubsettingClient,
   makeNewAnalysis,
+  useAnalysisState,
 } from '../core';
 import { DocumentationContainer } from '../core/components/docs/DocumentationContainer';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -43,6 +44,8 @@ export default function NotebookRoute(props: Props) {
   const [analysis, setAnalysis] =
     useState<Analysis | NewAnalysis | undefined>(initialAnalysis);
 
+  const analysisState = useAnalysisState(analysis, setAnalysis);
+
   return (
     <DocumentationContainer>
       <QueryClientProvider client={queryClient}>
@@ -65,11 +68,7 @@ export default function NotebookRoute(props: Props) {
                 dataClient={dataClient}
                 computeClient={computeClient}
               >
-                <EdaNotebookAnalysis
-                  analysis={analysis}
-                  studyId={props.match.params.datasetId}
-                  onAnalysisChange={setAnalysis}
-                />
+                <EdaNotebookAnalysis analysisState={analysisState} />
               </EDAWorkspaceContainer>
             )}
           />

--- a/packages/libs/eda/src/lib/notebook/TextNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/TextNotebookCell.tsx
@@ -1,12 +1,14 @@
-import { NotebookCellComponentProps } from './Types';
+import { NotebookCellProps } from './NotebookCell';
+import { TextCellDescriptor } from './NotebookPresets';
 
-export function TextNotebookCell(props: NotebookCellComponentProps<'text'>) {
+export function TextNotebookCell(props: NotebookCellProps<TextCellDescriptor>) {
   const { cell, isSubCell, isDisabled } = props;
-  const { text } = cell;
+
+  const { text, title } = cell;
 
   return (
     <details className={isSubCell ? 'subCell' : ''} open>
-      <summary>{cell.title}</summary>
+      <summary>{title}</summary>
       <div className={isDisabled ? 'disabled' : ''}>{text}</div>
     </details>
   );

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -100,7 +100,7 @@ export function VisualizationNotebookCell(
             visualization={visualization}
             computation={computation}
             copmutationAppOverview={appOverview}
-            filters={[]} // issue #1413
+            filters={analysis.descriptor.subset.descriptor} // issue #1413
             starredVariables={[]} // to be implemented
             toggleStarredVariable={() => {}}
             updateConfiguration={updateConfiguration}

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -5,12 +5,10 @@ import { useGeoConfig } from '../core/hooks/geoConfig';
 import { plugins } from '../core/components/computations/plugins';
 import { PlotContainerStyleOverrides } from '../core/components/visualizations/VisualizationTypes';
 import { NotebookCellProps } from './NotebookCell';
-import {
-  ComputeCellDescriptor,
-  VisualizationCellDescriptor,
-} from './NotebookPresets';
+import { VisualizationCellDescriptor } from './NotebookPresets';
 import { useCachedPromise } from '../core/hooks/cachedPromise';
 import { useComputeJobStatus } from '../core/components/computations/ComputeJobStatusHook';
+import { StatusIcon } from '../core/components/computations/RunComputeButton';
 
 export function VisualizationNotebookCell(
   props: NotebookCellProps<VisualizationCellDescriptor>
@@ -90,7 +88,12 @@ export function VisualizationNotebookCell(
 
   return visualization ? (
     <details className={isSubCell ? 'subCell' : ''} open>
-      <summary>{cell.title}</summary>
+      <summary style={{ display: 'flex', justifyContent: 'space-between' }}>
+        {cell.title}{' '}
+        {computeJobStatus && (
+          <StatusIcon status={computeJobStatus} showLabel={false} />
+        )}
+      </summary>
       <div className={isDisabled ? 'disabled' : ''}>
         {computation && vizPlugin && (
           <vizPlugin.fullscreenComponent

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -86,9 +86,10 @@ export function EdaNotebookParameter(props: Props<StringParam>) {
           />
         </WorkspaceContainer>
       </DocumentationContainer>
-      <ParameterComponent {...props} />
     </>
   );
+
+  // TO DO - don't forget: <ParameterComponent {...props} />
 }
 
 interface EdaNotebookAdapterProps {
@@ -99,16 +100,6 @@ interface EdaNotebookAdapterProps {
 function EdaNotebookAdapter(props: EdaNotebookAdapterProps) {
   const { analysisState } = props;
   const studyId = analysisState.analysis?.studyId;
-
-  // Used for subsetting. To be addressed in #1413
-  // const getDefaultVariableDescriptor = useGetDefaultVariableDescriptor();
-  // const varAndEnt = getDefaultVariableDescriptor();
-  // const [entityId, setEntityId] = useState<string | undefined>(
-  //   varAndEnt.entityId
-  // );
-  // const [variableId, setVariableId] = useState<string | undefined>(
-  //   varAndEnt.variableId
-  // );
 
   const analysisClient = useConfiguredAnalysisClient(edaServiceUrl);
   const subsettingClient = useConfiguredSubsettingClient(edaServiceUrl);

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -32,6 +32,7 @@ import { formatFilterDisplayValue } from '@veupathdb/eda/lib/core/utils/study-me
 import { DatasetItem } from '@veupathdb/wdk-client/lib/Views/Question/Params/DatasetParamUtils';
 import { parseJson } from '@veupathdb/eda/lib/notebook/Utils';
 import { EdaNotebookAnalysis } from '@veupathdb/eda/lib/notebook/EdaNotebookAnalysis';
+import ParameterComponent from '@veupathdb/wdk-client/lib/Views/Question/ParameterComponent';
 import { debounce } from 'lodash';
 
 const datasetIdParamName = 'eda_dataset_id';
@@ -53,19 +54,29 @@ export function EdaNotebookParameter(props: Props<StringParam>) {
     }
   );
 
-  // Here we periodically send analysis state back upstream to WDK
-  const debouncedPersist = useMemo(
-    () =>
-      debounce(
-        (a: Analysis | NewAnalysis | undefined) =>
-          onParamValueChange(JSON.stringify(a)),
-        500
-      ),
-    [onParamValueChange]
-  );
-  useEffect(() => {
-    debouncedPersist(analysis);
-  }, [analysis, debouncedPersist]);
+  // Disabled for now: persistence of analysis state to the 'param'
+  // It should probably be persisted to another 'param' because this
+  // 'param' needs to store the WGCNA module
+
+  //  // Here we periodically send analysis state back upstream to WDK
+  //  const debouncedPersist = useMemo(
+  //    () =>
+  //      debounce(
+  //        (a: Analysis | NewAnalysis | undefined) =>
+  //          onParamValueChange(JSON.stringify(a)),
+  //        500
+  //      ),
+  //    [onParamValueChange]
+  //  );
+  //  useEffect(() => {
+  //    debouncedPersist(analysis);
+  //  }, [analysis, debouncedPersist]);
+  //
+  // useEffect(() => {
+  //   return () => {
+  //     debouncedPersist.cancel();
+  //   };
+  // }, [debouncedPersist]);
 
   // TO DO (maybe)
   // Consider watching `value` for updates that happened on the WDK side
@@ -75,12 +86,6 @@ export function EdaNotebookParameter(props: Props<StringParam>) {
   // has two tabs open?? Good idea to look at what the regular EDA does.
 
   // debounce clean-up, just to be on the safe side
-  useEffect(() => {
-    return () => {
-      debouncedPersist.cancel();
-    };
-  }, [debouncedPersist]);
-
   // Create the all-singing, all-dancing analysisState
   const analysisState = useAnalysisState(analysis, setAnalysis);
 
@@ -96,10 +101,9 @@ export function EdaNotebookParameter(props: Props<StringParam>) {
           />
         </WorkspaceContainer>
       </DocumentationContainer>
+      <ParameterComponent {...props} />
     </>
   );
-
-  // TO DO - don't forget: <ParameterComponent {...props} />
 }
 
 interface EdaNotebookAdapterProps {


### PR DESCRIPTION
Refactor to wire in the analysis state "from the source" (even though we don't have a proper question string-param to store the state in).

Also simplified the rendering/configuring process. We just render using the read-only preset structure as a guide. Computation and visualization IDs are provided in the preset template, and while rendering, the cell components just fetch the computation and/or visualization from analysisState as needed. We were lucky that there's a method that retrieves a visualization **and** computation using just the viz id.

As noted in comments somewhere, we can change it so that the notebook structure is dynamic/persisted state and can store further configuration (e.g. the text contents of an EditableTextCell)

To dos:

- [x] probably remove `changeConfigHandlerOverride` - no don't remove it - we do need a simpler version that doesn't move visualisations around, however, this needs updating to handle multiple computations, I think. Not done, but a TO DO comment has been added
- [x] reinstate extra flair for subCell titles in ComputeNotebookCell.tsx - possibly add an optional flair prop for all cell descriptors?
- [x] remove lots of `console.log()`s
- [x] fix the temporary disappearing of the visualization when changing the viz thresholds