### PR TITLE
Add opt-in keyboard movement for Dialog components

### DIFF
--- a/packages/libs/wdk-client/src/Components/Overlays/Dialog.tsx
+++ b/packages/libs/wdk-client/src/Components/Overlays/Dialog.tsx
@@ -32,6 +32,12 @@ type Props = {
 
   draggable?: boolean;
   resizable?: boolean;
+  /**
+   * Enable keyboard movement of the dialog. Defaults to false.
+   * When enabled, pressing 'M' will enter keyboard-positioning mode
+   * where arrow keys can be used to move the dialog.
+   */
+  allowKeyboardMoving?: boolean;
   className?: string;
   onOpen?: () => void;
   onClose?: () => void;
@@ -205,8 +211,8 @@ function Dialog(props: Props) {
           }
         }
       }
-      // M key to enter toggle keyboard moving mode
-      if (e.key === 'M' || e.key === 'm') {
+      // M key to enter toggle keyboard moving mode (only if enabled)
+      if ((e.key === 'M' || e.key === 'm') && props.allowKeyboardMoving) {
         setIsMoving(true);
       }
       // Tab will do its normal thing but also show the focus key help
@@ -267,17 +273,19 @@ function Dialog(props: Props) {
         <Icon type="close" />
       </button>,
     ],
-    leftButtons = [
-      <button
-        title="Toggle keyboard placement mode (shortcut key: M)"
-        key="move"
-        type="button"
-        onClick={() => setIsMoving((prev) => !prev)}
-        style={isMoving ? { color: isMovingHighlightColor } : {}}
-      >
-        <Icon type="move" />
-      </button>,
-    ],
+    leftButtons = props.allowKeyboardMoving
+      ? [
+          <button
+            title="Toggle keyboard placement mode (shortcut key: M)"
+            key="move"
+            type="button"
+            onClick={() => setIsMoving((prev) => !prev)}
+            style={isMoving ? { color: isMovingHighlightColor } : {}}
+          >
+            <Icon type="move" />
+          </button>,
+        ]
+      : [],
   } = props;
 
   const content = (

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
@@ -590,6 +590,7 @@ export function ExpressionGraphFloater({
           open={open}
           resizable
           draggable
+          allowKeyboardMoving={true}
           onClose={onClose}
           title={<div className="ai-floater-header">{title?.toString()}</div>}
           description="This floating, keyboard-positionable popup shows one per-experiment AI summary and gene expression data side-by-side. Press the tab key to navigate and the F key to restore focus to the list of experiments. Press M to enter keyboard-positioning mode."

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisWordCloudModal.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/stepAnalysis/StepAnalysisWordCloudModal.tsx
@@ -19,6 +19,7 @@ export const WordCloudModal: React.FunctionComponent<WordCloudModalProps> = ({
     open={open}
     resizable
     draggable
+    allowKeyboardMoving={true}
     onClose={onClose}
     title={`Word Cloud of ${toolName} Results`}
     description="Floating, keyboard-positionable dialog containing a word cloud representation of the results. Press M to enter keyboard-positioning mode."


### PR DESCRIPTION
Fixes #1446 

  Changes Made:
  - Dialog Component: Added allowKeyboardMoving prop (defaults to false) to make keyboard movement opt-in
  - AiExpressionSummary: Opted into keyboard movement with allowKeyboardMoving={true}
  - WordCloudModal: Opted into keyboard movement with allowKeyboardMoving={true}

  Problem Solved:
  - Login forms and other text inputs won't accidentally trigger keyboard movement when users type 'M'
  - Components designed for keyboard movement still work by explicitly opting in
  - Maintains backward compatibility for all existing Dialog usages
