### PR TITLE
Mbio diff abund remove values from picker that have been filtered out

### DIFF
--- a/packages/libs/eda/src/lib/core/components/filter/util.ts
+++ b/packages/libs/eda/src/lib/core/components/filter/util.ts
@@ -1,8 +1,8 @@
 import { Filter } from '../../types/filter';
 
-type SummaryFetcher<T> = (filters: Filter[]) => Promise<T>;
+export type SummaryFetcher<T> = (filters: Filter[]) => Promise<T>;
 
-type Context = {
+export type Context = {
   entityId: string;
   variableId: string;
   filters?: Filter[];


### PR DESCRIPTION
Resolves #1417 

This PR adds functionality that asks the backend for the filtered distribution for the comparator variable. The result gives us a way to disable variables values in the drop downs that have been totally filtered out of the subset. 

Note this fix is only for categorical variables. Distributions for continuous variables already took into account the current filters.

Testing
- tested with local eda with qa mbio backend