### PR TITLE
EDA-in-WDK notebook wdk param handling refactor

### DIFF
--- a/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/ComputeNotebookCell.tsx
@@ -12,7 +12,7 @@ import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/Expanda
 export function ComputeNotebookCell(
   props: NotebookCellProps<ComputeCellDescriptor>
 ) {
-  const { analysisState, cell, isDisabled } = props;
+  const { analysisState, cell, isDisabled, wdkState } = props;
   const { analysis } = analysisState;
   if (analysis == null) throw new Error('Cannot find analysis.');
 
@@ -129,6 +129,7 @@ export function ComputeNotebookCell(
               cell={subCell}
               isDisabled={isSubCellDisabled}
               expandedPanelState={isSubCellDisabled ? 'closed' : 'open'}
+              wdkState={wdkState}
             />
           );
         })}

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -24,22 +24,20 @@ export type UpdateWdkParamValue = (
   newParamValue: string
 ) => void;
 
+export interface WdkState {
+  wdkParameters?: Parameter[];
+  wdkParamValues?: ParameterValues;
+  updateWdkParamValue?: UpdateWdkParamValue;
+}
+
 interface Props {
   analysisState: AnalysisState;
   notebookType: string;
-  wdkParameters?: Parameter[]; // Array of parameters from the wdk. Notebook preset will have a list of param names to match.
-  wdkParamValues?: ParameterValues;
-  updateWdkParamValue?: UpdateWdkParamValue; // Function to update the parameter value in the WDK search. Commandeers wdk's updateParamValue function
+  wdkState: WdkState;
 }
 
 export function EdaNotebookAnalysis(props: Props) {
-  const {
-    analysisState,
-    notebookType,
-    updateWdkParamValue,
-    wdkParameters,
-    wdkParamValues,
-  } = props;
+  const { analysisState, notebookType, wdkState } = props;
   const { analysis, setComputations, addVisualization } = analysisState;
 
   if (analysis == null) throw new Error('Cannot find analysis.');
@@ -125,9 +123,7 @@ export function EdaNotebookAnalysis(props: Props) {
             <NotebookCell
               key={index}
               analysisState={analysisState}
-              wdkParameters={wdkParameters}
-              wdkParamValues={wdkParamValues}
-              updateWdkParamValue={updateWdkParamValue}
+              wdkState={wdkState}
               cell={cell}
             />
           ))

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -16,18 +16,18 @@ import {
 
 // const NOTEBOOK_UI_SETTINGS_KEY = '@@NOTEBOOK@@';
 
-// Type of function that we'll call wdkUpdateParamValue. It's
+// Type of function that we'll call updateWdkParamValue. It's
 // adapted from one called updateParamValue used around the wdk and used
 // to update values of parameters that come from the wdk.
-export type UpdateWdkParamValue = (
+export type UpdateParamValue = (
   parameter: Parameter,
   newParamValue: string
 ) => void;
 
 export interface WdkState {
-  wdkParameters?: Parameter[];
-  wdkParamValues?: ParameterValues;
-  updateWdkParamValue?: UpdateWdkParamValue;
+  parameters?: Parameter[];
+  paramValues?: ParameterValues;
+  updateParamValue?: UpdateParamValue;
 }
 
 interface Props {

--- a/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
+++ b/packages/libs/eda/src/lib/notebook/EdaNotebookAnalysis.tsx
@@ -109,7 +109,7 @@ export function EdaNotebookAnalysis(props: Props) {
   //
   // If we need `notebookPreset` to be dynamic state (e.g. user can add/remove new cells)
   // or if we need to store cell configuration beyond what the computation and visualisation
-  // descriptors in analysisState.analysis can handle, then we can change this to persisted
+  // descriptors in analysisState.analysis and wdkParams can handle, then we can change this to persisted
   // `notebookState` coming from analysisState.analysis.descriptor.subset.uiSettings[NOTEBOOK_UI_SETTINGS_KEY]
   //
   return (

--- a/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
@@ -5,20 +5,14 @@ import { VisualizationNotebookCell } from './VisualizationNotebookCell';
 import { ComputeNotebookCell } from './ComputeNotebookCell';
 import { NotebookCellDescriptor } from './NotebookPresets';
 import { WdkParamNotebookCell } from './WdkParamNotebookCell';
-import {
-  Parameter,
-  ParameterValues,
-} from '@veupathdb/wdk-client/lib/Utils/WdkModel';
-import { UpdateWdkParamValue } from './EdaNotebookAnalysis';
+import { WdkState } from './EdaNotebookAnalysis';
 
 export interface NotebookCellProps<T extends NotebookCellDescriptor> {
   analysisState: AnalysisState;
   cell: T;
   isDisabled?: boolean; // Indicates if the cell is disabled (e.g., before a computation is complete).
   expandedPanelState?: 'closed' | 'open'; // Indicates if the ExpandabelPanel is expanded in the UI.
-  wdkParameters?: Parameter[];
-  wdkParamValues?: ParameterValues;
-  updateWdkParamValue?: UpdateWdkParamValue;
+  wdkState?: WdkState;
 }
 
 /**

--- a/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookCell.tsx
@@ -5,12 +5,20 @@ import { VisualizationNotebookCell } from './VisualizationNotebookCell';
 import { ComputeNotebookCell } from './ComputeNotebookCell';
 import { NotebookCellDescriptor } from './NotebookPresets';
 import { WdkParamNotebookCell } from './WdkParamNotebookCell';
+import {
+  Parameter,
+  ParameterValues,
+} from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import { UpdateWdkParamValue } from './EdaNotebookAnalysis';
 
 export interface NotebookCellProps<T extends NotebookCellDescriptor> {
   analysisState: AnalysisState;
   cell: T;
   isDisabled?: boolean; // Indicates if the cell is disabled (e.g., before a computation is complete).
   expandedPanelState?: 'closed' | 'open'; // Indicates if the ExpandabelPanel is expanded in the UI.
+  wdkParameters?: Parameter[];
+  wdkParamValues?: ParameterValues;
+  updateWdkParamValue?: UpdateWdkParamValue;
 }
 
 /**

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -9,7 +9,7 @@ import { updateParamValue } from './WdkParamNotebookCell';
 import { AnalysisState } from '../core/hooks/analysis';
 import { NodeData } from '@veupathdb/components/lib/types/plots/network';
 import { OptionsObject } from 'notistack';
-import { UpdateWdkParamValue } from './EdaNotebookAnalysis';
+import { UpdateParamValue } from './EdaNotebookAnalysis';
 
 export const NOTEBOOK_UI_STATE_KEY = '@@NOTEBOOK_WDK_PARAMS@@';
 
@@ -37,7 +37,7 @@ export interface VisualizationCellDescriptor
   // Useful for adding interactivity between the viz and other notebook cells.
   getVizPluginOptions?: (
     analysisState: AnalysisState,
-    updateWdkParamValue: UpdateWdkParamValue,
+    updateWdkParamValue: UpdateParamValue,
     param: Parameter,
     enqueueSnackbar: (message: string, options?: OptionsObject) => void // So we can call up a snackbar if we mess wtih the viz.
   ) => Partial<BipartiteNetworkOptions>; // We'll define this function custom for each notebook, so can expand output types as needed.
@@ -139,7 +139,7 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
             ),
             getVizPluginOptions: (
               analysisState: AnalysisState,
-              updateWdkParamValue: UpdateWdkParamValue,
+              updateWdkParamValue: UpdateParamValue,
               param: Parameter,
               enqueueSnackbar: (
                 message: string,

--- a/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookPresets.tsx
@@ -9,17 +9,9 @@ import { updateParamValue } from './WdkParamNotebookCell';
 import { AnalysisState } from '../core/hooks/analysis';
 import { NodeData } from '@veupathdb/components/lib/types/plots/network';
 import { OptionsObject } from 'notistack';
+import { UpdateWdkParamValue } from './EdaNotebookAnalysis';
 
 export const NOTEBOOK_UI_STATE_KEY = '@@NOTEBOOK_WDK_PARAMS@@';
-
-// Type of function that we'll call wdkUpdateParamValue. It's
-// adapted from one called updateParamValue used around the wdk and used
-// to update values of parameters that come from the wdk.
-export type WdkUpdateParamValue = (
-  parameter: Parameter,
-  newParamValue: string,
-  paramValues: Record<string, string>
-) => void;
 
 // The descriptors contain just enough information to render the cells when given the
 // appropriate context, such as analysis state.
@@ -35,9 +27,6 @@ export interface NotebookCellDescriptorBase<T extends string> {
   title: string;
   cells?: NotebookCellDescriptor[];
   helperText?: ReactNode; // Optional information to display above the cell. Instead of a full text cell, use this for quick help and titles.
-  associatedWdkParamName?: string; // Optional name of a wdk parameter related to this viz. Can be updated using the viz options.
-  associatedWdkParam?: Parameter; // Parameter object. Defined in wdk, not notebook preset.
-  wdkUpdateParamValue?: WdkUpdateParamValue; // Function to update the parameter value in the WDK search. Defined by the wdk, not the notebook preset
 }
 
 export interface VisualizationCellDescriptor
@@ -48,7 +37,7 @@ export interface VisualizationCellDescriptor
   // Useful for adding interactivity between the viz and other notebook cells.
   getVizPluginOptions?: (
     analysisState: AnalysisState,
-    wdkUpdateParamValue: WdkUpdateParamValue,
+    updateWdkParamValue: UpdateWdkParamValue,
     param: Parameter,
     enqueueSnackbar: (message: string, options?: OptionsObject) => void // So we can call up a snackbar if we mess wtih the viz.
   ) => Partial<BipartiteNetworkOptions>; // We'll define this function custom for each notebook, so can expand output types as needed.
@@ -70,7 +59,6 @@ export interface SubsetCellDescriptor
 export interface WdkParamCellDescriptor
   extends NotebookCellDescriptorBase<'wdkparam'> {
   paramNames: string[]; // Param names from the wdk query. These must match exactly or the notebook will err.
-  wdkParameters?: Parameter[]; // The parameters, including all their details, from the wdk query.
 }
 
 type PresetNotebook = {
@@ -149,10 +137,9 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
                 color={colors.grey[800]}
               />
             ),
-            associatedWdkParamName: 'wgcnaParam', // wdk param that controls module name
             getVizPluginOptions: (
               analysisState: AnalysisState,
-              wdkUpdateParamValue: WdkUpdateParamValue,
+              updateWdkParamValue: UpdateWdkParamValue,
               param: Parameter,
               enqueueSnackbar: (
                 message: string,
@@ -186,7 +173,7 @@ export const presetNotebooks: Record<string, PresetNotebook> = {
                   // Update module name in the wdk param selector
                   updateParamValue(
                     analysisState,
-                    wdkUpdateParamValue,
+                    updateWdkParamValue,
                     param
                   ).call(null, moduleName);
 

--- a/packages/libs/eda/src/lib/notebook/NotebookRoute.tsx
+++ b/packages/libs/eda/src/lib/notebook/NotebookRoute.tsx
@@ -71,6 +71,7 @@ export default function NotebookRoute(props: Props) {
                 <EdaNotebookAnalysis
                   analysisState={analysisState}
                   notebookType="wgcnaCorrelationNotebook"
+                  wdkState={{}}
                 />
               </EDAWorkspaceContainer>
             )}

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -26,13 +26,7 @@ export function VisualizationNotebookCell(
   );
   const { enqueueSnackbar } = useSnackbar();
 
-  const {
-    visualizationName,
-    visualizationId,
-    getVizPluginOptions,
-    wdkUpdateParamValue,
-    associatedWdkParam,
-  } = cell;
+  const { visualizationName, visualizationId, getVizPluginOptions } = cell;
 
   const { visualization, computation } =
     analysisState.getVisualizationAndComputation(visualizationId) ?? {};
@@ -96,22 +90,22 @@ export function VisualizationNotebookCell(
 
   // Override vizPlugin Options with ones defined in the notebook preset.
   // For now this is used to link the bipartite network to the wdk param.
-  if (
-    vizPlugin &&
-    getVizPluginOptions &&
-    associatedWdkParam &&
-    wdkUpdateParamValue
-  ) {
-    vizPlugin.options = {
-      ...vizPlugin.options,
-      ...getVizPluginOptions(
-        analysisState,
-        wdkUpdateParamValue,
-        associatedWdkParam,
-        enqueueSnackbar
-      ),
-    };
-  }
+  //  if (
+  //    vizPlugin &&
+  //    getVizPluginOptions &&
+  //    associatedWdkParam &&
+  //    wdkUpdateParamValue
+  //  ) {
+  //    vizPlugin.options = {
+  //      ...vizPlugin.options,
+  //      ...getVizPluginOptions(
+  //        analysisState,
+  //        wdkUpdateParamValue,
+  //        associatedWdkParam,
+  //        enqueueSnackbar
+  //      ),
+  //    };
+  //  }
 
   return visualization ? (
     <>

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -14,7 +14,8 @@ import useSnackbar from '@veupathdb/coreui/lib/components/notifications/useSnack
 export function VisualizationNotebookCell(
   props: NotebookCellProps<VisualizationCellDescriptor>
 ) {
-  const { analysisState, cell, isDisabled, expandedPanelState } = props;
+  const { analysisState, cell, isDisabled, expandedPanelState, wdkState } =
+    props;
   const { analysis, updateVisualization } = analysisState;
   if (analysis == null) throw new Error('Cannot find analysis.');
 

--- a/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/VisualizationNotebookCell.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useEntityCounts } from '../core/hooks/entityCounts';
 import { useDataClient, useStudyEntities } from '../core/hooks/workspace';
 import { useGeoConfig } from '../core/hooks/geoConfig';
@@ -18,6 +18,7 @@ export function VisualizationNotebookCell(
     props;
   const { analysis, updateVisualization } = analysisState;
   if (analysis == null) throw new Error('Cannot find analysis.');
+  if (wdkState == null) throw new Error('No WDK state.');
 
   const entities = useStudyEntities();
   const geoConfigs = useGeoConfig(entities);
@@ -89,24 +90,13 @@ export function VisualizationNotebookCell(
     plotContainerStyleOverrides.width = 1100;
   }
 
-  // Override vizPlugin Options with ones defined in the notebook preset.
-  // For now this is used to link the bipartite network to the wdk param.
-  //  if (
-  //    vizPlugin &&
-  //    getVizPluginOptions &&
-  //    associatedWdkParam &&
-  //    wdkUpdateParamValue
-  //  ) {
-  //    vizPlugin.options = {
-  //      ...vizPlugin.options,
-  //      ...getVizPluginOptions(
-  //        analysisState,
-  //        wdkUpdateParamValue,
-  //        associatedWdkParam,
-  //        enqueueSnackbar
-  //      ),
-  //    };
-  //  }
+  const vizOptions = useMemo(
+    () => ({
+      ...vizPlugin?.options,
+      ...getVizPluginOptions?.(wdkState, enqueueSnackbar),
+    }),
+    [wdkState, enqueueSnackbar]
+  );
 
   return visualization ? (
     <>
@@ -124,7 +114,7 @@ export function VisualizationNotebookCell(
         >
           {computation && vizPlugin && (
             <vizPlugin.fullscreenComponent
-              options={vizPlugin.options}
+              options={vizOptions}
               dataElementConstraints={constraints}
               dataElementDependencyOrder={dataElementDependencyOrder}
               visualization={visualization}

--- a/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
@@ -10,7 +10,7 @@ import { NumberInput } from '@veupathdb/components/lib/components/widgets/Number
 import { NumberOrDate } from '@veupathdb/components/lib/types/general';
 import { AnalysisState } from '../core';
 import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
-import { UpdateWdkParamValue } from './EdaNotebookAnalysis';
+import { UpdateParamValue } from './EdaNotebookAnalysis';
 
 const uiStateKey = NOTEBOOK_UI_STATE_KEY;
 
@@ -113,7 +113,7 @@ export function WdkParamNotebookCell(
 //
 export const updateParamValue = (
   analysisState: AnalysisState,
-  updateWdkParamValue: UpdateWdkParamValue,
+  updateWdkParamValue: UpdateParamValue,
   param: Parameter
 ) => {
   return (value: NumberOrDate | string | undefined) => {

--- a/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
@@ -76,9 +76,7 @@ export function WdkParamNotebookCell(
                     <div className="InputGroup">
                       <span>{param.displayName}</span>
                       <NumberInput
-                        value={
-                          Number(paramCurrentValue) ?? param.initialDisplayValue
-                        }
+                        value={Number(paramCurrentValue)}
                         minValue={0} // TO DO: Currently not derived from the parameter, though they should be.
                         maxValue={1}
                         step={0.01}

--- a/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
@@ -1,18 +1,10 @@
 import ExpandablePanel from '@veupathdb/coreui/lib/components/containers/ExpandablePanel';
 import { NotebookCellProps } from './NotebookCell';
-import {
-  NOTEBOOK_UI_STATE_KEY,
-  WdkParamCellDescriptor,
-} from './NotebookPresets';
+import { WdkParamCellDescriptor } from './NotebookPresets';
 import { SingleSelect } from '@veupathdb/coreui';
 import { Item } from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxList';
 import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
 import { NumberOrDate } from '@veupathdb/components/lib/types/general';
-import { AnalysisState } from '../core';
-import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
-import { UpdateParamValue } from './EdaNotebookAnalysis';
-
-const uiStateKey = NOTEBOOK_UI_STATE_KEY;
 
 export function WdkParamNotebookCell(
   props: NotebookCellProps<WdkParamCellDescriptor>
@@ -62,13 +54,17 @@ export function WdkParamNotebookCell(
                       }))
                     : [];
 
+                  const buttonDisplayContent = selectItems.find(
+                    ({ value }) => value === paramCurrentValue
+                  )?.display;
+
                   return (
                     <div className="InputGroup">
                       <span>{param.displayName}</span>
                       <SingleSelect
                         items={selectItems}
                         value={paramCurrentValue}
-                        buttonDisplayContent={paramCurrentValue}
+                        buttonDisplayContent={buttonDisplayContent}
                         onSelect={(newValue: string) =>
                           updateParamValue?.(param, newValue)
                         }
@@ -107,40 +103,3 @@ export function WdkParamNotebookCell(
     </>
   );
 }
-
-//
-// TO DO: probably get rid of this?
-//
-export const updateParamValue = (
-  analysisState: AnalysisState,
-  updateWdkParamValue: UpdateParamValue,
-  param: Parameter
-) => {
-  return (value: NumberOrDate | string | undefined) => {
-    const stringValue = value?.toString() ?? '';
-    // TO DO: early return instead of using empty string fallback?
-
-    if (updateWdkParamValue) {
-      // translate the uiSettings stored in the analysisState to
-      // an object that the updateWdkParamValue can handle.
-      const uiSettingsAsRecord: Record<string, string> = Object.entries(
-        analysisState.analysis?.descriptor.subset.uiSettings[uiStateKey] ?? {}
-      ).reduce((acc, [key, val]) => {
-        acc[key] = val?.toString() ?? '';
-        return acc;
-      }, {} as Record<string, string>);
-
-      // Set the new value (stringValue) in the uiSettings.
-      updateWdkParamValue(param, stringValue); // there was a deprecated third arg: `uiSettingsAsRecord`
-    }
-
-    // Also update the analysisState with the new parameter value.
-    analysisState.setVariableUISettings((currentState) => ({
-      ...currentState,
-      [uiStateKey]: {
-        ...currentState[uiStateKey],
-        [param.name]: stringValue,
-      },
-    }));
-  };
-};

--- a/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
@@ -20,13 +20,13 @@ export function WdkParamNotebookCell(
   const { cell, isDisabled, wdkState = {} } = props;
 
   const { paramNames, title } = cell;
-  const { wdkParameters, wdkParamValues, updateWdkParamValue } = wdkState;
+  const { parameters, paramValues, updateParamValue } = wdkState;
 
   // userInputParameters are the wdk parameters that the user will
   // fill out in the search. For example, in wgcna the user needs to select a module,
   // but doesn't need to select the hidden param for this search called "dataset".
 
-  const userInputParameters = wdkParameters?.filter((param) =>
+  const userInputParameters = parameters?.filter((param) =>
     paramNames?.includes(param.name)
   );
 
@@ -47,9 +47,9 @@ export function WdkParamNotebookCell(
           <div className="WdkParamInputs">
             {userInputParameters &&
               paramNames &&
-              wdkParamValues &&
+              paramValues &&
               userInputParameters.map((param) => {
-                const paramCurrentValue = wdkParamValues[param.name];
+                const paramCurrentValue = paramValues[param.name];
 
                 // There are many param types. The following is not exhaustive.
                 if (param.type === 'single-pick-vocabulary') {
@@ -70,7 +70,7 @@ export function WdkParamNotebookCell(
                         value={paramCurrentValue}
                         buttonDisplayContent={paramCurrentValue}
                         onSelect={(newValue: string) =>
-                          updateWdkParamValue?.(param, newValue)
+                          updateParamValue?.(param, newValue)
                         }
                       />
                     </div>
@@ -88,7 +88,7 @@ export function WdkParamNotebookCell(
                         step={0.01}
                         onValueChange={(newValue?: NumberOrDate) =>
                           newValue != null &&
-                          updateWdkParamValue?.(param, newValue.toString())
+                          updateParamValue?.(param, newValue.toString())
                         }
                       />
                     </div>

--- a/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/WdkParamNotebookCell.tsx
@@ -8,7 +8,6 @@ import { SingleSelect } from '@veupathdb/coreui';
 import { Item } from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxList';
 import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
 import { NumberOrDate } from '@veupathdb/components/lib/types/general';
-import { useEffect } from 'react';
 import { AnalysisState } from '../core';
 import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { UpdateWdkParamValue } from './EdaNotebookAnalysis';
@@ -18,15 +17,10 @@ const uiStateKey = NOTEBOOK_UI_STATE_KEY;
 export function WdkParamNotebookCell(
   props: NotebookCellProps<WdkParamCellDescriptor>
 ) {
-  const {
-    cell,
-    isDisabled,
-    wdkParameters,
-    wdkParamValues,
-    updateWdkParamValue,
-  } = props;
+  const { cell, isDisabled, wdkState = {} } = props;
 
   const { paramNames, title } = cell;
+  const { wdkParameters, wdkParamValues, updateWdkParamValue } = wdkState;
 
   // userInputParameters are the wdk parameters that the user will
   // fill out in the search. For example, in wgcna the user needs to select a module,

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -32,14 +32,8 @@ import { DatasetItem } from '@veupathdb/wdk-client/lib/Views/Question/Params/Dat
 import { parseJson } from '@veupathdb/eda/lib/notebook/Utils';
 import {
   EdaNotebookAnalysis,
-  UpdateWdkParamValue,
+  WdkState,
 } from '@veupathdb/eda/lib/notebook/EdaNotebookAnalysis';
-
-export interface WdkState {
-  wdkParameters?: Parameter[];
-  wdkParamValues?: ParameterValues;
-  updateWdkParamValue?: (parameter: Parameter, newParamValue: string) => void;
-}
 
 type EdaNotebookParameterProps = {
   value: string;
@@ -50,8 +44,6 @@ type EdaNotebookParameterProps = {
 
 export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
   const { value, datasetIdParamName, notebookTypeParamName, wdkState } = props;
-
-  const { parameters = [], paramValues = {}, updateParamValue } = wdkState;
 
   // TEMPORARY: We don't have this value coming from the wdk yet.
   const studyId = datasetIdParamName ?? 'DS_82dc5abc7f';

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -51,6 +51,8 @@ type EdaNotebookParameterProps = {
 export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
   const { value, datasetIdParamName, notebookTypeParamName, wdkState } = props;
 
+  const { parameters = [], paramValues = {}, updateParamValue } = wdkState;
+
   // TEMPORARY: We don't have this value coming from the wdk yet.
   const studyId = datasetIdParamName ?? 'DS_82dc5abc7f';
   const notebookType = notebookTypeParamName ?? 'wgcnaCorrelationNotebook';

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
-import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import {
+  Parameter,
+  ParameterValues,
+} from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { WorkspaceContainer } from '@veupathdb/eda/lib/workspace/WorkspaceContainer';
 import {
   Analysis,
@@ -27,15 +30,18 @@ import {
 import { formatFilterDisplayValue } from '@veupathdb/eda/lib/core/utils/study-metadata';
 import { DatasetItem } from '@veupathdb/wdk-client/lib/Views/Question/Params/DatasetParamUtils';
 import { parseJson } from '@veupathdb/eda/lib/notebook/Utils';
-import { EdaNotebookAnalysis } from '@veupathdb/eda/lib/notebook/EdaNotebookAnalysis';
-import { WdkUpdateParamValue } from '@veupathdb/eda/lib/notebook/NotebookPresets';
+import {
+  EdaNotebookAnalysis,
+  UpdateWdkParamValue,
+} from '@veupathdb/eda/lib/notebook/EdaNotebookAnalysis';
 
 type EdaNotebookParameterProps = {
   value: string;
   datasetIdParamName?: string;
   notebookTypeParamName?: string;
-  parameters?: Parameter[]; // Array of parameters from the wdk. Notebook preset will have a list of param names to match.
-  wdkUpdateParamValue?: WdkUpdateParamValue;
+  wdkParameters?: Parameter[]; // Array of parameter definitions from the wdk. Notebook preset will have a list of param names to match.
+  wdkParamValues?: ParameterValues;
+  updateWdkParamValue?: UpdateWdkParamValue;
 };
 
 export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
@@ -43,8 +49,9 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
     value,
     datasetIdParamName,
     notebookTypeParamName,
-    parameters = [],
-    wdkUpdateParamValue,
+    wdkParameters = [],
+    wdkParamValues = {},
+    updateWdkParamValue,
   } = props;
 
   // TEMPORARY: We don't have this value coming from the wdk yet.
@@ -111,8 +118,9 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
             <EdaNotebookAdapter
               analysisState={analysisState}
               notebookType={notebookType}
-              parameters={parameters}
-              wdkUpdateParamValue={wdkUpdateParamValue}
+              wdkParameters={wdkParameters}
+              wdkParamValues={wdkParamValues}
+              updateWdkParamValue={updateWdkParamValue}
             />
           </CoreUIThemeProvider>
         </WorkspaceContainer>
@@ -124,8 +132,9 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
 interface EdaNotebookAdapterProps {
   analysisState: AnalysisState;
   notebookType: string;
-  parameters?: Parameter[]; // Passed to notebook
-  wdkUpdateParamValue?: WdkUpdateParamValue; // Passed to notebook
+  wdkParameters?: Parameter[]; // Passed to notebook
+  wdkParamValues?: ParameterValues;
+  updateWdkParamValue?: UpdateWdkParamValue; // Passed to notebook
 }
 
 function EdaNotebookAdapter(props: EdaNotebookAdapterProps) {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -35,24 +35,21 @@ import {
   UpdateWdkParamValue,
 } from '@veupathdb/eda/lib/notebook/EdaNotebookAnalysis';
 
+export interface WdkState {
+  wdkParameters?: Parameter[];
+  wdkParamValues?: ParameterValues;
+  updateWdkParamValue?: (parameter: Parameter, newParamValue: string) => void;
+}
+
 type EdaNotebookParameterProps = {
   value: string;
   datasetIdParamName?: string;
   notebookTypeParamName?: string;
-  wdkParameters?: Parameter[]; // Array of parameter definitions from the wdk. Notebook preset will have a list of param names to match.
-  wdkParamValues?: ParameterValues;
-  updateWdkParamValue?: UpdateWdkParamValue;
+  wdkState: WdkState;
 };
 
 export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
-  const {
-    value,
-    datasetIdParamName,
-    notebookTypeParamName,
-    wdkParameters = [],
-    wdkParamValues = {},
-    updateWdkParamValue,
-  } = props;
+  const { value, datasetIdParamName, notebookTypeParamName, wdkState } = props;
 
   // TEMPORARY: We don't have this value coming from the wdk yet.
   const studyId = datasetIdParamName ?? 'DS_82dc5abc7f';
@@ -118,9 +115,7 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
             <EdaNotebookAdapter
               analysisState={analysisState}
               notebookType={notebookType}
-              wdkParameters={wdkParameters}
-              wdkParamValues={wdkParamValues}
-              updateWdkParamValue={updateWdkParamValue}
+              wdkState={wdkState}
             />
           </CoreUIThemeProvider>
         </WorkspaceContainer>
@@ -132,13 +127,11 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
 interface EdaNotebookAdapterProps {
   analysisState: AnalysisState;
   notebookType: string;
-  wdkParameters?: Parameter[]; // Passed to notebook
-  wdkParamValues?: ParameterValues;
-  updateWdkParamValue?: UpdateWdkParamValue; // Passed to notebook
+  wdkState: WdkState;
 }
 
 function EdaNotebookAdapter(props: EdaNotebookAdapterProps) {
-  const { analysisState } = props;
+  const { analysisState, wdkState, notebookType } = props;
   const studyId = analysisState.analysis?.studyId;
 
   const analysisClient = useConfiguredAnalysisClient(edaServiceUrl);
@@ -158,7 +151,11 @@ function EdaNotebookAdapter(props: EdaNotebookAdapterProps) {
           dataClient={dataClient}
           computeClient={computeClient}
         >
-          <EdaNotebookAnalysis {...props} />
+          <EdaNotebookAnalysis
+            analysisState={analysisState}
+            notebookType={notebookType}
+            wdkState={wdkState}
+          />
         </EDAWorkspaceContainer>
       )}
     </div>

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
@@ -7,12 +7,7 @@ import {
   Parameter,
   ParameterValues,
 } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
-
-export interface WdkState {
-  wdkParameters?: Parameter[];
-  wdkParamValues?: ParameterValues;
-  updateWdkParamValue?: (parameter: Parameter, newParamValue: string) => void;
-}
+import { WdkState } from './EdaNotebookAnalysis';
 
 export const EdaNotebookQuestionForm = (props: Props) => {
   const { searchName } = props;
@@ -34,9 +29,9 @@ export const EdaNotebookQuestionForm = (props: Props) => {
   );
 
   const wdkState: WdkState = {
-    wdkParameters: props.state.question.parameters,
-    wdkParamValues: props.state.paramValues,
-    updateWdkParamValue,
+    parameters: props.state.question.parameters,
+    paramValues: props.state.paramValues,
+    updateParamValue,
   };
 
   // An override that renders the notebook instead of any default parameter or parameter group ui.

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
@@ -3,20 +3,13 @@ import DefaultQuestionForm, {
 } from '@veupathdb/wdk-client/lib/Views/Question/DefaultQuestionForm';
 import React, { useCallback } from 'react';
 import { EdaNotebookParameter } from './EdaNotebookParameter';
-import {
-  ParameterGroup,
-  Parameter,
-  ParameterValues,
-} from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 
 export const EdaNotebookQuestionForm = (props: Props) => {
   const { searchName } = props;
   if (!searchName) {
     throw new Error('No search defined.');
   }
-
-  const foo = props.state.paramValues;
-  const asd = foo['asd'];
 
   // We'll use this function throughout the notebook to update any wdk parameters.
   const updateWdkParamValue = useCallback(

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
@@ -3,7 +3,16 @@ import DefaultQuestionForm, {
 } from '@veupathdb/wdk-client/lib/Views/Question/DefaultQuestionForm';
 import React, { useCallback } from 'react';
 import { EdaNotebookParameter } from './EdaNotebookParameter';
-import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import {
+  Parameter,
+  ParameterValues,
+} from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+
+export interface WdkState {
+  wdkParameters?: Parameter[];
+  wdkParamValues?: ParameterValues;
+  updateWdkParamValue?: (parameter: Parameter, newParamValue: string) => void;
+}
 
 export const EdaNotebookQuestionForm = (props: Props) => {
   const { searchName } = props;
@@ -24,16 +33,15 @@ export const EdaNotebookQuestionForm = (props: Props) => {
     [props, searchName]
   );
 
+  const wdkState: WdkState = {
+    wdkParameters: props.state.question.parameters,
+    wdkParamValues: props.state.paramValues,
+    updateWdkParamValue,
+  };
+
   // An override that renders the notebook instead of any default parameter or parameter group ui.
   const renderParamGroup = () => {
-    return (
-      <EdaNotebookParameter
-        value={'test'}
-        wdkParameters={props.state.question.parameters}
-        wdkParamValues={props.state.paramValues}
-        updateWdkParamValue={updateWdkParamValue}
-      />
-    );
+    return <EdaNotebookParameter value={'test'} wdkState={wdkState} />;
   };
 
   return (

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
@@ -3,11 +3,8 @@ import DefaultQuestionForm, {
 } from '@veupathdb/wdk-client/lib/Views/Question/DefaultQuestionForm';
 import React, { useCallback } from 'react';
 import { EdaNotebookParameter } from './EdaNotebookParameter';
-import {
-  Parameter,
-  ParameterValues,
-} from '@veupathdb/wdk-client/lib/Utils/WdkModel';
-import { WdkState } from './EdaNotebookAnalysis';
+import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import { WdkState } from '@veupathdb/eda/lib/notebook/EdaNotebookAnalysis';
 
 export const EdaNotebookQuestionForm = (props: Props) => {
   const { searchName } = props;
@@ -16,7 +13,7 @@ export const EdaNotebookQuestionForm = (props: Props) => {
   }
 
   // We'll use this function throughout the notebook to update any wdk parameters.
-  const updateWdkParamValue = useCallback(
+  const updateParamValue = useCallback(
     (parameter: Parameter, newParamValue: string) => {
       props.eventHandlers.updateParamValue({
         searchName,

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookQuestionForm.tsx
@@ -15,17 +15,16 @@ export const EdaNotebookQuestionForm = (props: Props) => {
     throw new Error('No search defined.');
   }
 
+  const foo = props.state.paramValues;
+  const asd = foo['asd'];
+
   // We'll use this function throughout the notebook to update any wdk parameters.
-  const wdkUpdateParamValue = useCallback(
-    (
-      parameter: Parameter,
-      newParamValue: string,
-      paramValues: ParameterValues
-    ) => {
+  const updateWdkParamValue = useCallback(
+    (parameter: Parameter, newParamValue: string) => {
       props.eventHandlers.updateParamValue({
         searchName,
         parameter,
-        paramValues,
+        paramValues: {}, // deprecated
         paramValue: newParamValue,
       });
     },
@@ -33,12 +32,13 @@ export const EdaNotebookQuestionForm = (props: Props) => {
   );
 
   // An override that renders the notebook instead of any default parameter or parameter group ui.
-  const renderParamGroup = (group: ParameterGroup, formProps: Props) => {
+  const renderParamGroup = () => {
     return (
       <EdaNotebookParameter
         value={'test'}
-        parameters={props.state.question.parameters}
-        wdkUpdateParamValue={wdkUpdateParamValue}
+        wdkParameters={props.state.question.parameters}
+        wdkParamValues={props.state.paramValues}
+        updateWdkParamValue={updateWdkParamValue}
       />
     );
   };


### PR DESCRIPTION
There were a couple of issues and overengineered bits I have had a look at.

### mutating immutable state (constants)

In both of the `useEffect` blocks in `EdaNotebookAnalysis` we’re doing things like

```
cell.wdkParameters = props.parameters;
cell.wdkUpdateParamValue = props.wdkUpdateParamValue;
```
but `presetNotebooks[...]` is an imported constant—modifying it directly means every consumer of that preset will see the change. That defeats the point of having a static “preset” and could lead to surprising cross-analysis/question state leaks.

#### solution
Pass new `wdkState` alongside `analysisState` to all notebook cell components as the notebook tree is rendered. The `type == 'wdkparam'` notebook cell already knows the **names** of the parameters it is rendering (from its `paramNames` prop). All it needs is the richer information passed through inside `wdkState` which is namely:
* the parameter values (`paramValues`)
* the parameter details (`parameters`)
* an update callback (`updateParamValue`)

So while rendering it can grab the richer information from these via param name.

Note that there was an unused/deprecated arg to the underlying `questionProps.eventHandlers.updateParamValue()` which we can ignore, and that simplifies things greatly. See EdaNotebookQuestionForm.tsx

For background on the deprecated arg, see https://github.com/VEuPathDB/web-monorepo/blob/ada2097f530175742f0734e8a0f03a98e6c58033/packages/libs/wdk-client/src/StoreModules/QuestionStoreModule.ts#L259C5-L308 and https://github.com/VEuPathDB/web-monorepo/blob/ada2097f530175742f0734e8a0f03a98e6c58033/packages/libs/wdk-client/src/Actions/QuestionActions.ts#L258

### unnecessary dual use of UiSettings + WDK for state storage

Most user-configuration (e.g. computation and visualization settings and thresholds) is stored in `AnalysisState.analysis` (which will ultimately be deserialised from a WDK parameter called `eda_analysis_spec` or similar) and for everything else the WDK param storage is used directly (wgcna module name and the 0.75 correlation-with-eigengene parameter).

We should store things in either `analysisState` or `wdkState` but not both.

#### solution

Remove all the uiSettings stuff and use `wdkState.paramValues[param.name]` for the current value of WDK params.