### PR TITLE
Wgnca notebook improvements 1381

### DIFF
--- a/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
@@ -13,9 +13,14 @@
 
     width: calc(var(--paper-width) * var(--paper-scale));
     margin: 1em auto;
+    padding: 0 1em;
 
     > * + * {
       margin-block-start: 1rem;
+    }
+
+    > H5 {
+      padding-bottom: 0.5em;
     }
 
     .Heading {

--- a/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebook.scss
@@ -68,6 +68,22 @@
     .NotebookCellHelpText:first-of-type {
       margin-top: 2em;
     }
+
+    .WdkParamInputs {
+      display: flex;
+      flex-direction: column;
+      gap: 2em;
+      margin-top: 1em;
+      margin-bottom: 1em;
+    }
+
+    .InputGroup {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 1em;
+      font-weight: 500;
+    }
     > details {
       border: 1px solid;
       border-color: color-mix(

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -7,8 +7,8 @@ import { createComputation } from '../core/components/computations/Utils';
 import { presetNotebooks, NotebookCellDescriptor } from './NotebookPresets';
 import { Computation } from '../core/types/visualization';
 import { plugins } from '../core/components/computations/plugins';
-import CoreUIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
-import { colors, H5 } from '@veupathdb/coreui';
+import { H5 } from '@veupathdb/coreui';
+import colors from '@veupathdb/coreui/lib/definitions/colors';
 
 // const NOTEBOOK_UI_SETTINGS_KEY = '@@NOTEBOOK@@';
 
@@ -96,31 +96,23 @@ export function EdaNotebookAnalysis(props: Props) {
   // `notebookState` coming from analysisState.analysis.descriptor.subset.uiSettings[NOTEBOOK_UI_SETTINGS_KEY]
   //
   return (
-    // The CoreUIThemeProvider should be moved elsewhere. Should go in the genomics form override.
-    <CoreUIThemeProvider
-      theme={{
-        palette: {
-          primary: { hue: colors.cyan, level: 600 },
-          secondary: { hue: colors.mutedRed, level: 500 },
-        },
-      }}
-    >
-      <div className="EdaNotebook">
-        <div className="Paper">
-          {notebookPreset.header && <H5 text={notebookPreset.header} />}
-          {analysis.descriptor.computations.length > 0 ? (
-            notebookPreset.cells.map((cell, index) => (
-              <NotebookCell
-                key={index}
-                analysisState={analysisState}
-                cell={cell}
-              />
-            ))
-          ) : (
-            <Loading />
-          )}
-        </div>
+    <div className="EdaNotebook">
+      <div className="Paper">
+        {notebookPreset.header && (
+          <H5 text={notebookPreset.header} color={colors.gray[600]} />
+        )}
+        {analysis.descriptor.computations.length > 0 ? (
+          notebookPreset.cells.map((cell, index) => (
+            <NotebookCell
+              key={index}
+              analysisState={analysisState}
+              cell={cell}
+            />
+          ))
+        ) : (
+          <Loading />
+        )}
       </div>
-    </CoreUIThemeProvider>
+    </div>
   );
 }

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -21,6 +21,11 @@ interface Props {
   analysisState: AnalysisState;
   notebookType: string;
   parameters?: Parameter[]; // Array of parameters from the wdk. Notebook preset will have a list of param names to match.
+  wdkUpdateParamValue?: (
+    parameter: Parameter,
+    newParamValue: string,
+    paramValues: Record<string, string>
+  ) => void;
 }
 
 export function EdaNotebookAnalysis(props: Props) {
@@ -119,9 +124,11 @@ export function EdaNotebookAnalysis(props: Props) {
 
     // Update the notebook cell with the filtered parameters
     wdkParamNotebookCell.wdkParameters = wdkParameters;
+    wdkParamNotebookCell.wdkUpdateParamValue = props.wdkUpdateParamValue;
+
     notebookPreset.cells[notebookPreset.cells.indexOf(wdkParamNotebookCell)] =
       wdkParamNotebookCell;
-  }, [analysis, notebookPreset, props.parameters]);
+  }, [analysis, notebookPreset, props.parameters, props.wdkUpdateParamValue]);
 
   //
   // Now we render the notebook directly from the read-only `notebookPreset`,

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -98,32 +98,26 @@ export function EdaNotebookAnalysis(props: Props) {
   }, [analysis, setComputations, addVisualization, notebookPreset]);
 
   // If the notebook preset has any wdk parameter cells, we need to
-  // check to ensure we have matching parameters from the notebook and wdk.
+  // check to ensure we have matching parameters from the notebook and wdk then
+  // add these parameters to the notebook cell.
   useEffect(() => {
-    if (analysis == null || notebookPreset == null) return;
+    if (
+      analysis == null ||
+      notebookPreset == null ||
+      props.parameters == null ||
+      props.wdkUpdateParamValue == null
+    )
+      return;
 
-    // Extract the wdk parameter notebook cell.
+    // Extract the wdk parameter notebook cell. There should only be one.
     const wdkParamNotebookCell = notebookPreset.cells.find(
       (cell) => cell.type === 'wdkparam'
     ) as WdkParamCellDescriptor;
 
-    if (wdkParamNotebookCell == null || props.parameters == null) return;
-
-    // Filter the wdk parameters to include only those listed in the notebook cell
-    const wdkParameters = props.parameters.filter((param) =>
-      wdkParamNotebookCell.paramNames.includes(param.name)
-    );
-
-    if (wdkParameters.length < wdkParamNotebookCell.paramNames.length) {
-      throw new Error(
-        `Not all WDK parameters specified in the notebook preset (${wdkParamNotebookCell.paramNames.join(
-          ', '
-        )}) were found in the provided parameters.`
-      );
-    }
+    if (wdkParamNotebookCell == null) return;
 
     // Update the notebook cell with the filtered parameters
-    wdkParamNotebookCell.wdkParameters = wdkParameters;
+    wdkParamNotebookCell.wdkParameters = props.parameters;
     wdkParamNotebookCell.wdkUpdateParamValue = props.wdkUpdateParamValue;
 
     notebookPreset.cells[notebookPreset.cells.indexOf(wdkParamNotebookCell)] =

--- a/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
@@ -4,6 +4,7 @@ import { TextNotebookCell } from './TextNotebookCell';
 import { VisualizationNotebookCell } from './VisualizationNotebookCell';
 import { ComputeNotebookCell } from './ComputeNotebookCell';
 import { NotebookCellDescriptor } from './NotebookPresets';
+import { WdkParamNotebookCell } from './WdkParamNotebookCell';
 
 export interface NotebookCellProps<T extends NotebookCellDescriptor> {
   analysisState: AnalysisState;
@@ -26,6 +27,8 @@ export function NotebookCell(props: NotebookCellProps<NotebookCellDescriptor>) {
       return <VisualizationNotebookCell {...props} cell={cell} />;
     case 'compute':
       return <ComputeNotebookCell {...props} cell={cell} />;
+    case 'wdkparam':
+      return <WdkParamNotebookCell {...props} cell={cell} />;
     default:
       return null;
   }

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -168,6 +168,13 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
         cellId: 'wdkparam_1',
         title: 'Finalize search parameters',
         paramNames: ['wgcnaParam', 'wgcna_correlation_cutoff'],
+        helperText: (
+          <NumberedHeader
+            number={3}
+            text={'Refine parameters for returning the list of genes.'}
+            color={colors.grey[800]}
+          />
+        ),
       },
     ],
   },

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -50,6 +50,11 @@ export interface WdkParamCellDescriptor
   extends NotebookCellDescriptorBase<'wdkparam'> {
   paramNames: string[]; // Param names from the wdk query. These must match exactly or the notebook will err.
   wdkParameters?: Parameter[]; // The parameters, including all their details, from the wdk query.
+  wdkUpdateParamValue?: (
+    parameter: Parameter,
+    newParamValue: string,
+    paramValues: Record<string, string>
+  ) => void; // Function to update the parameter value in the WDK search.
 }
 
 type PresetNotebook = {

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from 'react';
 import { NumberedHeader } from '../workspace/Subsetting/SubsetDownloadModal';
 import { colors } from '@material-ui/core';
+import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 
 const height = 25;
 const color = 'black';
@@ -15,11 +16,13 @@ export type NotebookCellDescriptor =
   | VisualizationCellDescriptor
   | ComputeCellDescriptor
   | TextCellDescriptor
-  | SubsetCellDescriptor;
+  | SubsetCellDescriptor
+  | WdkParamCellDescriptor;
 
 export interface NotebookCellDescriptorBase<T extends string> {
   type: T;
   title: string;
+  cellId: string; // Unique identifier for the cell, used for referencing one cell from another.
   cells?: NotebookCellDescriptor[];
   helperText?: ReactNode; // Optional information to display above the cell. Instead of a full text cell, use this for quick help and titles.
 }
@@ -43,6 +46,12 @@ export interface TextCellDescriptor extends NotebookCellDescriptorBase<'text'> {
 export interface SubsetCellDescriptor
   extends NotebookCellDescriptorBase<'subset'> {}
 
+export interface WdkParamCellDescriptor
+  extends NotebookCellDescriptorBase<'wdkparam'> {
+  paramNames: string[]; // Param names from the wdk query. These must match exactly or the notebook will err.
+  wdkParameters?: Parameter[]; // The parameters, including all their details, from the wdk query.
+}
+
 type PresetNotebook = {
   name: string;
   displayName: string;
@@ -62,6 +71,7 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
     cells: [
       {
         type: 'compute',
+        cellId: 'diff_1',
         title: 'Differential Abundance',
         computationName: 'differentialabundance',
         computationId: 'diff_1',
@@ -98,12 +108,14 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
             title: 'Volcano Plot',
             visualizationName: 'volcanoplot',
             visualizationId: 'volcano_1',
+            cellId: 'volcano_1',
           },
         ],
       },
       {
         type: 'text',
         title: 'Text Cell',
+        cellId: 'text_1',
         text: 'This is a text cell for the differential abundance notebook.',
       },
     ],
@@ -119,6 +131,7 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
     cells: [
       {
         type: 'compute',
+        cellId: 'correlation_1',
         title: 'Correlation Computation',
         computationName: 'correlation',
         computationId: 'correlation_1',
@@ -135,6 +148,7 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
           {
             type: 'visualization',
             title: 'Network Visualization',
+            cellId: 'bipartite_1',
             visualizationName: 'bipartitenetwork',
             visualizationId: 'bipartite_1',
             helperText: (
@@ -149,6 +163,12 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
           },
         ],
       },
+      {
+        type: 'wdkparam',
+        cellId: 'wdkparam_1',
+        title: 'Finalize search parameters',
+        paramNames: ['wgcnaParam', 'wgcna_correlation_cutoff'],
+      },
     ],
   },
   boxplotNotebook: {
@@ -158,6 +178,7 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
     cells: [
       {
         type: 'visualization',
+        cellId: 'boxplot_1',
         title: 'Boxplot Visualization',
         visualizationName: 'boxplot',
         visualizationId: 'boxplot_1',

--- a/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
@@ -1,0 +1,26 @@
+import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/ExpandablePanel';
+import { NotebookCellProps } from './NotebookCell';
+import { WdkParamCellDescriptor } from './NotebookPresets';
+
+export function WdkParamNotebookCell(
+  props: NotebookCellProps<WdkParamCellDescriptor>
+) {
+  const { cell, isDisabled } = props;
+
+  const { paramNames, title, wdkParameters } = cell;
+
+  console.log(wdkParameters);
+
+  return (
+    <ExpandablePanel
+      title={title}
+      subTitle={''}
+      state="open"
+      themeRole="primary"
+    >
+      <div className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}>
+        {paramNames.concat(', ')}
+      </div>
+    </ExpandablePanel>
+  );
+}

--- a/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
@@ -20,6 +20,12 @@ export function WdkParamNotebookCell(
 
   const { paramNames, title, wdkParameters, wdkUpdateParamValue } = cell;
 
+  const userInputParameters = wdkParameters?.filter((param) =>
+    paramNames?.includes(param.name)
+  );
+
+  console.log(wdkParameters);
+
   useEffect(() => {
     const uiSettings: DynamicObject = (analysisState.analysis?.descriptor.subset
       .uiSettings[uiStateKey] ?? {}) as DynamicObject;
@@ -41,6 +47,8 @@ export function WdkParamNotebookCell(
     }));
   }, [wdkParameters, analysisState]);
 
+  console.log(analysisState.analysis?.descriptor.subset.uiSettings);
+
   return (
     <>
       <div className="NotebookCellHelpText">
@@ -56,8 +64,9 @@ export function WdkParamNotebookCell(
           className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}
         >
           <div className="WdkParamInputs">
-            {wdkParameters &&
-              wdkParameters.map((param) => {
+            {userInputParameters &&
+              paramNames &&
+              userInputParameters.map((param) => {
                 const paramCurrentValue =
                   analysisState.analysis?.descriptor.subset.uiSettings[
                     uiStateKey
@@ -79,6 +88,7 @@ export function WdkParamNotebookCell(
                       <SingleSelect
                         items={selectItems}
                         value={paramCurrentValue as string}
+                        buttonDisplayContent={paramCurrentValue as string}
                         onSelect={(value: string) => {
                           if (wdkUpdateParamValue) {
                             const uiSettingsAsRecord: Record<string, string> =
@@ -89,6 +99,7 @@ export function WdkParamNotebookCell(
                                 acc[key] = value?.toString() ?? ''; // Convert value to string or use an empty string if undefined
                                 return acc;
                               }, {} as Record<string, string>);
+
                             wdkUpdateParamValue(
                               param,
                               value,
@@ -105,7 +116,6 @@ export function WdkParamNotebookCell(
                             })
                           );
                         }}
-                        buttonDisplayContent={'Select an option'}
                       />
                     </div>
                   );

--- a/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
@@ -1,6 +1,10 @@
 import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/ExpandablePanel';
 import { NotebookCellProps } from './NotebookCell';
 import { WdkParamCellDescriptor } from './NotebookPresets';
+import { SingleSelect } from '@veupathdb/coreui';
+import { Item } from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxList';
+import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
+import { NumberOrDate } from '@veupathdb/components/lib/types/general';
 
 export function WdkParamNotebookCell(
   props: NotebookCellProps<WdkParamCellDescriptor>
@@ -12,15 +16,74 @@ export function WdkParamNotebookCell(
   console.log(wdkParameters);
 
   return (
-    <ExpandablePanel
-      title={title}
-      subTitle={''}
-      state="open"
-      themeRole="primary"
-    >
-      <div className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}>
-        {paramNames.concat(', ')}
+    <>
+      <div className="NotebookCellHelpText">
+        <span>{cell.helperText}</span>
       </div>
-    </ExpandablePanel>
+      <ExpandablePanel
+        title={title}
+        subTitle={''}
+        state="open"
+        themeRole="primary"
+      >
+        <div
+          className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}
+        >
+          <div className="WdkParamInputs">
+            {wdkParameters &&
+              wdkParameters.map((param) => {
+                if (param.type === 'single-pick-vocabulary') {
+                  const selectItems: Item<string>[] = Array.isArray(
+                    param.vocabulary
+                  )
+                    ? param.vocabulary.map((item: [string, string, null]) => ({
+                        value: item[0],
+                        display: item[1],
+                      }))
+                    : [];
+
+                  return (
+                    <div className="InputGroup">
+                      <span>{param.displayName}</span>
+                      <SingleSelect
+                        items={selectItems}
+                        value={'a'}
+                        onSelect={(value: string) => {
+                          console.log(`Selected value: ${value}`);
+                        }}
+                        buttonDisplayContent={'Select an option'}
+                      />
+                    </div>
+                  );
+                } else if (param.type === 'string') {
+                  // HACK - this is temporary until wgcna correlation cutoff is renamed a "number"
+                  return (
+                    <div className="InputGroup">
+                      <span>{param.displayName}</span>
+                      <NumberInput
+                        value={0.75}
+                        minValue={0}
+                        maxValue={1}
+                        step={0.01}
+                        onValueChange={(newValue?: NumberOrDate) => {
+                          if (newValue !== undefined) {
+                            console.log(`Selected value: ${newValue}`);
+                          }
+                        }}
+                      />
+                    </div>
+                  );
+                } else {
+                  return (
+                    <div key={param.name}>
+                      <strong>{param.name}</strong>
+                    </div>
+                  );
+                }
+              })}
+          </div>
+        </div>
+      </ExpandablePanel>
+    </>
   );
 }

--- a/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
+++ b/packages/libs/wdk-client/src/Views/Question/DefaultQuestionForm.tsx
@@ -57,6 +57,7 @@ export type Props = {
   onSubmit?: (e: React.FormEvent) => boolean | void;
   resetFormConfig: ResetFormConfig;
   containerClassName?: string;
+  searchName?: string;
 };
 
 const cx = makeClassNameHelper('wdk-QuestionForm');

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -40,6 +40,7 @@ type EdaNotebookParameterProps = {
   value: string;
   datasetIdParamName?: string;
   notebookTypeParamName?: string;
+  parameters?: Parameter[]; // Array of parameters from the wdk. Notebook preset will have a list of param names to match.
 };
 
 export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
@@ -48,6 +49,7 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
     value,
     datasetIdParamName,
     notebookTypeParamName,
+    parameters = [],
   } = props;
 
   // TEMPORARY: We don't have this value coming from the wdk yet.
@@ -114,6 +116,7 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
             <EdaNotebookAdapter
               analysisState={analysisState}
               notebookType={notebookType}
+              parameters={parameters}
             />
           </CoreUIThemeProvider>
         </WorkspaceContainer>
@@ -125,6 +128,7 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
 interface EdaNotebookAdapterProps {
   analysisState: AnalysisState;
   notebookType: string;
+  parameters?: Parameter[];
 }
 
 function EdaNotebookAdapter(props: EdaNotebookAdapterProps) {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -21,7 +21,8 @@ import {
 } from '@veupathdb/eda/lib/core';
 import { edaServiceUrl } from '@veupathdb/web-common/lib/config';
 import { DocumentationContainer } from '@veupathdb/eda/lib/core/components/docs/DocumentationContainer';
-
+import CoreUIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
+import colors from '@veupathdb/coreui/lib/definitions/colors';
 import './EdaSubsetParameter.scss';
 import {
   defaultFormatParameterValue,
@@ -32,19 +33,26 @@ import { formatFilterDisplayValue } from '@veupathdb/eda/lib/core/utils/study-me
 import { DatasetItem } from '@veupathdb/wdk-client/lib/Views/Question/Params/DatasetParamUtils';
 import { parseJson } from '@veupathdb/eda/lib/notebook/Utils';
 import { EdaNotebookAnalysis } from '@veupathdb/eda/lib/notebook/EdaNotebookAnalysis';
-import ParameterComponent from '@veupathdb/wdk-client/lib/Views/Question/ParameterComponent';
 import { debounce } from 'lodash';
 
-const datasetIdParamName = 'eda_dataset_id';
-const notebookTypeParamName = 'eda_notebook_type';
+type EdaNotebookParameterProps = {
+  onParamValueChange?: (value: string) => void;
+  value: string;
+  datasetIdParamName?: string;
+  notebookTypeParamName?: string;
+};
 
-export function EdaNotebookParameter(props: Props<StringParam>) {
-  const { onParamValueChange, value, ctx } = props;
+export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
+  const {
+    onParamValueChange,
+    value,
+    datasetIdParamName,
+    notebookTypeParamName,
+  } = props;
 
   // TEMPORARY: We don't have this value coming from the wdk yet.
-  const studyId = ctx.paramValues[datasetIdParamName] ?? 'DS_82dc5abc7f';
-  const notebookType =
-    ctx.paramValues[notebookTypeParamName] ?? 'wgcnaCorrelationNotebook';
+  const studyId = datasetIdParamName ?? 'DS_82dc5abc7f';
+  const notebookType = notebookTypeParamName ?? 'wgcnaCorrelationNotebook';
 
   // we need to maintain the analysis as regular "live" React state somewhere
   const [analysis, setAnalysis] = useState<NewAnalysis | Analysis | undefined>(
@@ -95,13 +103,21 @@ export function EdaNotebookParameter(props: Props<StringParam>) {
     <>
       <DocumentationContainer>
         <WorkspaceContainer studyId={studyId} edaServiceUrl={edaServiceUrl}>
-          <EdaNotebookAdapter
-            analysisState={analysisState}
-            notebookType={notebookType}
-          />
+          <CoreUIThemeProvider
+            theme={{
+              palette: {
+                primary: { hue: colors.cyan, level: 600 },
+                secondary: { hue: colors.mutedRed, level: 500 },
+              },
+            }}
+          >
+            <EdaNotebookAdapter
+              analysisState={analysisState}
+              notebookType={notebookType}
+            />
+          </CoreUIThemeProvider>
         </WorkspaceContainer>
       </DocumentationContainer>
-      <ParameterComponent {...props} />
     </>
   );
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -41,6 +41,11 @@ type EdaNotebookParameterProps = {
   datasetIdParamName?: string;
   notebookTypeParamName?: string;
   parameters?: Parameter[]; // Array of parameters from the wdk. Notebook preset will have a list of param names to match.
+  wdkUpdateParamValue?: (
+    parameter: Parameter,
+    newParamValue: string,
+    paramValues: Record<string, string>
+  ) => void;
 };
 
 export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
@@ -50,6 +55,7 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
     datasetIdParamName,
     notebookTypeParamName,
     parameters = [],
+    wdkUpdateParamValue,
   } = props;
 
   // TEMPORARY: We don't have this value coming from the wdk yet.
@@ -117,6 +123,7 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
               analysisState={analysisState}
               notebookType={notebookType}
               parameters={parameters}
+              wdkUpdateParamValue={wdkUpdateParamValue}
             />
           </CoreUIThemeProvider>
         </WorkspaceContainer>
@@ -129,6 +136,11 @@ interface EdaNotebookAdapterProps {
   analysisState: AnalysisState;
   notebookType: string;
   parameters?: Parameter[];
+  wdkUpdateParamValue?: (
+    parameter: Parameter,
+    newParamValue: string,
+    paramValues: Record<string, string>
+  ) => void;
 }
 
 function EdaNotebookAdapter(props: EdaNotebookAdapterProps) {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
@@ -1,0 +1,18 @@
+import DefaultQuestionForm, {
+  Props,
+} from '@veupathdb/wdk-client/lib/Views/Question/DefaultQuestionForm';
+import React from 'react';
+import { EdaNotebookParameter } from './EdaNotebookParameter';
+import { ParameterGroup } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+
+export const EdaNotebookQuestionForm = (props: Props) => {
+  console.log('EdaNotebookQuestionForm props:', props);
+
+  // question params are in props.state.question.paramNames
+
+  const renderParamGroup = (group: ParameterGroup, formProps: Props) => {
+    return <EdaNotebookParameter value={'test'} />;
+  };
+
+  return <DefaultQuestionForm {...props} renderParamGroup={renderParamGroup} />;
+};

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
@@ -6,13 +6,22 @@ import { EdaNotebookParameter } from './EdaNotebookParameter';
 import { ParameterGroup } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 
 export const EdaNotebookQuestionForm = (props: Props) => {
-  console.log('EdaNotebookQuestionForm props:', props);
-
-  // question params are in props.state.question.paramNames
+  // value will be the serialized analysis object
 
   const renderParamGroup = (group: ParameterGroup, formProps: Props) => {
-    return <EdaNotebookParameter value={'test'} />;
+    return (
+      <EdaNotebookParameter
+        value={'test'}
+        parameters={props.state.question.parameters}
+      />
+    );
   };
 
-  return <DefaultQuestionForm {...props} renderParamGroup={renderParamGroup} />;
+  return (
+    <DefaultQuestionForm
+      {...props}
+      renderParamGroup={renderParamGroup}
+      resetFormConfig={{ offered: false }}
+    />
+  );
 };

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
@@ -3,16 +3,37 @@ import DefaultQuestionForm, {
 } from '@veupathdb/wdk-client/lib/Views/Question/DefaultQuestionForm';
 import React from 'react';
 import { EdaNotebookParameter } from './EdaNotebookParameter';
-import { ParameterGroup } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import {
+  ParameterGroup,
+  Parameter,
+  ParameterValues,
+} from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 
 export const EdaNotebookQuestionForm = (props: Props) => {
   // value will be the serialized analysis object
+
+  const { searchName } = props;
+  if (!searchName) {
+    throw new Error('No search defined.');
+  }
 
   const renderParamGroup = (group: ParameterGroup, formProps: Props) => {
     return (
       <EdaNotebookParameter
         value={'test'}
         parameters={props.state.question.parameters}
+        wdkUpdateParamValue={(
+          parameter: Parameter,
+          newParamValue: string,
+          paramValues: ParameterValues
+        ) => {
+          props.eventHandlers.updateParamValue({
+            searchName,
+            parameter,
+            paramValues,
+            paramValue: newParamValue,
+          });
+        }}
       />
     );
   };

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/pluginConfig.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/pluginConfig.tsx
@@ -48,6 +48,7 @@ import {
   EdaNotebookParameter,
   EdaNotebookStepDetails,
 } from './components/questions/EdaNotebookParameter';
+import { EdaNotebookQuestionForm } from './components/questions/EdaNotebookQuestionForm';
 
 const BlastForm = React.lazy(() => import('./plugins/BlastForm'));
 const BlastQuestionController = React.lazy(
@@ -195,16 +196,16 @@ const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [
     searchName: 'GenesByBindingSiteFeature',
     component: GenesByBindingSiteFeature,
   },
-  {
-    type: 'questionFormParameter',
-    name: 'wgcnaParam',
-    component: EdaNotebookParameter,
-  },
-  {
-    type: 'questionFormParameter',
-    test: ({ question }) => question?.queryName === 'GenesByWGCNAModule',
-    component: GenesByWGCNAModules,
-  },
+  // {
+  //   type: 'questionFormParameter',
+  //   name: 'wgcnaParam',
+  //   component: EdaNotebookParameter,
+  // },
+  // {
+  //   type: 'questionFormParameter',
+  //   test: ({ question }) => question?.queryName === 'GenesByWGCNAModule',
+  //   component: GenesByWGCNAModules,
+  // },
   {
     type: 'questionForm',
     name: 'DynSpansBySourceId',
@@ -274,10 +275,15 @@ const apiPluginConfig: ClientPluginRegistryEntry<any>[] = [
     test: isPhenotypeSubsetSearch,
     component: EdaSubsetStepDetails,
   },
+  // {
+  //   type: 'stepDetails',
+  //   test: ({ question }) => question?.queryName === 'GenesByWGCNAModule',
+  //   component: EdaNotebookStepDetails,
+  // },
   {
-    type: 'stepDetails',
+    type: 'questionForm',
     test: ({ question }) => question?.queryName === 'GenesByWGCNAModule',
-    component: EdaNotebookStepDetails,
+    component: EdaNotebookQuestionForm,
   },
 ];
 


### PR DESCRIPTION
Resolves #1381 

This PR adds functionality for the wgcna notebook. Specifically the goals are to
1. Add wdk parameter cell that renders inputs based on a specified list of parameters
2. Update the appropriate states/redux magic so that when a user hits "Get Answer", their param inputs are sent to the wdk.
3. Add interaction between network and param cell.


Some notes:
- At this time 06/30, parts 1 and 2 are functional. There's an issue with the organism, but I'm hoping it'll become more clear as I continue to poke around. I think organism is a hidden parameter for this search, so I'm having trouble finding it and finding where it's supposed to go.
- This PR does NOT address how the analysis object gets stored or how any new parameters are read in. I don't think we have the new eda notebook parameters in the model yet.


Testing:
- qa plasmo
- navigate to `a/app/search/transcript/GenesByRNASeqEvidence#GenesByRNASeqpfal3D7_Lee_Gambian_ebi_rnaSeq_RSRCWGCNAModules`