### PR TITLE
General eda notebook updates round 1

### DIFF
--- a/packages/libs/components/src/plots/BipartiteNetworkPlot.tsx
+++ b/packages/libs/components/src/plots/BipartiteNetworkPlot.tsx
@@ -23,6 +23,7 @@ export interface BipartiteNetworkPlotProps extends NetworkPlotProps {
 }
 
 const DEFAULT_TOP_PADDING = 40;
+const DEFAULT_BOTTOM_PADDING = 20;
 const DEFAULT_NODE_SPACING = 30;
 const DEFAULT_SVG_WIDTH = 400;
 
@@ -59,14 +60,16 @@ function BipartiteNetworkPlot(
   } = props;
 
   // Set up styles for the bipartite network and incorporate overrides
+  const topPadding =
+    partitions[0].name || partitions[1].name ? 80 : DEFAULT_TOP_PADDING;
   const svgStyles = {
     width: Number(containerStyles?.width) || DEFAULT_SVG_WIDTH,
     height:
       Math.max(partitions[1].nodeIds.length, partitions[0].nodeIds.length) *
         DEFAULT_NODE_SPACING +
-      DEFAULT_TOP_PADDING,
-    topPadding:
-      partitions[0].name || partitions[1].name ? 60 : DEFAULT_TOP_PADDING,
+      topPadding +
+      DEFAULT_BOTTOM_PADDING,
+    topPadding: topPadding,
     nodeSpacing: DEFAULT_NODE_SPACING,
     columnPadding: 100,
     ...svgStyleOverrides,
@@ -105,6 +108,7 @@ function BipartiteNetworkPlot(
       column2Position,
       svgStyles.nodeSpacing,
       svgStyles.topPadding,
+      getNodeActions,
     ]
   );
 

--- a/packages/libs/components/src/plots/NetworkPlot.css
+++ b/packages/libs/components/src/plots/NetworkPlot.css
@@ -5,7 +5,6 @@
 
 .network-plot-container {
   width: 100%;
-  height: 800px;
   overflow-y: scroll;
 }
 

--- a/packages/libs/components/src/plots/NetworkPlot.tsx
+++ b/packages/libs/components/src/plots/NetworkPlot.tsx
@@ -51,6 +51,8 @@ export interface NetworkPlotProps {
   annotations?: ReactNode[];
   /** visible node labels */
   visibleNodeLabels?: NodeLabelProp[];
+  /** Add additional functionality to a node click */
+  additionalOnNodeClickAction?: (node: NodeData) => void;
 }
 
 const DEFAULT_PLOT_WIDTH = 800;
@@ -80,6 +82,7 @@ function NetworkPlot(props: NetworkPlotProps, ref: Ref<HTMLDivElement>) {
     emptyNetworkContent,
     annotations,
     visibleNodeLabels,
+    additionalOnNodeClickAction,
   } = props;
 
   const [highlightedNodeId, setHighlightedNodeId] = useState<string>();
@@ -305,6 +308,8 @@ function NetworkPlot(props: NetworkPlotProps, ref: Ref<HTMLDivElement>) {
                           setHighlightedNodeId((id) =>
                             id === node.id ? undefined : node.id
                           );
+                          additionalOnNodeClickAction &&
+                            additionalOnNodeClickAction(node);
                         }}
                         fontWeight={isHighlighted ? 600 : 400}
                         // pass showLabel as a prop for hover event

--- a/packages/libs/components/src/stories/plots/NetworkPlot.stories.tsx
+++ b/packages/libs/components/src/stories/plots/NetworkPlot.stories.tsx
@@ -146,6 +146,16 @@ Thumbnail.args = {
   showThumbnail: true,
 };
 
+// Add additional behavior to a node click
+function handleNodeClick(node: NodeData) {
+  console.log('You clicked node ' + node.id);
+}
+export const WithAdditionalNodeClickBehavior = Template.bind({});
+WithAdditionalNodeClickBehavior.args = {
+  ...simpleData,
+  additionalOnNodeClickAction: handleNodeClick,
+};
+
 // Test node actions
 function getNodeActions(nodeId: string): NodeMenuAction[] {
   return [

--- a/packages/libs/eda/src/lib/core/components/computations/ComputationStepContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/ComputationStepContainer.tsx
@@ -13,6 +13,7 @@ type ComputationStepContainer = {
     color?: NumberedHeaderProps['color'];
   };
   isStepDisabled?: boolean;
+  showStepNumber?: boolean;
 };
 
 const disabledStyles: CSSProperties = {
@@ -24,14 +25,21 @@ export function ComputationStepContainer(props: ComputationStepContainer) {
   const theme = useUITheme();
   const primaryColor =
     theme?.palette.primary.hue[theme.palette.primary.level] ?? 'black';
-  const { children, computationStepInfo, isStepDisabled } = props;
+  const {
+    children,
+    computationStepInfo,
+    isStepDisabled,
+    showStepNumber = true,
+  } = props;
   return (
     <div style={isStepDisabled ? disabledStyles : undefined}>
-      <NumberedHeader
-        number={computationStepInfo.stepNumber}
-        text={computationStepInfo.stepTitle}
-        color={isStepDisabled ? 'darkgrey' : primaryColor}
-      />
+      {showStepNumber && (
+        <NumberedHeader
+          number={computationStepInfo.stepNumber}
+          text={computationStepInfo.stepTitle}
+          color={isStepDisabled ? 'darkgrey' : primaryColor}
+        />
+      )}
       {children}
     </div>
   );

--- a/packages/libs/eda/src/lib/core/components/computations/RunComputeButton.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/RunComputeButton.tsx
@@ -4,6 +4,7 @@ import { ComputationAppOverview } from '../../types/visualization';
 import { Tooltip } from '@veupathdb/coreui';
 import { JobStatus } from './ComputeJobStatusHook';
 import { removeParentheticals } from '../../utils/string-formatters';
+import './plugins/Plugins.scss';
 
 interface Props {
   computationAppOverview: ComputationAppOverview;
@@ -16,16 +17,7 @@ export function RunComputeButton(props: Props) {
   const { computationAppOverview, status, isConfigured, createJob } = props;
 
   return computationAppOverview.computeName ? (
-    <div
-      style={{
-        display: 'flex',
-        gap: '1em',
-        alignItems: 'center',
-        padding: '1em 0',
-        marginLeft: '3em',
-        marginBottom: '2em',
-      }}
-    >
+    <div className="RunComputeButton">
       <FilledButton
         themeRole="primary"
         // Remove any parentheticals from the button text

--- a/packages/libs/eda/src/lib/core/components/computations/Types.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/Types.ts
@@ -22,6 +22,8 @@ export interface ComputationConfigProps extends ComputationProps {
   visualizationId: string;
   addNewComputation: (name: string, configuration: unknown) => void;
   changeConfigHandlerOverride?: (propertyName: string, value: any) => void;
+  showStepNumber?: boolean; // Whether to show step number (NumberedHeader)
+  showExpandableHelp?: boolean; // If computation has expandable help, determines whether or not to show it.
 }
 
 export interface ComputationOverviewProps extends ComputationProps {}

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/Plugins.scss
@@ -69,3 +69,12 @@
     }
   }
 }
+
+.RunComputeButton {
+  display: flex;
+  gap: 1em;
+  align-items: center;
+  padding: 1em 0;
+  margin-left: 3em;
+  margin-bottom: 2em;
+}

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlation.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlation.tsx
@@ -32,6 +32,7 @@ import {
   CompleteCorrelationConfig,
   CorrelationConfig,
 } from '../../../types/apps';
+import { NodeData } from '@veupathdb/components/lib/types/plots/network';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
 
@@ -82,45 +83,6 @@ export const plugin: ComputationPlugin = {
           return [];
         }
       },
-      makeGetNodeMenuActions(studyMetadata) {
-        const entities = entityTreeToArray(studyMetadata.rootEntity);
-        const variables = entities.flatMap((e) => e.variables);
-        const collections = entities.flatMap(
-          (entity) => entity.collections ?? []
-        );
-        const hostCollection = collections.find(
-          (c) => c.id === 'EUPATH_0005050'
-        );
-        const parasiteCollection = collections.find(
-          (c) => c.id === 'EUPATH_0005051'
-        );
-        return function getNodeActions(nodeId: string) {
-          const [, variableId] = nodeId.split('.');
-          const variable = variables.find((v) => v.id === variableId);
-          if (variable == null) return [];
-
-          // E.g., "qa."
-          const urlPrefix = window.location.host.replace(
-            /(plasmodb|hostdb)\.org/,
-            ''
-          );
-
-          const href = parasiteCollection?.memberVariableIds.includes(
-            variable.id
-          )
-            ? `//${urlPrefix}plasmodb.org/plasmo/app/search/transcript/GenesByRNASeqpfal3D7_Lee_Gambian_ebi_rnaSeq_RSRCWGCNAModules?param.wgcnaParam=${variable.displayName.toLowerCase()}&autoRun=1`
-            : hostCollection?.memberVariableIds.includes(variable.id)
-            ? `//${urlPrefix}hostdb.org/hostdb/app/search/transcript/GenesByRNASeqhsapREF_Lee_Gambian_ebi_rnaSeq_RSRCWGCNAModules?param.wgcnaParam=${variable.displayName.toLowerCase()}&autoRun=1`
-            : undefined;
-          if (href == null) return [];
-          return [
-            {
-              label: 'See list of genes',
-              href,
-            },
-          ];
-        };
-      },
       getParitionNames(studyMetadata, config) {
         if (CorrelationConfig.is(config)) {
           const entities = entityTreeToArray(studyMetadata.rootEntity);
@@ -138,7 +100,7 @@ export const plugin: ComputationPlugin = {
           return { partition1Name, partition2Name };
         }
       },
-    }), // Must match name in data service and in visualization.tsx
+    }),
   },
   isEnabledInPicker: isEnabledInPicker,
   studyRequirements:

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/correlation.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/correlation.tsx
@@ -216,7 +216,6 @@ const DEFAULT_PROPORTION_NON_ZERO_THRESHOLD = 0.05;
 const DEFAULT_VARIANCE_THRESHOLD = 0;
 const DEFAULT_STANDARD_DEVIATION_THRESHOLD = 0;
 
-// Shows as Step 1 in the full screen visualization page
 export function CorrelationConfiguration(props: ComputationConfigProps) {
   const {
     computationAppOverview,
@@ -224,6 +223,8 @@ export function CorrelationConfiguration(props: ComputationConfigProps) {
     analysisState,
     visualizationId,
     changeConfigHandlerOverride,
+    showStepNumber = true,
+    showExpandableHelp = true,
   } = props;
 
   const configuration = computation.descriptor
@@ -350,6 +351,7 @@ export function CorrelationConfiguration(props: ComputationConfigProps) {
         stepNumber: 1,
         stepTitle: `Configure ${computationAppOverview.displayName}`,
       }}
+      showStepNumber={showStepNumber}
     >
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         <div className={cx()}>
@@ -464,14 +466,16 @@ export function CorrelationConfiguration(props: ComputationConfigProps) {
             bannerType="error"
           />
         </div>
-        <ExpandablePanel
-          title="Learn more about correlation"
-          subTitle={{}}
-          children={helpContent}
-          stylePreset="floating"
-          themeRole="primary"
-          styleOverrides={{ container: { marginLeft: 40 } }}
-        />
+        {showExpandableHelp && (
+          <ExpandablePanel
+            title="Learn more about correlation"
+            subTitle={{}}
+            children={helpContent}
+            stylePreset="floating"
+            themeRole="primary"
+            styleOverrides={{ container: { marginLeft: 40 } }}
+          />
+        )}
       </div>
     </ComputationStepContainer>
   );

--- a/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
@@ -86,6 +86,9 @@ export function ComputeNotebookCell(
 
   return computation && appOverview ? (
     <>
+      <div className="notebookCellHelpText">
+        <span>{cell.helperText}</span>
+      </div>
       <details className={isSubCell ? 'subCell' : ''} open>
         <summary>{cell.title}</summary>
         <div className={isDisabled ? 'disabled' : ''}>

--- a/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
@@ -86,11 +86,13 @@ export function ComputeNotebookCell(
 
   return computation && appOverview ? (
     <>
-      <div className="notebookCellHelpText">
+      <div className="NotebookCellHelpText">
         <span>{cell.helperText}</span>
       </div>
       <details className={isSubCell ? 'subCell' : ''} open>
-        <summary>{cell.title}</summary>
+        <summary>
+          <span>{cell.title}</span>
+        </summary>
         <div className={isDisabled ? 'disabled' : ''}>
           <plugin.configurationComponent
             analysisState={analysisState}
@@ -102,6 +104,8 @@ export function ComputeNotebookCell(
             computationAppOverview={appOverview}
             geoConfigs={[]}
             changeConfigHandlerOverride={changeConfigHandler}
+            showStepNumber={false}
+            showExpandableHelp={false} // no expandable sections within an expandable element.
           />
           <RunComputeButton
             computationAppOverview={appOverview}

--- a/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
@@ -15,7 +15,7 @@ import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/Expanda
 export function ComputeNotebookCell(
   props: NotebookCellProps<ComputeCellDescriptor>
 ) {
-  const { analysisState, cell, isSubCell, isDisabled } = props;
+  const { analysisState, cell, isDisabled } = props;
   const { analysis } = analysisState;
   if (analysis == null) throw new Error('Cannot find analysis.');
 

--- a/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
@@ -1,10 +1,7 @@
 import { useEntityCounts } from '../core/hooks/entityCounts';
 import { useDataClient } from '../core/hooks/workspace';
 import { isEqual } from 'lodash';
-import {
-  RunComputeButton,
-  StatusIcon,
-} from '../core/components/computations/RunComputeButton';
+import { RunComputeButton } from '../core/components/computations/RunComputeButton';
 import { useComputeJobStatus } from '../core/components/computations/ComputeJobStatusHook';
 import { NotebookCell, NotebookCellProps } from './NotebookCell';
 import { plugins } from '../core/components/computations/plugins';

--- a/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
@@ -130,8 +130,8 @@ export function ComputeNotebookCell(
               key={index}
               analysisState={analysisState}
               cell={subCell}
-              isSubCell={true}
               isDisabled={isSubCellDisabled}
+              expandedPanelState={isSubCellDisabled ? 'closed' : 'open'}
             />
           );
         })}

--- a/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
@@ -12,7 +12,7 @@ import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/Expanda
 export function ComputeNotebookCell(
   props: NotebookCellProps<ComputeCellDescriptor>
 ) {
-  const { analysisState, cell, isDisabled } = props;
+  const { analysisState, cell, isDisabled, wdkState } = props;
   const { analysis } = analysisState;
   if (analysis == null) throw new Error('Cannot find analysis.');
 
@@ -129,6 +129,7 @@ export function ComputeNotebookCell(
               cell={subCell}
               isDisabled={isSubCellDisabled}
               expandedPanelState={isSubCellDisabled ? 'closed' : 'open'}
+              wdkState={wdkState}
             />
           );
         })}

--- a/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
@@ -10,6 +10,7 @@ import { NotebookCell, NotebookCellProps } from './NotebookCell';
 import { plugins } from '../core/components/computations/plugins';
 import { ComputeCellDescriptor } from './NotebookPresets';
 import { useCachedPromise } from '../core/hooks/cachedPromise';
+import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/ExpandablePanel';
 
 export function ComputeNotebookCell(
   props: NotebookCellProps<ComputeCellDescriptor>
@@ -89,11 +90,15 @@ export function ComputeNotebookCell(
       <div className="NotebookCellHelpText">
         <span>{cell.helperText}</span>
       </div>
-      <details className={isSubCell ? 'subCell' : ''} open>
-        <summary>
-          <span>{cell.title}</span>
-        </summary>
-        <div className={isDisabled ? 'disabled' : ''}>
+      <ExpandablePanel
+        title={cell.title}
+        subTitle={''}
+        state="open"
+        themeRole="primary"
+      >
+        <div
+          className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}
+        >
           <plugin.configurationComponent
             analysisState={analysisState}
             computation={computation}
@@ -114,7 +119,7 @@ export function ComputeNotebookCell(
             createJob={createJob}
           />
         </div>
-      </details>
+      </ExpandablePanel>
       {cells &&
         cells.map((subCell, index) => {
           const isSubCellDisabled =

--- a/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
@@ -12,13 +12,7 @@
     --paper-scale: 0.5;
 
     width: calc(var(--paper-width) * var(--paper-scale));
-    /* height: calc(var(--paper-height) * var(--paper-scale)); */
-
-    padding: 2em;
     margin: 1em auto;
-
-    /* background-color: #f3f3f3; */
-    box-shadow: 0 0 2px #b5b5b5;
 
     > * + * {
       margin-block-start: 1rem;
@@ -119,9 +113,6 @@
         pointer-events: none;
         opacity: 0.5;
       }
-    }
-    > details.subCell {
-      margin-left: 2em;
     }
   }
 

--- a/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
@@ -45,6 +45,11 @@
     }
 
     /* Notebook cell styling */
+    .notebookCellHelpText {
+      margin-top: 2em;
+      font-weight: 500;
+      font-size: 1.2em;
+    }
     > details {
       border: 1px solid;
       border-color: color-mix(

--- a/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
@@ -13,9 +13,14 @@
 
     width: calc(var(--paper-width) * var(--paper-scale));
     margin: 1em auto;
+    padding: 0 1em;
 
     > * + * {
       margin-block-start: 1rem;
+    }
+
+    > H5 {
+      padding-bottom: 0.5em;
     }
 
     .Heading {
@@ -62,6 +67,22 @@
     }
     .NotebookCellHelpText:first-of-type {
       margin-top: 2em;
+    }
+
+    .WdkParamInputs {
+      display: flex;
+      flex-direction: column;
+      gap: 2em;
+      margin-top: 1em;
+      margin-bottom: 1em;
+    }
+
+    .InputGroup {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 1em;
+      font-weight: 500;
     }
     > details {
       border: 1px solid;

--- a/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
@@ -60,6 +60,9 @@
       font-weight: 500;
       font-size: 1.2em;
     }
+    .NotebookCellHelpText:first-of-type {
+      margin-top: 2em;
+    }
     > details {
       border: 1px solid;
       border-color: color-mix(

--- a/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
@@ -51,12 +51,12 @@
     .RunComputeButton {
       margin-left: 1em;
       margin-bottom: 0em;
-      margin-top: 1em;
+      margin-top: 1.5em;
     }
 
     /* Notebook cell styling */
     .NotebookCellHelpText {
-      margin-top: 3em;
+      margin-top: 4em;
       font-weight: 500;
       font-size: 1.2em;
     }
@@ -129,6 +129,15 @@
         pointer-events: none;
         opacity: 0.5;
       }
+    }
+
+    .NotebookCellContent {
+      padding: 2em;
+    }
+
+    .NotebookCellContent.disabled {
+      pointer-events: none;
+      opacity: 0.5;
     }
   }
 

--- a/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
@@ -44,9 +44,19 @@
       }
     }
 
+    /* Override left margin for AppStepConfigurationContainer */
+    .AppStepConfigurationContainer {
+      margin-left: 1em;
+    }
+    .RunComputeButton {
+      margin-left: 1em;
+      margin-bottom: 0em;
+      margin-top: 1em;
+    }
+
     /* Notebook cell styling */
-    .notebookCellHelpText {
-      margin-top: 2em;
+    .NotebookCellHelpText {
+      margin-top: 3em;
       font-weight: 500;
       font-size: 1.2em;
     }
@@ -63,10 +73,10 @@
       border-bottom-right-radius: 0.5em;
 
       > summary {
-        padding: 0.75em;
+        padding: 1em;
         cursor: pointer;
         font-size: 1.2em;
-        font-weight: 500;
+        font-weight: 300;
         background-color: color-mix(
           in srgb,
           var(--coreui-color-primary) 10%,
@@ -93,6 +103,7 @@
 
         > * {
           display: inline; // prevents contents from wrapping underneath the arrow
+          padding-left: 0.75em;
         }
 
         div.subCellTitle {

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -100,16 +100,6 @@ export function EdaNotebookAnalysis(props: Props) {
   return (
     <div className="EdaNotebook">
       <div className="Paper">
-        <div className="Heading">
-          <h1>
-            <SaveableTextEditor
-              className="Title"
-              value={analysisState.analysis?.displayName ?? ''}
-              onSave={analysisState.setName}
-            />
-          </h1>
-          <h2>{safeHtml(studyRecord.displayName)}</h2>
-        </div>
         {analysis.descriptor.computations.length > 0 ? (
           notebookPreset.cells.map((cell, index) => (
             <NotebookCell

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -1,10 +1,6 @@
 import { useEffect } from 'react';
 import { AnalysisState, useStudyRecord } from '../core';
-import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
-import {
-  Loading,
-  SaveableTextEditor,
-} from '@veupathdb/wdk-client/lib/Components';
+import { Loading } from '@veupathdb/wdk-client/lib/Components';
 import { NotebookCell } from './NotebookCell';
 import './EdaNotebook.scss';
 import { createComputation } from '../core/components/computations/Utils';
@@ -12,7 +8,7 @@ import { presetNotebooks, NotebookCellDescriptor } from './NotebookPresets';
 import { Computation } from '../core/types/visualization';
 import { plugins } from '../core/components/computations/plugins';
 import CoreUIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
-import { colors, H3, H5, H6 } from '@veupathdb/coreui';
+import { colors, H5 } from '@veupathdb/coreui';
 
 // const NOTEBOOK_UI_SETTINGS_KEY = '@@NOTEBOOK@@';
 

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -12,7 +12,7 @@ import { presetNotebooks, NotebookCellDescriptor } from './NotebookPresets';
 import { Computation } from '../core/types/visualization';
 import { plugins } from '../core/components/computations/plugins';
 import CoreUIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
-import { colors } from '@veupathdb/coreui';
+import { colors, H3, H5, H6 } from '@veupathdb/coreui';
 
 // const NOTEBOOK_UI_SETTINGS_KEY = '@@NOTEBOOK@@';
 
@@ -111,6 +111,7 @@ export function EdaNotebookAnalysis(props: Props) {
     >
       <div className="EdaNotebook">
         <div className="Paper">
+          {notebookPreset.header && <H5 text={notebookPreset.header} />}
           {analysis.descriptor.computations.length > 0 ? (
             notebookPreset.cells.map((cell, index) => (
               <NotebookCell

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -11,6 +11,8 @@ import { createComputation } from '../core/components/computations/Utils';
 import { presetNotebooks, NotebookCellDescriptor } from './NotebookPresets';
 import { Computation } from '../core/types/visualization';
 import { plugins } from '../core/components/computations/plugins';
+import CoreUIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
+import { colors } from '@veupathdb/coreui';
 
 // const NOTEBOOK_UI_SETTINGS_KEY = '@@NOTEBOOK@@';
 
@@ -98,20 +100,30 @@ export function EdaNotebookAnalysis(props: Props) {
   // `notebookState` coming from analysisState.analysis.descriptor.subset.uiSettings[NOTEBOOK_UI_SETTINGS_KEY]
   //
   return (
-    <div className="EdaNotebook">
-      <div className="Paper">
-        {analysis.descriptor.computations.length > 0 ? (
-          notebookPreset.cells.map((cell, index) => (
-            <NotebookCell
-              key={index}
-              analysisState={analysisState}
-              cell={cell}
-            />
-          ))
-        ) : (
-          <Loading />
-        )}
+    // The CoreUIThemeProvider should be moved elsewhere. Should go in the genomics form override.
+    <CoreUIThemeProvider
+      theme={{
+        palette: {
+          primary: { hue: colors.cyan, level: 600 },
+          secondary: { hue: colors.mutedRed, level: 500 },
+        },
+      }}
+    >
+      <div className="EdaNotebook">
+        <div className="Paper">
+          {analysis.descriptor.computations.length > 0 ? (
+            notebookPreset.cells.map((cell, index) => (
+              <NotebookCell
+                key={index}
+                analysisState={analysisState}
+                cell={cell}
+              />
+            ))
+          ) : (
+            <Loading />
+          )}
+        </div>
       </div>
-    </div>
+    </CoreUIThemeProvider>
   );
 }

--- a/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
@@ -8,7 +8,6 @@ import { NotebookCellDescriptor } from './NotebookPresets';
 export interface NotebookCellProps<T extends NotebookCellDescriptor> {
   analysisState: AnalysisState;
   cell: T;
-  isSubCell?: boolean; // Indicates if this cell is a sub-cell of another cell. Affects styling.
   isDisabled?: boolean; // Indicates if the cell is disabled (e.g., before a computation is complete).
 }
 

--- a/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
@@ -9,6 +9,7 @@ export interface NotebookCellProps<T extends NotebookCellDescriptor> {
   analysisState: AnalysisState;
   cell: T;
   isDisabled?: boolean; // Indicates if the cell is disabled (e.g., before a computation is complete).
+  expandedPanelState?: 'closed' | 'open'; // Indicates if the ExpandabelPanel is expanded in the UI.
 }
 
 /**

--- a/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
@@ -4,12 +4,15 @@ import { TextNotebookCell } from './TextNotebookCell';
 import { VisualizationNotebookCell } from './VisualizationNotebookCell';
 import { ComputeNotebookCell } from './ComputeNotebookCell';
 import { NotebookCellDescriptor } from './NotebookPresets';
+import { WdkParamNotebookCell } from './WdkParamNotebookCell';
+import { WdkState } from './EdaNotebookAnalysis';
 
 export interface NotebookCellProps<T extends NotebookCellDescriptor> {
   analysisState: AnalysisState;
   cell: T;
   isDisabled?: boolean; // Indicates if the cell is disabled (e.g., before a computation is complete).
   expandedPanelState?: 'closed' | 'open'; // Indicates if the ExpandabelPanel is expanded in the UI.
+  wdkState?: WdkState;
 }
 
 /**
@@ -26,6 +29,8 @@ export function NotebookCell(props: NotebookCellProps<NotebookCellDescriptor>) {
       return <VisualizationNotebookCell {...props} cell={cell} />;
     case 'compute':
       return <ComputeNotebookCell {...props} cell={cell} />;
+    case 'wdkparam':
+      return <WdkParamNotebookCell {...props} cell={cell} />;
     default:
       return null;
   }

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -48,6 +48,7 @@ type PresetNotebook = {
   displayName: string;
   projects: string[];
   cells: NotebookCellDescriptor[];
+  header?: string; // Optional header text for the notebook, to be displayed above the cells.
 };
 
 // Preset notebooks
@@ -112,6 +113,8 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
   wgcnaCorrelationNotebook: {
     name: 'wgcnacorrelation',
     displayName: 'WGCNA Correlation Notebook',
+    header:
+      "Use steps 1-3 to find a module of interest, then click 'Get Answer' to retrieve a list of genes.",
     projects: ['MicrobiomeDB'],
     cells: [
       {

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -17,6 +17,7 @@ export interface NotebookCellDescriptorBase<T extends string> {
   type: T;
   title: string;
   cells?: NotebookCellDescriptor[];
+  helperText?: string; // Optional text to display above the cell. Instead of a full text cell, use this for quick help and titles.
 }
 
 export interface VisualizationCellDescriptor
@@ -59,17 +60,14 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
         title: 'Differential Abundance',
         computationName: 'differentialabundance',
         computationId: 'diff_1',
+        helperText:
+          '(1) Configure and run a DESeq2 computation to find differentially expressed genes.',
         cells: [
           {
             type: 'visualization',
             title: 'Volcano Plot',
             visualizationName: 'volcanoplot',
             visualizationId: 'volcano_1',
-          },
-          {
-            type: 'text',
-            title: 'Sub Text Cell',
-            text: 'This is a sub text cell for the differential abundance notebook.',
           },
         ],
       },
@@ -88,26 +86,20 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
     projects: ['MicrobiomeDB'],
     cells: [
       {
-        type: 'text',
-        title: 'Extra help',
-        text: 'Some more text for the WGCNA correlation notebook.',
-      },
-      {
         type: 'compute',
         title: 'WGCNA Correlation',
         computationName: 'correlation',
         computationId: 'correlation_1',
+        helperText:
+          '(1) Configure and run a correlation computation to find a module of interest.',
         cells: [
-          {
-            type: 'text',
-            title: 'Using the network plot',
-            text: 'Network plot explanation... To Do',
-          },
           {
             type: 'visualization',
             title: 'Correlation Plot',
             visualizationName: 'bipartitenetwork',
             visualizationId: 'bipartite_1',
+            helperText:
+              '(2) Visualize the correlation results with the bipartite network. Click on nodes to highlight them in the network.',
           },
         ],
       },

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -1,7 +1,11 @@
 // Notebook presets
 
 import { ReactNode } from 'react';
+import { NumberedHeader } from '../workspace/Subsetting/SubsetDownloadModal';
+import { colors } from '@material-ui/core';
 
+const height = 25;
+const color = 'black';
 // The descriptors contain just enough information to render the cells when given the
 // appropriate context, such as analysis state. In EdaNotebookAnalysis, these
 // descriptors get converted into cells using the ids and such generated in
@@ -17,7 +21,7 @@ export interface NotebookCellDescriptorBase<T extends string> {
   type: T;
   title: string;
   cells?: NotebookCellDescriptor[];
-  helperText?: string; // Optional text to display above the cell. Instead of a full text cell, use this for quick help and titles.
+  helperText?: ReactNode; // Optional information to display above the cell. Instead of a full text cell, use this for quick help and titles.
 }
 
 export interface VisualizationCellDescriptor
@@ -60,8 +64,33 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
         title: 'Differential Abundance',
         computationName: 'differentialabundance',
         computationId: 'diff_1',
-        helperText:
-          '(1) Configure and run a DESeq2 computation to find differentially expressed genes.',
+        helperText: (
+          <>
+            <div
+              style={{
+                display: 'inline-block',
+                width: height + 'px',
+                height: height + 'px',
+                lineHeight: height + 'px',
+                color: color,
+                border: '2px solid' + color,
+                borderRadius: height + 'px',
+                fontSize: 18,
+                fontWeight: 'bold',
+                textAlign: 'center',
+                boxSizing: 'content-box',
+                userSelect: 'none',
+              }}
+            >
+              1
+            </div>
+            <span>
+              {' '}
+              Configure and run a DESeq2 computation to find differentially
+              expressed genes.
+            </span>
+          </>
+        ),
         cells: [
           {
             type: 'visualization',
@@ -90,16 +119,30 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
         title: 'Correlation Computation',
         computationName: 'correlation',
         computationId: 'correlation_1',
-        helperText:
-          '(1) Configure and run a correlation computation between WGCNA module eigengene expression and other features of interest.',
+        helperText: (
+          <NumberedHeader
+            number={1}
+            text={
+              'Configure and run a correlation computation between WGCNA module eigengene expression and other features of interest.'
+            }
+            color={colors.grey[800]}
+          />
+        ),
         cells: [
           {
             type: 'visualization',
             title: 'Network Visualization',
             visualizationName: 'bipartitenetwork',
             visualizationId: 'bipartite_1',
-            helperText:
-              '(2) Visualize the correlation results between the two groups in the network. Click on nodes to highlight them in the network.',
+            helperText: (
+              <NumberedHeader
+                number={2}
+                text={
+                  'Visualize the correlation results between the two groups in the network. Click on nodes to highlight them in the network.'
+                }
+                color={colors.grey[800]}
+              />
+            ),
           },
         ],
       },

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -87,19 +87,19 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
     cells: [
       {
         type: 'compute',
-        title: 'WGCNA Correlation',
+        title: 'Correlation Computation',
         computationName: 'correlation',
         computationId: 'correlation_1',
         helperText:
-          '(1) Configure and run a correlation computation to find a module of interest.',
+          '(1) Configure and run a correlation computation between WGCNA module eigengene expression and other features of interest.',
         cells: [
           {
             type: 'visualization',
-            title: 'Correlation Plot',
+            title: 'Network Visualization',
             visualizationName: 'bipartitenetwork',
             visualizationId: 'bipartite_1',
             helperText:
-              '(2) Visualize the correlation results with the bipartite network. Click on nodes to highlight them in the network.',
+              '(2) Visualize the correlation results between the two groups in the network. Click on nodes to highlight them in the network.',
           },
         ],
       },

--- a/packages/libs/eda/src/lib/notebook/NotebookRoute.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookRoute.tsx
@@ -71,6 +71,7 @@ export default function NotebookRoute(props: Props) {
                 <EdaNotebookAnalysis
                   analysisState={analysisState}
                   notebookType="wgcnaCorrelationNotebook"
+                  wdkState={{}}
                 />
               </EDAWorkspaceContainer>
             )}

--- a/packages/libs/eda/src/lib/notebook/SubsettingNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/SubsettingNotebookCell.tsx
@@ -44,7 +44,7 @@ export function SubsettingNotebookCell(
 
   return (
     <>
-      <div className="notebookCellHelpText">
+      <div className="NotebookCellHelpText">
         <span>{cell.helperText}</span>
       </div>
       <details className={isSubCell ? 'subCell' : ''} open>

--- a/packages/libs/eda/src/lib/notebook/SubsettingNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/SubsettingNotebookCell.tsx
@@ -9,11 +9,12 @@ import FilterChipList from '../core/components/FilterChipList';
 import Subsetting from '../workspace/Subsetting';
 import { NotebookCellProps } from './NotebookCell';
 import { SubsetCellDescriptor } from './NotebookPresets';
+import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/ExpandablePanel';
 
 export function SubsettingNotebookCell(
   props: NotebookCellProps<SubsetCellDescriptor>
 ) {
-  const { analysisState, cell, isSubCell } = props;
+  const { analysisState, cell, isDisabled } = props;
 
   const getDefaultVariableDescriptor = useGetDefaultVariableDescriptor();
   const varAndEnt = getDefaultVariableDescriptor();
@@ -47,35 +48,43 @@ export function SubsettingNotebookCell(
       <div className="NotebookCellHelpText">
         <span>{cell.helperText}</span>
       </div>
-      <details className={isSubCell ? 'subCell' : ''} open>
-        <summary>{cell.title}</summary>
-        <div>
-          <FilterChipList
-            filters={analysisState.analysis?.descriptor.subset.descriptor}
-            entities={entities}
-            selectedEntityId={entityId}
-            selectedVariableId={variableId}
-            removeFilter={(filter) => {
-              analysisState.setFilters((filters) =>
-                filters.filter(
-                  (f) =>
-                    f.entityId !== filter.entityId ||
-                    f.variableId !== filter.variableId
-                )
-              );
-            }}
+      <ExpandablePanel
+        title={cell.title}
+        subTitle={''}
+        state="open"
+        themeRole="primary"
+      >
+        <div
+          className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}
+        >
+          <div>
+            <FilterChipList
+              filters={analysisState.analysis?.descriptor.subset.descriptor}
+              entities={entities}
+              selectedEntityId={entityId}
+              selectedVariableId={variableId}
+              removeFilter={(filter) => {
+                analysisState.setFilters((filters) =>
+                  filters.filter(
+                    (f) =>
+                      f.entityId !== filter.entityId ||
+                      f.variableId !== filter.variableId
+                  )
+                );
+              }}
+              variableLinkConfig={variableLinkConfig}
+            />
+          </div>
+          <Subsetting
+            analysisState={analysisState}
+            entityId={entityId ?? ''}
+            variableId={variableId ?? ''}
+            totalCounts={totalCountsResult.value}
+            filteredCounts={filteredCountsResult.value}
             variableLinkConfig={variableLinkConfig}
           />
         </div>
-        <Subsetting
-          analysisState={analysisState}
-          entityId={entityId ?? ''}
-          variableId={variableId ?? ''}
-          totalCounts={totalCountsResult.value}
-          filteredCounts={filteredCountsResult.value}
-          variableLinkConfig={variableLinkConfig}
-        />
-      </details>
+      </ExpandablePanel>
     </>
   );
 }

--- a/packages/libs/eda/src/lib/notebook/SubsettingNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/SubsettingNotebookCell.tsx
@@ -43,34 +43,39 @@ export function SubsettingNotebookCell(
   );
 
   return (
-    <details className={isSubCell ? 'subCell' : ''} open>
-      <summary>{cell.title}</summary>
-      <div>
-        <FilterChipList
-          filters={analysisState.analysis?.descriptor.subset.descriptor}
-          entities={entities}
-          selectedEntityId={entityId}
-          selectedVariableId={variableId}
-          removeFilter={(filter) => {
-            analysisState.setFilters((filters) =>
-              filters.filter(
-                (f) =>
-                  f.entityId !== filter.entityId ||
-                  f.variableId !== filter.variableId
-              )
-            );
-          }}
+    <>
+      <div className="notebookCellHelpText">
+        <span>{cell.helperText}</span>
+      </div>
+      <details className={isSubCell ? 'subCell' : ''} open>
+        <summary>{cell.title}</summary>
+        <div>
+          <FilterChipList
+            filters={analysisState.analysis?.descriptor.subset.descriptor}
+            entities={entities}
+            selectedEntityId={entityId}
+            selectedVariableId={variableId}
+            removeFilter={(filter) => {
+              analysisState.setFilters((filters) =>
+                filters.filter(
+                  (f) =>
+                    f.entityId !== filter.entityId ||
+                    f.variableId !== filter.variableId
+                )
+              );
+            }}
+            variableLinkConfig={variableLinkConfig}
+          />
+        </div>
+        <Subsetting
+          analysisState={analysisState}
+          entityId={entityId ?? ''}
+          variableId={variableId ?? ''}
+          totalCounts={totalCountsResult.value}
+          filteredCounts={filteredCountsResult.value}
           variableLinkConfig={variableLinkConfig}
         />
-      </div>
-      <Subsetting
-        analysisState={analysisState}
-        entityId={entityId ?? ''}
-        variableId={variableId ?? ''}
-        totalCounts={totalCountsResult.value}
-        filteredCounts={filteredCountsResult.value}
-        variableLinkConfig={variableLinkConfig}
-      />
-    </details>
+      </details>
+    </>
   );
 }

--- a/packages/libs/eda/src/lib/notebook/TextNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/TextNotebookCell.tsx
@@ -1,15 +1,22 @@
+import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/ExpandablePanel';
 import { NotebookCellProps } from './NotebookCell';
 import { TextCellDescriptor } from './NotebookPresets';
 
 export function TextNotebookCell(props: NotebookCellProps<TextCellDescriptor>) {
-  const { cell, isSubCell, isDisabled } = props;
+  const { cell, isDisabled } = props;
 
   const { text, title } = cell;
 
   return (
-    <details className={isSubCell ? 'subCell' : ''} open>
-      <summary>{title}</summary>
-      <div className={isDisabled ? 'disabled' : ''}>{text}</div>
-    </details>
+    <ExpandablePanel
+      title={title}
+      subTitle={''}
+      state="open"
+      themeRole="primary"
+    >
+      <div className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}>
+        {text}
+      </div>
+    </ExpandablePanel>
   );
 }

--- a/packages/libs/eda/src/lib/notebook/Types.ts
+++ b/packages/libs/eda/src/lib/notebook/Types.ts
@@ -51,7 +51,6 @@ export interface NotebookCellComponentProps<T extends NotebookCell['type']> {
   cell: NotebookCellOfType<T>;
   // Allow partial updates, but don't allow `type` to be changed.
   updateCell: (cell: Omit<Partial<NotebookCellOfType<T>>, 'type'>) => void;
-  isSubCell?: boolean; // Indicates if this cell is a sub-cell of another cell. Affects styling.
   isDisabled?: boolean; // Indicates if the cell is disabled (e.g., during loading).
 }
 

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -9,6 +9,7 @@ import { VisualizationCellDescriptor } from './NotebookPresets';
 import { useCachedPromise } from '../core/hooks/cachedPromise';
 import { useComputeJobStatus } from '../core/components/computations/ComputeJobStatusHook';
 import { StatusIcon } from '../core/components/computations/RunComputeButton';
+import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/ExpandablePanel';
 
 export function VisualizationNotebookCell(
   props: NotebookCellProps<VisualizationCellDescriptor>
@@ -91,23 +92,15 @@ export function VisualizationNotebookCell(
       <div className="NotebookCellHelpText">
         <span>{cell.helperText}</span>
       </div>
-      <details className={isSubCell ? 'subCell' : ''} open>
-        <summary>
-          <span
-            style={{
-              display: 'inline-flex',
-              justifyContent: 'space-between',
-              width: '95%', // this is a bit of a hack. Ideally it would be 100% but
-              // then the triangle marker goes on a different line. No obvious easy cleaner way :-(
-            }}
-          >
-            <span>{cell.title}</span>
-            {computeJobStatus && (
-              <StatusIcon status={computeJobStatus} showLabel={false} />
-            )}
-          </span>
-        </summary>
-        <div className={isDisabled ? 'disabled' : ''}>
+      <ExpandablePanel
+        title={cell.title}
+        subTitle={''}
+        state="open"
+        themeRole="primary"
+      >
+        <div
+          className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}
+        >
           {computation && vizPlugin && (
             <vizPlugin.fullscreenComponent
               options={vizPlugin.options}
@@ -130,7 +123,7 @@ export function VisualizationNotebookCell(
             />
           )}
         </div>
-      </details>
+      </ExpandablePanel>
     </>
   ) : (
     <details>

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -14,7 +14,7 @@ import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/Expanda
 export function VisualizationNotebookCell(
   props: NotebookCellProps<VisualizationCellDescriptor>
 ) {
-  const { analysisState, cell, isDisabled } = props;
+  const { analysisState, cell, isDisabled, expandedPanelState } = props;
   const { analysis, updateVisualization } = analysisState;
   if (analysis == null) throw new Error('Cannot find analysis.');
 
@@ -95,7 +95,7 @@ export function VisualizationNotebookCell(
       <ExpandablePanel
         title={cell.title}
         subTitle={''}
-        state="open"
+        state={expandedPanelState ?? 'open'}
         themeRole="primary"
       >
         <div

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -8,7 +8,6 @@ import { NotebookCellProps } from './NotebookCell';
 import { VisualizationCellDescriptor } from './NotebookPresets';
 import { useCachedPromise } from '../core/hooks/cachedPromise';
 import { useComputeJobStatus } from '../core/components/computations/ComputeJobStatusHook';
-import { StatusIcon } from '../core/components/computations/RunComputeButton';
 import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/ExpandablePanel';
 
 export function VisualizationNotebookCell(

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -87,46 +87,51 @@ export function VisualizationNotebookCell(
   }
 
   return visualization ? (
-    <details className={isSubCell ? 'subCell' : ''} open>
-      <summary>
-        <span
-          style={{
-            display: 'inline-flex',
-            justifyContent: 'space-between',
-            width: '95%', // this is a bit of a hack. Ideally it would be 100% but
-            // then the triangle marker goes on a different line. No obvious easy cleaner way :-(
-          }}
-        >
-          <span>{cell.title}</span>
-          {computeJobStatus && (
-            <StatusIcon status={computeJobStatus} showLabel={false} />
-          )}
-        </span>
-      </summary>
-      <div className={isDisabled ? 'disabled' : ''}>
-        {computation && vizPlugin && (
-          <vizPlugin.fullscreenComponent
-            options={vizPlugin.options}
-            dataElementConstraints={constraints}
-            dataElementDependencyOrder={dataElementDependencyOrder}
-            visualization={visualization}
-            computation={computation}
-            copmutationAppOverview={appOverview}
-            filters={analysis.descriptor.subset.descriptor} // issue #1413
-            starredVariables={[]} // to be implemented
-            toggleStarredVariable={() => {}}
-            updateConfiguration={updateConfiguration}
-            totalCounts={totalCountsResult}
-            filteredCounts={filteredCountsResult}
-            geoConfigs={geoConfigs}
-            otherVizOverviews={[]}
-            computeJobStatus={computeJobStatus}
-            hideInputsAndControls={false}
-            plotContainerStyleOverrides={plotContainerStyleOverrides}
-          />
-        )}
+    <>
+      <div className="notebookCellHelpText">
+        <span>{cell.helperText}</span>
       </div>
-    </details>
+      <details className={isSubCell ? 'subCell' : ''} open>
+        <summary>
+          <span
+            style={{
+              display: 'inline-flex',
+              justifyContent: 'space-between',
+              width: '95%', // this is a bit of a hack. Ideally it would be 100% but
+              // then the triangle marker goes on a different line. No obvious easy cleaner way :-(
+            }}
+          >
+            <span>{cell.title}</span>
+            {computeJobStatus && (
+              <StatusIcon status={computeJobStatus} showLabel={false} />
+            )}
+          </span>
+        </summary>
+        <div className={isDisabled ? 'disabled' : ''}>
+          {computation && vizPlugin && (
+            <vizPlugin.fullscreenComponent
+              options={vizPlugin.options}
+              dataElementConstraints={constraints}
+              dataElementDependencyOrder={dataElementDependencyOrder}
+              visualization={visualization}
+              computation={computation}
+              copmutationAppOverview={appOverview}
+              filters={analysis.descriptor.subset.descriptor} // issue #1413
+              starredVariables={[]} // to be implemented
+              toggleStarredVariable={() => {}}
+              updateConfiguration={updateConfiguration}
+              totalCounts={totalCountsResult}
+              filteredCounts={filteredCountsResult}
+              geoConfigs={geoConfigs}
+              otherVizOverviews={[]}
+              computeJobStatus={computeJobStatus}
+              hideInputsAndControls={false}
+              plotContainerStyleOverrides={plotContainerStyleOverrides}
+            />
+          )}
+        </div>
+      </details>
+    </>
   ) : (
     <details>
       <summary>Loading</summary>

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -88,7 +88,7 @@ export function VisualizationNotebookCell(
 
   return visualization ? (
     <>
-      <div className="notebookCellHelpText">
+      <div className="NotebookCellHelpText">
         <span>{cell.helperText}</span>
       </div>
       <details className={isSubCell ? 'subCell' : ''} open>

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -14,7 +14,7 @@ import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/Expanda
 export function VisualizationNotebookCell(
   props: NotebookCellProps<VisualizationCellDescriptor>
 ) {
-  const { analysisState, cell, isSubCell, isDisabled } = props;
+  const { analysisState, cell, isDisabled } = props;
   const { analysis, updateVisualization } = analysisState;
   if (analysis == null) throw new Error('Cannot find analysis.');
 

--- a/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
@@ -1,0 +1,103 @@
+import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/ExpandablePanel';
+import { NotebookCellProps } from './NotebookCell';
+import { WdkParamCellDescriptor } from './NotebookPresets';
+import { SingleSelect } from '@veupathdb/coreui';
+import { Item } from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxList';
+import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
+import { NumberOrDate } from '@veupathdb/components/lib/types/general';
+
+export function WdkParamNotebookCell(
+  props: NotebookCellProps<WdkParamCellDescriptor>
+) {
+  const { cell, isDisabled, wdkState = {} } = props;
+
+  const { paramNames, title } = cell;
+  const { parameters, paramValues, updateParamValue } = wdkState;
+
+  // userInputParameters are the wdk parameters that the user will
+  // fill out in the search. For example, in wgcna the user needs to select a module,
+  // but doesn't need to select the hidden param for this search called "dataset".
+
+  const userInputParameters = parameters?.filter((param) =>
+    paramNames?.includes(param.name)
+  );
+
+  return (
+    <>
+      <div className="NotebookCellHelpText">
+        <span>{cell.helperText}</span>
+      </div>
+      <ExpandablePanel
+        title={title}
+        subTitle={''}
+        state="open"
+        themeRole="primary"
+      >
+        <div
+          className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}
+        >
+          <div className="WdkParamInputs">
+            {userInputParameters &&
+              paramNames &&
+              paramValues &&
+              userInputParameters.map((param) => {
+                const paramCurrentValue = paramValues[param.name];
+
+                // There are many param types. The following is not exhaustive.
+                if (param.type === 'single-pick-vocabulary') {
+                  const selectItems: Item<string>[] = Array.isArray(
+                    param.vocabulary
+                  )
+                    ? param.vocabulary.map((item: [string, string, null]) => ({
+                        value: item[0],
+                        display: item[1],
+                      }))
+                    : [];
+
+                  const buttonDisplayContent = selectItems.find(
+                    ({ value }) => value === paramCurrentValue
+                  )?.display;
+
+                  return (
+                    <div className="InputGroup">
+                      <span>{param.displayName}</span>
+                      <SingleSelect
+                        items={selectItems}
+                        value={paramCurrentValue}
+                        buttonDisplayContent={buttonDisplayContent}
+                        onSelect={(newValue: string) =>
+                          updateParamValue?.(param, newValue)
+                        }
+                      />
+                    </div>
+                  );
+                } else if (param.type === 'string' && param.isNumber) {
+                  return (
+                    <div className="InputGroup">
+                      <span>{param.displayName}</span>
+                      <NumberInput
+                        value={Number(paramCurrentValue)}
+                        minValue={0} // TO DO: Currently not derived from the parameter, though they should be.
+                        maxValue={1}
+                        step={0.01}
+                        onValueChange={(newValue?: NumberOrDate) =>
+                          newValue != null &&
+                          updateParamValue?.(param, newValue.toString())
+                        }
+                      />
+                    </div>
+                  );
+                } else {
+                  return (
+                    <div key={param.name}>
+                      <strong>{param.name}</strong>
+                    </div>
+                  );
+                }
+              })}
+          </div>
+        </div>
+      </ExpandablePanel>
+    </>
+  );
+}

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
@@ -57,6 +57,7 @@ export type Props = {
   onSubmit?: (e: React.FormEvent) => boolean | void;
   resetFormConfig: ResetFormConfig;
   containerClassName?: string;
+  searchName?: string;
 };
 
 const cx = makeClassNameHelper('wdk-QuestionForm');

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
@@ -1,0 +1,48 @@
+import DefaultQuestionForm, {
+  Props,
+} from '@veupathdb/wdk-client/lib/Views/Question/DefaultQuestionForm';
+import React, { useCallback } from 'react';
+import { EdaNotebookParameter } from './EdaNotebookParameter';
+import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import { WdkState } from '@veupathdb/eda/lib/notebook/EdaNotebookAnalysis';
+
+export const EdaNotebookQuestionForm = (props: Props) => {
+  const { searchName } = props;
+  if (!searchName) {
+    throw new Error('No search defined.');
+  }
+
+  // We'll use this function throughout the notebook to update any wdk parameters.
+  const updateParamValue = useCallback(
+    (parameter: Parameter, newParamValue: string) => {
+      props.eventHandlers.updateParamValue({
+        searchName,
+        parameter,
+        paramValues: {}, // deprecated
+        paramValue: newParamValue,
+      });
+    },
+    [props.eventHandlers, searchName]
+  );
+
+  const wdkState: WdkState = {
+    parameters: props.state.question.parameters,
+    paramValues: props.state.paramValues,
+    updateParamValue,
+  };
+
+  // An override that renders the notebook instead of any default parameter or parameter group ui.
+  // NOTE: this function is run for every visible parameter group. May cause
+  // an issue if the wdk question has multipl parameter groups.
+  const renderParamGroup = () => {
+    return <EdaNotebookParameter value={'test'} wdkState={wdkState} />;
+  };
+
+  return (
+    <DefaultQuestionForm
+      {...props}
+      renderParamGroup={renderParamGroup}
+      resetFormConfig={{ offered: false }}
+    />
+  );
+};

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/pluginConfig.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/pluginConfig.tsx
@@ -44,10 +44,7 @@ import {
   EdaSubsetStepDetails,
 } from './components/questions/EdaSubsetParameter';
 import { GenesByEdaSubset } from './components/questions/GenesByEdaSubset';
-import {
-  EdaNotebookParameter,
-  EdaNotebookStepDetails,
-} from './components/questions/EdaNotebookParameter';
+import { EdaNotebookQuestionForm } from './components/questions/EdaNotebookQuestionForm';
 
 const BlastForm = React.lazy(() => import('./plugins/BlastForm'));
 const BlastQuestionController = React.lazy(
@@ -196,16 +193,6 @@ const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [
     component: GenesByBindingSiteFeature,
   },
   {
-    type: 'questionFormParameter',
-    name: 'wgcnaParam',
-    component: EdaNotebookParameter,
-  },
-  {
-    type: 'questionFormParameter',
-    test: ({ question }) => question?.queryName === 'GenesByWGCNAModule',
-    component: GenesByWGCNAModules,
-  },
-  {
     type: 'questionForm',
     name: 'DynSpansBySourceId',
     component: DynSpansBySourceId,
@@ -275,9 +262,9 @@ const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [
     component: EdaSubsetStepDetails,
   },
   {
-    type: 'stepDetails',
+    type: 'questionForm',
     test: ({ question }) => question?.queryName === 'GenesByWGCNAModule',
-    component: EdaNotebookStepDetails,
+    component: EdaNotebookQuestionForm,
   },
 ];
 


### PR DESCRIPTION
Resolves #1416 


- [x] Remove indentation
- [x] Add "helper text" to cell. This is where we'll have the "(1) Do something" that just lives above the cell.
- [x] Remove Analysis name. Users dont need to set a name.
- [x] Remove numbers from compute steps
- [x] Change `details` to `ExpandablePanel`

This PR adds a few new props to components used in regular eda, so worth checking that still works just fine :) Specifically, ensure the mbio compute page looks normal. (I checked and it looks fine)

I tried out having the disabled cells closed by default. Then they open when they're ready. We'll see if folks like this.

I didn't remove the text cell. I think it can stay and just serve the new purpose of having extended help inside. I'm considering moving that correlation help into a text cell. Or possibly the bipartite network might want a bunch of help in a text cell... we'll see.