### PR TITLE
Banner styling updates

### DIFF
--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -285,6 +285,13 @@ export default function Banner(props: BannerComponentProps) {
               {secondaryActionButtonProps != null && (
                 <OutlinedButton
                   text={secondaryActionButtonProps.text}
+                  themeRole={
+                    type === 'danger'
+                      ? 'error'
+                      : type === 'normal'
+                      ? 'primary'
+                      : type
+                  }
                   styleOverrides={{
                     container: {
                       marginRight: '0.5em',
@@ -296,6 +303,13 @@ export default function Banner(props: BannerComponentProps) {
               {primaryActionButtonProps != null && (
                 <FilledButton
                   text={primaryActionButtonProps.text}
+                  themeRole={
+                    type === 'danger'
+                      ? 'error'
+                      : type === 'normal'
+                      ? 'primary'
+                      : type
+                  }
                   styleOverrides={{
                     container: {
                       marginRight: '0.5em',

--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -178,6 +178,7 @@ export default function Banner(props: BannerComponentProps) {
       color: ${getColorTheme(type, 600)};
       &:hover {
         color: ${getColorTheme(type, 700)};
+        background: transparent;
       }`;
   }, [type]);
 

--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -73,8 +73,6 @@ export type BannerComponentProps = {
   CollapsibleContent?: React.FC;
 };
 
-const MAIN_COLOR_LEVEL = 600;
-
 function getIconComponentFromType(type: BannerProps['type']) {
   switch (type) {
     case 'warning':
@@ -141,6 +139,11 @@ export default function Banner(props: BannerComponentProps) {
     secondaryActionButtonProps,
   } = banner;
 
+  const mainColorLevel =
+    theme && type in theme.palette
+      ? theme.palette[type as keyof typeof theme.palette].level
+      : 600;
+
   const [isShowMore, setIsShowMore] = useState(false);
 
   const IconComponent = getIconComponentFromType(type);
@@ -177,9 +180,9 @@ export default function Banner(props: BannerComponentProps) {
       border: none;
       cursor: pointer;
       margin-left: 4px; // makes space between CTA button and close same as close and banner border
-      color: ${getColorTheme(type, MAIN_COLOR_LEVEL)};
+      color: ${getColorTheme(type, mainColorLevel)};
       &:hover {
-        color: ${getColorTheme(type, MAIN_COLOR_LEVEL + 100)};
+        color: ${getColorTheme(type, mainColorLevel + 100)};
         background: transparent;
       }`;
   }, [type]);
@@ -193,13 +196,13 @@ export default function Banner(props: BannerComponentProps) {
             display: flex;
             color: ${intense ? 'white' : 'black'};
             background-color: ${intense
-              ? getColorTheme(type, MAIN_COLOR_LEVEL)
+              ? getColorTheme(type, mainColorLevel)
               : getColorTheme(type, 100)};
             border: ${intense
               ? 'none'
               : CollapsibleContent != null
               ? `1px solid #dedede`
-              : `1px solid ${getColorTheme(type, MAIN_COLOR_LEVEL)}`};
+              : `1px solid ${getColorTheme(type, mainColorLevel)}`};
             box-sizing: border-box;
             border-radius: ${CollapsibleContent != null ? '0' : '7px'};
             margin: ${spacing?.margin != null ? spacing.margin : '10px 0'};
@@ -234,7 +237,7 @@ export default function Banner(props: BannerComponentProps) {
                       ? 'white'
                       : CollapsibleContent != null
                       ? '#00008B'
-                      : getColorTheme(type, MAIN_COLOR_LEVEL)};
+                      : getColorTheme(type, mainColorLevel)};
                     font-size: 1.4em;
                     line-height: 1.4em;
                     width: 30px;

--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -174,6 +174,7 @@ export default function Banner(props: BannerComponentProps) {
       background: transparent;
       border: none;
       cursor: pointer;
+      margin-left: 4px; // makes space between CTA button and close same as close and banner border
       color: ${getColorTheme(type, 600)};
       &:hover {
         color: ${getColorTheme(type, 700)};

--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -73,6 +73,8 @@ export type BannerComponentProps = {
   CollapsibleContent?: React.FC;
 };
 
+const MAIN_COLOR_LEVEL = 600;
+
 function getIconComponentFromType(type: BannerProps['type']) {
   switch (type) {
     case 'warning':
@@ -175,9 +177,9 @@ export default function Banner(props: BannerComponentProps) {
       border: none;
       cursor: pointer;
       margin-left: 4px; // makes space between CTA button and close same as close and banner border
-      color: ${getColorTheme(type, 600)};
+      color: ${getColorTheme(type, MAIN_COLOR_LEVEL)};
       &:hover {
-        color: ${getColorTheme(type, 700)};
+        color: ${getColorTheme(type, MAIN_COLOR_LEVEL + 100)};
         background: transparent;
       }`;
   }, [type]);
@@ -191,13 +193,13 @@ export default function Banner(props: BannerComponentProps) {
             display: flex;
             color: ${intense ? 'white' : 'black'};
             background-color: ${intense
-              ? getColorTheme(type, 600)
+              ? getColorTheme(type, MAIN_COLOR_LEVEL)
               : getColorTheme(type, 100)};
             border: ${intense
               ? 'none'
               : CollapsibleContent != null
               ? `1px solid #dedede`
-              : `1px solid ${getColorTheme(type, 600)}`};
+              : `1px solid ${getColorTheme(type, MAIN_COLOR_LEVEL)}`};
             box-sizing: border-box;
             border-radius: ${CollapsibleContent != null ? '0' : '7px'};
             margin: ${spacing?.margin != null ? spacing.margin : '10px 0'};
@@ -232,7 +234,7 @@ export default function Banner(props: BannerComponentProps) {
                       ? 'white'
                       : CollapsibleContent != null
                       ? '#00008B'
-                      : getColorTheme(type, 600)};
+                      : getColorTheme(type, MAIN_COLOR_LEVEL)};
                     font-size: 1.4em;
                     line-height: 1.4em;
                     width: 30px;

--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -22,6 +22,11 @@ import {
   ColorHue,
 } from '../../definitions/colors';
 import { useUITheme } from '../theming';
+import {
+  FilledButton,
+  OutlinedButton,
+  SwissArmyButtonVariantProps,
+} from '../buttons';
 
 export type BannerProps = {
   // Banner type determines colors and icons. 'normal' has a default color but ideally should use the primary theme color
@@ -57,6 +62,8 @@ export type BannerProps = {
   fadeoutEffect?: boolean;
   setFadeoutEffect?: (newValue: boolean) => void;
   hideIcon?: boolean;
+  primaryActionButtonProps?: Omit<SwissArmyButtonVariantProps, 'themeRole'>;
+  secondaryActionButtonProps?: Omit<SwissArmyButtonVariantProps, 'themeRole'>;
 };
 
 export type BannerComponentProps = {
@@ -128,6 +135,8 @@ export default function Banner(props: BannerComponentProps) {
     fadeoutEffect,
     setFadeoutEffect,
     hideIcon = false,
+    primaryActionButtonProps,
+    secondaryActionButtonProps,
   } = banner;
 
   const [isShowMore, setIsShowMore] = useState(false);
@@ -273,6 +282,28 @@ export default function Banner(props: BannerComponentProps) {
                   </>
                 )}
               </div>
+              {secondaryActionButtonProps != null && (
+                <OutlinedButton
+                  text={secondaryActionButtonProps.text}
+                  styleOverrides={{
+                    container: {
+                      marginRight: '0.5em',
+                    },
+                  }}
+                  {...secondaryActionButtonProps}
+                />
+              )}
+              {primaryActionButtonProps != null && (
+                <FilledButton
+                  text={primaryActionButtonProps.text}
+                  styleOverrides={{
+                    container: {
+                      marginRight: '0.5em',
+                    },
+                  }}
+                  {...primaryActionButtonProps}
+                />
+              )}
               {pinned || !onClose ? null : (
                 <button
                   css={css`

--- a/packages/libs/coreui/src/components/banners/Banner.tsx
+++ b/packages/libs/coreui/src/components/banners/Banner.tsx
@@ -24,6 +24,7 @@ import {
 import { useUITheme } from '../theming';
 
 export type BannerProps = {
+  // Banner type determines colors and icons. 'normal' has a default color but ideally should use the primary theme color
   type: 'warning' | 'danger' | 'error' | 'success' | 'info' | 'normal';
   message: ReactNode;
   pinned?: boolean;
@@ -164,10 +165,11 @@ export default function Banner(props: BannerComponentProps) {
       background: transparent;
       border: none;
       cursor: pointer;
+      color: ${getColorTheme(type, 600)};
       &:hover {
-        color: ${intense ? 'black' : getColorTheme(type, 600)};
+        color: ${getColorTheme(type, 700)};
       }`;
-  }, [type, intense]);
+  }, [type]);
 
   // conditional border color and radius with the presence of CollapsibleContent
   return (
@@ -219,18 +221,19 @@ export default function Banner(props: BannerComponentProps) {
                       ? 'white'
                       : CollapsibleContent != null
                       ? '#00008B'
-                      : 'black'};
+                      : getColorTheme(type, 600)};
                     font-size: 1.4em;
                     line-height: 1.4em;
                     width: 30px;
                     text-align: center;
-                    margin-right: 5px;
+                    margin-right: 8px;
                   `}
                 />
               )}
-              <span
+              <div
                 css={css`
                   margin-right: auto;
+                  color: ${getColorTheme(type, 900)};
                 `}
               >
                 {/* showMore implementation */}
@@ -269,7 +272,7 @@ export default function Banner(props: BannerComponentProps) {
                     </button>
                   </>
                 )}
-              </span>
+              </div>
               {pinned || !onClose ? null : (
                 <button
                   css={css`

--- a/packages/libs/coreui/src/components/buttons/FilledButton/index.tsx
+++ b/packages/libs/coreui/src/components/buttons/FilledButton/index.tsx
@@ -60,7 +60,6 @@ export default function FilledButton({
     },
   };
   const theme = useUITheme();
-  console.log('filledbutton level', themeRole, theme?.palette);
   const themeStyle = useMemo<PartialButtonStyleSpec>(
     () =>
       theme && themeRole

--- a/packages/libs/coreui/src/components/buttons/FilledButton/index.tsx
+++ b/packages/libs/coreui/src/components/buttons/FilledButton/index.tsx
@@ -60,6 +60,7 @@ export default function FilledButton({
     },
   };
   const theme = useUITheme();
+  console.log('filledbutton level', themeRole, theme?.palette);
   const themeStyle = useMemo<PartialButtonStyleSpec>(
     () =>
       theme && themeRole

--- a/packages/libs/coreui/src/components/theming/types.ts
+++ b/packages/libs/coreui/src/components/theming/types.ts
@@ -17,6 +17,10 @@ export type UITheme = {
   palette: {
     primary: ColorDescriptor;
     secondary: ColorDescriptor;
+    error: ColorDescriptor;
+    warning: ColorDescriptor;
+    info: ColorDescriptor;
+    success: ColorDescriptor;
   };
   typography?: {
     headers?: {

--- a/packages/libs/coreui/src/stories/notifications/Banners.stories.tsx
+++ b/packages/libs/coreui/src/stories/notifications/Banners.stories.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import UIThemeProvider from '../../components/theming/UIThemeProvider';
-import { gray } from '../../definitions/colors';
-import { FilledButton, OutlinedButton } from '../../components/buttons';
+import { blue, error, gray, success, warning } from '../../definitions/colors';
 
 import Banner, { BannerComponentProps } from '../../components/banners/Banner';
 import Toggle from '../../components/widgets/Toggle';
@@ -17,8 +16,12 @@ const Template: Story<BannerComponentProps> = (args) => {
     <UIThemeProvider
       theme={{
         palette: {
-          primary: { hue: gray, level: 200 },
+          primary: { hue: blue, level: 600 },
           secondary: { hue: gray, level: 500 },
+          error: { hue: error, level: 600 },
+          warning: { hue: warning, level: 600 },
+          info: { hue: blue, level: 600 },
+          success: { hue: success, level: 600 },
         },
       }}
     >
@@ -866,38 +869,25 @@ export const Collapsible = (args) => {
 };
 
 // Banner with call to action buttons
-export const BannerWithCta = (args) => {
-  // set useState to close Banner
-  const [shouldShowWarning, setShouldShowWarning] = useState<boolean>(true);
-  const handleCloseWarning = () => {
-    setShouldShowWarning(false);
-  };
-
-  return (
-    <div style={{ width: '750px' }}>
-      {shouldShowWarning && (
-        <Banner
-          banner={{
-            type: 'warning',
-            message: 'This is a "warning" banner with call to action buttons.',
-            pinned: false,
-            intense: false,
-            primaryActionButtonProps: {
-              text: 'Primary Action',
-              onPress: () => {
-                alert('Primary Action Clicked!');
-              },
-            },
-            secondaryActionButtonProps: {
-              text: 'Secondary Action',
-              onPress: () => {
-                alert('Secondary Action Clicked!');
-              },
-            },
-          }}
-          onClose={handleCloseWarning}
-        />
-      )}
-    </div>
-  );
-};
+export const BannerWithCta = Template.bind({});
+BannerWithCta.args = {
+  banner: {
+    type: 'success',
+    message: 'This is a "warning" banner with call to action buttons.',
+    pinned: false,
+    intense: false,
+    primaryActionButtonProps: {
+      text: 'Primary Action',
+      onPress: () => {
+        alert('Primary Action Clicked!');
+      },
+    },
+    secondaryActionButtonProps: {
+      text: 'Secondary Action',
+      onPress: () => {
+        alert('Secondary Action Clicked!');
+      },
+    },
+  },
+  onClose: () => null,
+} as BannerComponentProps;

--- a/packages/libs/coreui/src/stories/notifications/Banners.stories.tsx
+++ b/packages/libs/coreui/src/stories/notifications/Banners.stories.tsx
@@ -3,7 +3,10 @@ import { Story, Meta } from '@storybook/react/types-6-0';
 import UIThemeProvider from '../../components/theming/UIThemeProvider';
 import { blue, error, gray, success, warning } from '../../definitions/colors';
 
-import Banner, { BannerComponentProps } from '../../components/banners/Banner';
+import Banner, {
+  BannerComponentProps,
+  BannerProps,
+} from '../../components/banners/Banner';
 import Toggle from '../../components/widgets/Toggle';
 
 export default {
@@ -869,11 +872,12 @@ export const Collapsible = (args) => {
 };
 
 // Banner with call to action buttons
-export const BannerWithCta = Template.bind({});
-BannerWithCta.args = {
+const cta2StoryTheme: BannerProps['type'] = 'success';
+export const BannerWith2CTA = Template.bind({});
+BannerWith2CTA.args = {
   banner: {
-    type: 'success',
-    message: 'This is a "warning" banner with call to action buttons.',
+    type: cta2StoryTheme,
+    message: `This is a ${cta2StoryTheme} banner with call to action buttons.`,
     pinned: false,
     intense: false,
     primaryActionButtonProps: {
@@ -890,4 +894,21 @@ BannerWithCta.args = {
     },
   },
   onClose: () => null,
+} as BannerComponentProps;
+
+const cta1StoryTheme: BannerProps['type'] = 'warning';
+export const BannerWith1CTA = Template.bind({});
+BannerWith1CTA.args = {
+  banner: {
+    type: cta1StoryTheme,
+    message: `This is a ${cta1StoryTheme} banner with a call to action button.`,
+    pinned: true,
+    intense: false,
+    primaryActionButtonProps: {
+      text: 'Take Action',
+      onPress: () => {
+        alert('Action Taken!');
+      },
+    },
+  },
 } as BannerComponentProps;

--- a/packages/libs/coreui/src/stories/notifications/Banners.stories.tsx
+++ b/packages/libs/coreui/src/stories/notifications/Banners.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import UIThemeProvider from '../../components/theming/UIThemeProvider';
 import { gray } from '../../definitions/colors';
+import { FilledButton, OutlinedButton } from '../../components/buttons';
 
 import Banner, { BannerComponentProps } from '../../components/banners/Banner';
 import Toggle from '../../components/widgets/Toggle';
@@ -861,5 +862,42 @@ export const Collapsible = (args) => {
         )}
       </div>
     </>
+  );
+};
+
+// Banner with call to action buttons
+export const BannerWithCta = (args) => {
+  // set useState to close Banner
+  const [shouldShowWarning, setShouldShowWarning] = useState<boolean>(true);
+  const handleCloseWarning = () => {
+    setShouldShowWarning(false);
+  };
+
+  return (
+    <div style={{ width: '750px' }}>
+      {shouldShowWarning && (
+        <Banner
+          banner={{
+            type: 'warning',
+            message: 'This is a "warning" banner with call to action buttons.',
+            pinned: false,
+            intense: false,
+            primaryActionButtonProps: {
+              text: 'Primary Action',
+              onPress: () => {
+                alert('Primary Action Clicked!');
+              },
+            },
+            secondaryActionButtonProps: {
+              text: 'Secondary Action',
+              onPress: () => {
+                alert('Secondary Action Clicked!');
+              },
+            },
+          }}
+          onClose={handleCloseWarning}
+        />
+      )}
+    </div>
   );
 };

--- a/packages/libs/coreui/src/stories/notifications/Banners.stories.tsx
+++ b/packages/libs/coreui/src/stories/notifications/Banners.stories.tsx
@@ -22,7 +22,7 @@ const Template: Story<BannerComponentProps> = (args) => {
           primary: { hue: blue, level: 600 },
           secondary: { hue: gray, level: 500 },
           error: { hue: error, level: 600 },
-          warning: { hue: warning, level: 600 },
+          warning: { hue: warning, level: 400 }, // level is different than 600 to test that the banner handles this appropriately
           info: { hue: blue, level: 600 },
           success: { hue: success, level: 600 },
         },

--- a/packages/libs/eda/src/index.tsx
+++ b/packages/libs/eda/src/index.tsx
@@ -54,7 +54,12 @@ import { useAttemptActionClickHandler } from '@veupathdb/study-data-access/lib/d
 import { useCoreUIFonts } from '@veupathdb/coreui/lib/hooks';
 
 // Definitions
-import { colors, H3 } from '@veupathdb/coreui';
+import { H3 } from '@veupathdb/coreui';
+import colors, {
+  error,
+  success,
+  warning,
+} from '@veupathdb/coreui/lib/definitions/colors';
 
 import './index.css';
 
@@ -127,6 +132,10 @@ wrapComponents({
                 palette: {
                   primary: { hue: colors.mutedCyan, level: 600 },
                   secondary: { hue: colors.mutedRed, level: 500 },
+                  error: { hue: error, level: 600 },
+                  warning: { hue: warning, level: 600 },
+                  info: { hue: colors.mutedCyan, level: 600 },
+                  success: { hue: success, level: 600 },
                 },
               }}
             >

--- a/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.tsx
+++ b/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.tsx
@@ -8,7 +8,11 @@ import { UserProfileFormData } from '../../../StoreModules/UserProfileStoreModul
 import { User } from '../../../Utils/WdkUser';
 import { ServiceConfig } from '../../../Service/ServiceBase';
 import CoreUIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
-import colors from '@veupathdb/coreui/lib/definitions/colors';
+import colors, {
+  error,
+  warning,
+  success,
+} from '@veupathdb/coreui/lib/definitions/colors';
 
 type UserProfileProps = Omit<
   UserFormContainerProps,
@@ -36,6 +40,10 @@ const UserProfile: React.FC<UserProfileProps> = (props) => (
       palette: {
         primary: { hue: colors.mutedCyan, level: 600 },
         secondary: { hue: colors.mutedRed, level: 500 },
+        error: { hue: error, level: 600 },
+        warning: { hue: warning, level: 600 },
+        info: { hue: colors.mutedCyan, level: 600 },
+        success: { hue: success, level: 600 },
       },
     }}
   >

--- a/packages/libs/web-common/src/components/Announcements.tsx
+++ b/packages/libs/web-common/src/components/Announcements.tsx
@@ -9,6 +9,9 @@ import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 import { ServiceConfig } from '@veupathdb/wdk-client/lib/Service/ServiceBase';
 import { makeEdaRoute } from '../routes';
 import { colors, Warning } from '@veupathdb/coreui';
+import Banner, {
+  BannerProps,
+} from '@veupathdb/coreui/lib/components/banners/Banner';
 import { SubscriptionManagementBanner } from './SubscriptionManagementBanner';
 import { BannerDismissal } from '../hooks/announcements';
 
@@ -35,7 +38,7 @@ interface SiteAnnouncement {
   dismissible?: boolean;
   dismissalDurationSeconds?: number;
   renderDisplay: (props: AnnouncementRenderProps) => React.ReactNode;
-  renderAlone?: boolean;
+  customRender?: boolean;
 }
 
 interface AnnouncementsData {
@@ -109,14 +112,27 @@ const siteAnnouncements: SiteAnnouncement[] = [
     id: 'subscription-info',
     dismissible: true,
     renderDisplay: (props: AnnouncementRenderProps) => {
+      const bannerProps: BannerProps = {
+        type: 'info',
+        message: (
+          <div style={{ fontSize: '1.2em' }}>
+            VEuPathDB now operates under a subscription model in order to remain
+            open source.{' '}
+            <Link to="/static-content/subscriptions.html">
+              Learn about our model{' '}
+            </Link>
+            or view our{' '}
+            <Link to="static-content/subscribers.html">2025 subscribers</Link>.
+          </div>
+        ),
+      };
       return (
-        <div key="subscription-info">
-          VEuPathDB now operates under a subscription model in order to stay
-          open source.
+        <div style={{ margin: '3px' }}>
+          <Banner banner={bannerProps} onClose={() => console.log('closed')} />
         </div>
       );
     },
-    renderAlone: true,
+    customRender: true,
   },
   // subscription management banner for an individual
   {
@@ -133,7 +149,7 @@ const siteAnnouncements: SiteAnnouncement[] = [
       // }
       // return null;
     },
-    renderAlone: true,
+    customRender: true,
   },
   // alpha
   {
@@ -1314,7 +1330,7 @@ export default function Announcements({
             : null;
 
           return isSiteAnnouncement(announcementData) &&
-            announcementData.renderAlone ? (
+            announcementData.customRender ? (
             display
           ) : (
             <AnnouncementContainer

--- a/packages/libs/web-common/src/components/Announcements.tsx
+++ b/packages/libs/web-common/src/components/Announcements.tsx
@@ -35,6 +35,7 @@ interface SiteAnnouncement {
   dismissible?: boolean;
   dismissalDurationSeconds?: number;
   renderDisplay: (props: AnnouncementRenderProps) => React.ReactNode;
+  renderAlone?: boolean;
 }
 
 interface AnnouncementsData {
@@ -103,17 +104,36 @@ const infoIcon = (
 // a unique id for the announcement, and a function that takes props and returns a React Element.
 // Use props as an opportunity to determine if the message should be displayed for the given context.
 const siteAnnouncements: SiteAnnouncement[] = [
-  // subscription management banner
+  // General subscription info
+  {
+    id: 'subscription-info',
+    dismissible: true,
+    renderDisplay: (props: AnnouncementRenderProps) => {
+      return (
+        <div key="subscription-info">
+          VEuPathDB now operates under a subscription model in order to stay
+          open source.
+        </div>
+      );
+    },
+    renderAlone: true,
+  },
+  // subscription management banner for an individual
   {
     id: 'subscription-management',
     dismissible: true,
     dismissalDurationSeconds: 48 * 60 * 60, // 48 hours
     renderDisplay: (props: AnnouncementRenderProps) => {
-      if (props.currentUser && props.currentUser.isGuest) {
-        return <SubscriptionManagementBanner key="subscription-management" />;
-      }
-      return null;
+      // if (props.currentUser && props.currentUser.isGuest) {
+      return (
+        <div style={{ margin: '3px' }}>
+          <SubscriptionManagementBanner key="subscription-management" />
+        </div>
+      );
+      // }
+      // return null;
     },
+    renderAlone: true,
   },
   // alpha
   {
@@ -1254,7 +1274,7 @@ export default function Announcements({
         (announcementData: SiteMessage | SiteAnnouncement) => {
           const category = announcementData.category || 'page-information';
 
-          // Currently, only announcements of category "information" are dismissible
+          // Announcements marked dismissible or those with category='information' are dismissible.
           const dismissible = isSiteAnnouncement(announcementData)
             ? announcementData.dismissible ?? category === 'information'
             : category === 'information';
@@ -1293,7 +1313,10 @@ export default function Announcements({
             ? toElement(announcementData)
             : null;
 
-          return (
+          return isSiteAnnouncement(announcementData) &&
+            announcementData.renderAlone ? (
+            display
+          ) : (
             <AnnouncementContainer
               key={announcementData.id}
               category={category}

--- a/packages/libs/web-common/src/components/Announcements.tsx
+++ b/packages/libs/web-common/src/components/Announcements.tsx
@@ -141,9 +141,14 @@ const siteAnnouncements: SiteAnnouncement[] = [
     dismissalDurationSeconds: 48 * 60 * 60, // 48 hours
     renderDisplay: (props: AnnouncementRenderProps) => {
       // if (props.currentUser && props.currentUser.isGuest) {
+      const firstName = props.currentUser.properties['firstName'];
+      const address = firstName ? `${firstName}, you` : 'You';
       return (
         <div style={{ margin: '3px' }}>
-          <SubscriptionManagementBanner key="subscription-management" />
+          <SubscriptionManagementBanner
+            key="subscription-management"
+            address={address}
+          />
         </div>
       );
       // }

--- a/packages/libs/web-common/src/components/Announcements.tsx
+++ b/packages/libs/web-common/src/components/Announcements.tsx
@@ -38,7 +38,7 @@ interface SiteAnnouncement {
   dismissible?: boolean;
   dismissalDurationSeconds?: number;
   renderDisplay: (props: AnnouncementRenderProps) => React.ReactNode;
-  customRender?: boolean;
+  renderAsIs?: boolean;
 }
 
 interface AnnouncementsData {
@@ -132,7 +132,7 @@ const siteAnnouncements: SiteAnnouncement[] = [
         </div>
       );
     },
-    customRender: true,
+    renderAsIs: true,
   },
   // subscription management banner for an individual
   {
@@ -149,7 +149,7 @@ const siteAnnouncements: SiteAnnouncement[] = [
       // }
       // return null;
     },
-    customRender: true,
+    renderAsIs: true,
   },
   // alpha
   {
@@ -1330,7 +1330,7 @@ export default function Announcements({
             : null;
 
           return isSiteAnnouncement(announcementData) &&
-            announcementData.customRender ? (
+            announcementData.renderAsIs ? (
             display
           ) : (
             <AnnouncementContainer

--- a/packages/libs/web-common/src/components/Announcements.tsx
+++ b/packages/libs/web-common/src/components/Announcements.tsx
@@ -53,6 +53,7 @@ interface AnnouncementContainerProps {
   isOpen: boolean;
   onClose: () => void;
   display: React.ReactNode;
+  renderAsIs?: boolean;
 }
 
 interface AnnouncementBannerProps {
@@ -1334,10 +1335,7 @@ export default function Announcements({
             ? toElement(announcementData)
             : null;
 
-          return isSiteAnnouncement(announcementData) &&
-            announcementData.renderAsIs ? (
-            display
-          ) : (
+          return (
             <AnnouncementContainer
               key={announcementData.id}
               category={category}
@@ -1345,6 +1343,10 @@ export default function Announcements({
               isOpen={isOpen}
               onClose={onClose}
               display={display}
+              renderAsIs={
+                isSiteAnnouncement(announcementData) &&
+                announcementData.renderAsIs
+              }
             />
           );
         }
@@ -1364,7 +1366,13 @@ function AnnouncementContainer(props: AnnouncementContainerProps) {
       ? warningIcon
       : infoIcon;
 
-  return <AnnouncementBanner {...props} icon={icon} />;
+  return props.renderAsIs &&
+    props.display &&
+    React.isValidElement(props.display) ? (
+    props.display
+  ) : (
+    <AnnouncementBanner {...props} icon={icon} />
+  );
 }
 
 /**

--- a/packages/libs/web-common/src/components/SubscriptionManagementBanner.jsx
+++ b/packages/libs/web-common/src/components/SubscriptionManagementBanner.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 import { Link } from 'react-router-dom';
 
-export function SubscriptionManagementBanner() {
+export function SubscriptionManagementBanner({ address }) {
   const message = (
     <div style={{ fontSize: '1.2em' }}>
-      <strong>You are not associated with a subscription.</strong> Please join
-      your group's subscription, or if you are a PI or group manager{' '}
+      <strong>{address} are not associated with a subscription.</strong> Please
+      join your group's subscription, or if you are a PI or group manager{' '}
       <Link to="/static-content/subscriptions.html">create a subscription</Link>
       .
     </div>

--- a/packages/libs/web-common/src/components/SubscriptionManagementBanner.jsx
+++ b/packages/libs/web-common/src/components/SubscriptionManagementBanner.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 import { Link } from 'react-router-dom';
+import { SwissArmyButtonVariantProps } from '@veupathdb/coreui/lib/components/buttons/SwissArmyButton';
 
 export function SubscriptionManagementBanner() {
   const message = (
@@ -16,6 +17,12 @@ export function SubscriptionManagementBanner() {
     type: 'warning',
     message: message,
     pinned: false,
+    primaryActionButtonProps: {
+      text: 'Join a subscribed group',
+      onPress: () => {
+        window.location.href = 'app/user/profile';
+      },
+    },
   };
 
   return (

--- a/packages/libs/web-common/src/components/SubscriptionManagementBanner.jsx
+++ b/packages/libs/web-common/src/components/SubscriptionManagementBanner.jsx
@@ -1,40 +1,29 @@
 import React from 'react';
+import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 import { Link } from 'react-router-dom';
-import FilledButton from '@veupathdb/coreui/lib/components/buttons/FilledButton';
 
 export function SubscriptionManagementBanner() {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: '16px',
-        backgroundColor: '#f8f9fa',
-        border: '1px solid #dee2e6',
-        borderRadius: '4px',
-      }}
-    >
-      <div
-        style={{
-          textAlign: 'left',
-          display: 'flex',
-          flexDirection: 'column',
-          rowGap: '8px',
-        }}
-      >
-        <div>Urgent call: First sentence goes here.</div>
-        <div>
-          Second sentence goes here. It will be longer and will have a{' '}
-          <Link to="/static-content/subscriptions.html">
-            regular link to the subscription invoicing form
-          </Link>
-          .
-        </div>
-      </div>
-      <Link to="/user/profile/#subscription">
-        <FilledButton text="Manage Subscription" />
-      </Link>
+  const message = (
+    <div style={{ fontSize: '1.2em' }}>
+      You are not associated with a subscription. Please join your group's
+      subscription, or if you are a PI or group manager{' '}
+      <Link to="/static-content/subscriptions.html">create a subscription</Link>
+      .
     </div>
+  );
+
+  const bannerProps = {
+    type: 'warning',
+    message: message,
+    pinned: false,
+  };
+
+  return (
+    <Banner
+      banner={bannerProps}
+      onClose={() => {
+        console.log('closed');
+      }}
+    />
   );
 }

--- a/packages/libs/web-common/src/components/SubscriptionManagementBanner.jsx
+++ b/packages/libs/web-common/src/components/SubscriptionManagementBanner.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 import { Link } from 'react-router-dom';
-import { SwissArmyButtonVariantProps } from '@veupathdb/coreui/lib/components/buttons/SwissArmyButton';
 
 export function SubscriptionManagementBanner() {
   const message = (
     <div style={{ fontSize: '1.2em' }}>
-      You are not associated with a subscription. Please join your group's
-      subscription, or if you are a PI or group manager{' '}
+      <strong>You are not associated with a subscription.</strong> Please join
+      your group's subscription, or if you are a PI or group manager{' '}
       <Link to="/static-content/subscriptions.html">create a subscription</Link>
       .
     </div>

--- a/packages/sites/clinepi-site/webapp/js/client/component-wrappers/Page.tsx
+++ b/packages/sites/clinepi-site/webapp/js/client/component-wrappers/Page.tsx
@@ -13,6 +13,11 @@ import UIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemePro
 import { colors } from '@veupathdb/coreui';
 import { useCoreUIFonts } from '@veupathdb/coreui/lib/hooks';
 import makeSnackbarProvider from '@veupathdb/coreui/lib/components/notifications/SnackbarProvider';
+import {
+  error,
+  success,
+  warning,
+} from '@veupathdb/coreui/lib/definitions/colors';
 
 export function Page(DefaultComponent: React.ComponentType<Props>) {
   return function ClinEpiPage(props: Props) {
@@ -27,6 +32,10 @@ export function Page(DefaultComponent: React.ComponentType<Props>) {
             palette: {
               primary: { hue: colors.mutedCyan, level: 600 },
               secondary: { hue: colors.mutedRed, level: 500 },
+              error: { hue: error, level: 600 },
+              warning: { hue: warning, level: 600 },
+              info: { hue: colors.mutedCyan, level: 600 },
+              success: { hue: success, level: 600 },
             },
           }}
         >

--- a/packages/sites/clinepi-site/webapp/js/client/component-wrappers/Page.tsx
+++ b/packages/sites/clinepi-site/webapp/js/client/component-wrappers/Page.tsx
@@ -10,14 +10,13 @@ import {
 } from '@material-ui/core';
 import { workspaceThemeOptions as MUIThemeOptions } from '@veupathdb/eda/lib/workspaceTheme';
 import UIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
-import { colors } from '@veupathdb/coreui';
-import { useCoreUIFonts } from '@veupathdb/coreui/lib/hooks';
-import makeSnackbarProvider from '@veupathdb/coreui/lib/components/notifications/SnackbarProvider';
-import {
+import colors, {
   error,
   success,
   warning,
 } from '@veupathdb/coreui/lib/definitions/colors';
+import { useCoreUIFonts } from '@veupathdb/coreui/lib/hooks';
+import makeSnackbarProvider from '@veupathdb/coreui/lib/components/notifications/SnackbarProvider';
 
 export function Page(DefaultComponent: React.ComponentType<Props>) {
   return function ClinEpiPage(props: Props) {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
@@ -38,7 +38,11 @@ import {
 import { workspaceThemeOptions as MUIThemeOptions } from '@veupathdb/eda/lib/workspaceTheme';
 
 import UIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
-import { colors } from '@veupathdb/coreui';
+import colors, {
+  error,
+  success,
+  warning,
+} from '@veupathdb/coreui/lib/definitions/colors';
 import { ErrorBoundary } from '@veupathdb/wdk-client/lib/Controllers';
 
 export const SiteHeader = () => ApiSiteHeader;
@@ -506,6 +510,10 @@ export function Page() {
               palette: {
                 primary: { hue: colors.mutedBlue, level: 600 },
                 secondary: { hue: colors.mutedRed, level: 500 },
+                error: { hue: error, level: 600 },
+                warning: { hue: warning, level: 600 },
+                info: { hue: colors.mutedCyan, level: 600 },
+                success: { hue: success, level: 600 },
               },
             }}
           >

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/componentWrappers.jsx
@@ -43,7 +43,6 @@ import colors, {
   success,
   warning,
 } from '@veupathdb/coreui/lib/definitions/colors';
-import { ErrorBoundary } from '@veupathdb/wdk-client/lib/Controllers';
 
 export const SiteHeader = () => ApiSiteHeader;
 

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/EdaNotebookParameter.tsx
@@ -1,8 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Parameter,
-  ParameterValues,
-} from '@veupathdb/wdk-client/lib/Utils/WdkModel';
+import { Parameter } from '@veupathdb/wdk-client/lib/Utils/WdkModel';
 import { WorkspaceContainer } from '@veupathdb/eda/lib/workspace/WorkspaceContainer';
 import {
   Analysis,
@@ -20,7 +17,11 @@ import {
 import { edaServiceUrl } from '@veupathdb/web-common/lib/config';
 import { DocumentationContainer } from '@veupathdb/eda/lib/core/components/docs/DocumentationContainer';
 import CoreUIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
-import colors from '@veupathdb/coreui/lib/definitions/colors';
+import colors, {
+  error,
+  warning,
+  success,
+} from '@veupathdb/coreui/lib/definitions/colors';
 import './EdaSubsetParameter.scss';
 import {
   defaultFormatParameterValue,
@@ -103,6 +104,10 @@ export function EdaNotebookParameter(props: EdaNotebookParameterProps) {
               palette: {
                 primary: { hue: colors.mutedCyan, level: 600 },
                 secondary: { hue: colors.mutedRed, level: 500 },
+                error: { hue: error, level: 600 },
+                warning: { hue: warning, level: 600 },
+                info: { hue: colors.mutedCyan, level: 600 },
+                success: { hue: success, level: 600 },
               },
             }}
           >

--- a/packages/sites/mbio-site/webapp/wdkCustomization/js/client/component-wrappers/Page.tsx
+++ b/packages/sites/mbio-site/webapp/wdkCustomization/js/client/component-wrappers/Page.tsx
@@ -16,7 +16,11 @@ import {
 import { workspaceThemeOptions as MUIThemeOptions } from '@veupathdb/eda/lib/workspaceTheme';
 import UIThemeProvider from '@veupathdb/coreui/lib/components/theming/UIThemeProvider';
 
-import { colors } from '@veupathdb/coreui';
+import colors, {
+  error,
+  warning,
+  success,
+} from '@veupathdb/coreui/lib/definitions/colors';
 import { useCoreUIFonts } from '@veupathdb/coreui/lib/hooks';
 
 export function Page(DefaultComponent: React.ComponentType<Props>) {
@@ -34,6 +38,10 @@ export function Page(DefaultComponent: React.ComponentType<Props>) {
             palette: {
               primary: { hue: colors.mutedBlue, level: 500 },
               secondary: { hue: colors.mutedRed, level: 500 },
+              error: { hue: error, level: 600 },
+              warning: { hue: warning, level: 600 },
+              info: { hue: colors.mutedCyan, level: 600 },
+              success: { hue: success, level: 600 },
             },
           }}
         >

--- a/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/packages/sites/ortho-site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -40,7 +40,11 @@ import {
 } from 'ortho-client/hooks/searchCheckboxTree';
 
 import './OrthoMCLPage.scss';
-import { colors } from '@veupathdb/coreui';
+import colors, {
+  error,
+  success,
+  warning,
+} from '@veupathdb/coreui/lib/definitions/colors';
 import { UIThemeProvider } from '@veupathdb/coreui/lib/components/theming';
 
 const cx = makeClassNameHelper('vpdb-');
@@ -93,6 +97,10 @@ export const OrthoMCLPage: FunctionComponent<Props> = (props) => {
         palette: {
           primary: { hue: colors.mutedBlue, level: 600 },
           secondary: { hue: colors.mutedRed, level: 500 },
+          error: { hue: error, level: 600 },
+          warning: { hue: warning, level: 600 },
+          info: { hue: colors.mutedBlue, level: 600 },
+          success: { hue: success, level: 600 },
         },
       }}
     >


### PR DESCRIPTION
So far i've just attacked the banner.

To make a long story short, we were halfway to creating the new banner (shown in figma mockups) when the first round of cuts happened. So we have these gorgeous mockups of banners, but hand't implemented them. This PR doesn't do all of the implementing (that should be branched from main), but adds enough for us to get rolling with the subscriptions stuff.

So far
- theme palettes should generally have warning, error, etc. colors defined, so i've added ours. This should have no effect anywhere other than the banner
- banner gets two options for call to action buttons. Primary (filled) and secondary (outlined). Both look nice with the close button :) 


One open question - currently, the banner uses specific levels (eg. 600) to set the border color and so on. This color should match the button colors. Right now it does because our theme colors are set to level 600. But in the future they may not be. So we could 1. have the banner component define it's CTA button colors using level 600 regardless (pretty nice but verbose), 2. the Button components could take a `themeLevelOffset` prop that shifts their button color 100 up or down, or 3. have the banner set its borders and such based on the theme color level instead of level 600. I like the third one best right now...
Update: Done. Now, for example, if we set the error theme to red: 400, the buttons (which listen to the 400 part), will match the banner (who now also listens to the 400 part instead of asserting it must be 600).


<img width="1061" height="187" alt="Screen Shot 2025-08-20 at 3 03 45 PM" src="https://github.com/user-attachments/assets/b75765ef-5c42-4207-83c4-e2d10fcf6d92" />

<img width="850" height="160" alt="Screen Shot 2025-08-20 at 3 11 10 PM" src="https://github.com/user-attachments/assets/83021b63-9342-4eaa-a2e2-c07d124ffd71" />


For adding the newly styled banners to the announcements, I aimed to leave alone as much as the current strategy as possible and just hijacked the rendering of the component. The idea is that now if the announcement has `renderAsIs=true`, the render method will be called outside of all the wdk announcement containers. In other words, we'll just render it as-is. 
