### PR TITLE
Fix header grid layout and improve user menu positioning across screen sizes

### DIFF
--- a/packages/libs/web-common/src/App/UserMenu/UserMenu.scss
+++ b/packages/libs/web-common/src/App/UserMenu/UserMenu.scss
@@ -1,3 +1,5 @@
+@import '../../styles/breakpoints.scss';
+
 $red: #dd314e;
 $white: #e0e0e0;
 
@@ -13,8 +15,7 @@ $white: #e0e0e0;
 
   &--expanded {
     height: 5em !important;
-    transform: translateY(-13px);
-    margin-top: 6px;
+    transform: translateY(-10px);
   }
 
   .UserMenu-IconContainer {
@@ -57,6 +58,10 @@ $white: #e0e0e0;
       transition: none;
       top: 100%;
     }
+  }
+
+  @media screen and (max-width: $hamburger-width) {
+    transform: translateY(-2px);
   }
 }
 

--- a/packages/libs/web-common/src/components/homepage/Header.scss
+++ b/packages/libs/web-common/src/components/homepage/Header.scss
@@ -18,7 +18,7 @@
     'site-branding .         project-branding project-branding'
     'site-branding searchbar .                .     '
     'site-branding menubar   social           login          ';
-  grid-template-columns: auto 1fr 0.3fr 0.1fr;
+  grid-template-columns: auto 1.5fr 0.5fr 0.1fr;
 
   align-items: center;
 

--- a/packages/libs/web-common/src/components/homepage/Header.scss
+++ b/packages/libs/web-common/src/components/homepage/Header.scss
@@ -1,7 +1,5 @@
 @import '../../styles/collapsed-header-mixins.scss';
 
-/* $hamburger-width: 1170px; */
-
 @mixin shadowed {
   text-shadow: 1px 1px 1px #00000052, -1px -1px 1px #00000052,
     1px -1px 1px #00000052, -1px 1px 1px #00000052, 2px 2px 2px #00000052,

--- a/packages/libs/web-common/src/components/homepage/Header.scss
+++ b/packages/libs/web-common/src/components/homepage/Header.scss
@@ -1,4 +1,6 @@
-$hamburger-width: 1013px;
+@import '../../styles/collapsed-header-mixins.scss';
+
+/* $hamburger-width: 1170px; */
 
 @mixin shadowed {
   text-shadow: 1px 1px 1px #00000052, -1px -1px 1px #00000052,
@@ -16,7 +18,7 @@ $hamburger-width: 1013px;
     'site-branding .         project-branding project-branding'
     'site-branding searchbar .                .     '
     'site-branding menubar   social           login          ';
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr 0.3fr 0.1fr;
 
   align-items: center;
 

--- a/packages/libs/web-common/src/styles/breakpoints.scss
+++ b/packages/libs/web-common/src/styles/breakpoints.scss
@@ -1,6 +1,6 @@
 // Header breakpoints
-$cramped-header-width: 1215px;
-$hamburger-width: 1013px;
+$cramped-header-width: 1300px;
+$hamburger-width: 1160px;
 $small-mobile-width: 415px;
 
 // Search Pane + Main + News breakpoints


### PR DESCRIPTION
  Changes

  - Header Grid Layout: Fixed grid template columns specification - the previous `auto 1fr auto` was incorrectly defining only 3 columns when the grid template areas actually define 4 columns. Updated to `auto 1fr 0.3fr 0.1fr` for proper spacing distribution
  - Responsive Breakpoints: Increased breakpoints to provide more breathing room (the horizontal nav menu has gained extra items since this was last looked at - **UserMenu was cropped off-screen at some window widths**):
    - `$hamburger-width`: 1013px → 1160px
    - `$cramped-header-width`: 1215px → 1300px
  - User Menu Positioning:
    - Simplified expanded state positioning by removing `margin-top: 6px` and adjusting `translateY` from -13px to -10px
    - Added responsive positioning with `translateY(-2px)` for mobile screens to prevent the user status check mark from being cropped at the top
  - Import Cleanup: Added proper SCSS imports for shared breakpoints and mixins to eliminate magic numbers

  These changes resolve the grid layout mismatch and ensure the user menu displays properly across all screen sizes.

As a result we now have a bit of space between the user icon and the social icons, and when logging in/out, there is hopefully NO movement, horizontal or vertical.

<img width="1373" height="132" alt="image" src="https://github.com/user-attachments/assets/677212ce-81cf-4ced-bef7-85146e6058c4" />

