### PR TITLE
Patch the plot annotation regression

### DIFF
--- a/packages/libs/components/src/plots/PlotlyPlot.tsx
+++ b/packages/libs/components/src/plots/PlotlyPlot.tsx
@@ -219,6 +219,9 @@ function PlotlyPlot<T>(
       title,
       colorPalette,
       plotlyAnnotations,
+      xAxisTitle,
+      yAxisTitle,
+      maxLegendTitleTextLength,
     ]
   );
 

--- a/packages/libs/components/src/plots/PlotlyPlot.tsx
+++ b/packages/libs/components/src/plots/PlotlyPlot.tsx
@@ -205,7 +205,10 @@ function PlotlyPlot<T>(
       },
       autosize: true, // responds properly to enclosing div resizing (not to be confused with config.responsive)
       colorway: colorPalette,
-      annotations: plotlyAnnotations,
+      annotations: [
+        ...(plotlyProps.layout.annotations ?? []),
+        ...(plotlyAnnotations ?? []),
+      ],
     }),
     [
       plotlyProps.layout,
@@ -215,6 +218,7 @@ function PlotlyPlot<T>(
       legendTitle,
       title,
       colorPalette,
+      plotlyAnnotations,
     ]
   );
 


### PR DESCRIPTION
Fixes #1429

A more recent feature was overwriting any `annotations` produced by our plot components.