### PR TITLE
Add `build-forever` watch mode for library development

### DIFF
--- a/packages/configs/react-scripts/bin/react-scripts.js
+++ b/packages/configs/react-scripts/bin/react-scripts.js
@@ -5,10 +5,11 @@ import { main as compileMain } from '../scripts/compile.js';
 import { main as copyAssetsMain } from '../scripts/copy-assets.js';
 import { main as runSiteDevServer } from '../scripts/run-site-dev-server.js';
 import { main as start } from '../scripts/start.js';
+import { main as buildForeverMain } from '../scripts/build-forever.js';
 
 const script = process.argv[2];
 
-const { compile, copyAssets } = configureBuildScripts({
+const { compile, copyAssets, buildForever } = configureBuildScripts({
   srcDir: process.argv[3],
   targetDir: process.argv[4],
 });
@@ -39,6 +40,9 @@ switch (script) {
   case 'prepare':
     compile().then(copyAssets).catch(handleError);
     break;
+  case 'build-forever':
+    buildForever().catch(handleError);
+    break;
   default:
     spawn('npx', ['react-app-rewired', ...process.argv.slice(2)], {
       stdio: 'inherit',
@@ -50,6 +54,7 @@ function configureBuildScripts({ srcDir = 'src/lib', targetDir = 'lib' }) {
   return {
     compile: () => compileMain(targetDir),
     copyAssets: () => copyAssetsMain(srcDir, targetDir),
+    buildForever: () => buildForeverMain({ srcDir, targetDir }),
   };
 }
 

--- a/packages/configs/react-scripts/package.json
+++ b/packages/configs/react-scripts/package.json
@@ -28,5 +28,8 @@
   },
   "peerDependencies": {
     "react-scripts": "^5.0.0"
+  },
+  "devDependencies": {
+    "chokidar": "^4.0.3"
   }
 }

--- a/packages/configs/react-scripts/scripts/build-forever.js
+++ b/packages/configs/react-scripts/scripts/build-forever.js
@@ -1,0 +1,71 @@
+import chokidar from 'chokidar';
+import { main as compileMain } from './compile.js';
+import { main as copyAssetsMain } from './copy-assets.js';
+
+export async function main({ srcDir = 'src/lib', targetDir = 'lib' }) {
+  console.log(`🔄 Starting watch mode...`);
+  console.log(`📁 Watching: ${srcDir}`);
+  console.log(`📦 Building to: ${targetDir}`);
+
+  // Initial build
+  console.log('\n🏗️  Initial build...');
+  await compileMain(targetDir);
+  await copyAssetsMain(srcDir, targetDir);
+  console.log('✅ Initial build complete\n');
+
+  // Set up file watching with chokidar
+  let isBuilding = false;
+
+  const triggerBuild = async (path) => {
+    if (isBuilding) return;
+
+    isBuilding = true;
+    const timestamp = new Date().toLocaleTimeString();
+    console.log(`\n🔄 [${timestamp}] Change detected: ${path}`);
+
+    try {
+      console.log('🏗️  Rebuilding...');
+      await compileMain(targetDir);
+      await copyAssetsMain(srcDir, targetDir);
+      console.log('✅ Build complete\n');
+    } catch (error) {
+      console.error('❌ Build failed:', error.message);
+    } finally {
+      isBuilding = false;
+    }
+  };
+
+  // Initialize watcher
+  const watcher = chokidar.watch(srcDir, {
+    ignored: [
+      /(^|[\/\\])\../, // ignore dotfiles
+      /node_modules/, // ignore node_modules
+    ],
+    persistent: true,
+    ignoreInitial: true,
+    awaitWriteFinish: {
+      stabilityThreshold: 2000,
+      pollInterval: 500,
+    },
+  });
+
+  // Set up event handlers
+  watcher
+    .on('add', triggerBuild)
+    .on('change', triggerBuild)
+    .on('unlink', (path) => console.log(`🗑️  File removed: ${path}`))
+    .on('ready', () => {
+      console.log('👀 Watching for changes... (Press Ctrl+C to stop)\n');
+    })
+    .on('error', (error) => console.error(`❌ Watcher error: ${error}`));
+
+  // Keep process alive
+  process.stdin.resume();
+
+  // Cleanup on exit
+  process.on('SIGINT', () => {
+    console.log('\n👋 Stopping watch mode...');
+    watcher.close();
+    process.exit(0);
+  });
+}

--- a/packages/libs/blast-summary-view/package.json
+++ b/packages/libs/blast-summary-view/package.json
@@ -25,6 +25,7 @@
     "compile": "veupathdb-react-scripts compile",
     "copy-assets": "veupathdb-react-scripts copy-assets",
     "build-npm-modules": "veupathdb-react-scripts prepare",
+    "build-forever": "veupathdb-react-scripts build-forever",
     "clean": "rm -rf lib"
   },
   "eslintConfig": {

--- a/packages/libs/components/package.json
+++ b/packages/libs/components/package.json
@@ -59,6 +59,7 @@
     "build": "npm-run-all build-npm-modules",
     "build-storybook": "build-storybook -s public",
     "build-npm-modules": "veupathdb-react-scripts prepare src",
+    "build-forever": "veupathdb-react-scripts build-forever src",
     "clean": "rm -rf lib"
   },
   "eslintConfig": {

--- a/packages/libs/eda/package.json
+++ b/packages/libs/eda/package.json
@@ -45,6 +45,7 @@
     "test": "veupathdb-react-scripts test",
     "eject": "veupathdb-react-scripts eject",
     "build-npm-modules": "veupathdb-react-scripts prepare",
+    "build-forever": "veupathdb-react-scripts build-forever",
     "clean": "rm -rf lib"
   },
   "eslintConfig": {

--- a/packages/libs/multi-blast/package.json
+++ b/packages/libs/multi-blast/package.json
@@ -41,6 +41,7 @@
     "compile": "veupathdb-react-scripts compile",
     "copy-assets": "veupathdb-react-scripts copy-assets",
     "build-npm-modules": "veupathdb-react-scripts prepare",
+    "build-forever": "veupathdb-react-scripts build-forever",
     "clean": "rm -rf lib"
   },
   "eslintConfig": {

--- a/packages/libs/preferred-organisms/package.json
+++ b/packages/libs/preferred-organisms/package.json
@@ -33,6 +33,7 @@
     "compile": "vepoathdb-react-scripts compile",
     "copy-assets": "veupathdb-react-scripts copy-assets",
     "build-npm-modules": "veupathdb-react-scripts prepare",
+    "build-forever": "veupathdb-react-scripts build-forever",
     "clean": "rm -rf lib"
   },
   "eslintConfig": {

--- a/packages/libs/study-data-access/package.json
+++ b/packages/libs/study-data-access/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build-npm-modules": "veupathdb-react-scripts prepare src lib",
     "build": "veupathdb-react-scripts prepare src lib",
+    "build-forever": "veupathdb-react-scripts build-forever src",
     "clean": "rm -rf lib"
   },
   "typings": "./lib/index.d.ts",

--- a/packages/libs/user-datasets/package.json
+++ b/packages/libs/user-datasets/package.json
@@ -21,6 +21,7 @@
     "compile": "veupathdb-react-scripts compile",
     "copy-assets": "veupathdb-react-scripts copy-assets",
     "build-npm-modules": "veupathdb-react-scripts prepare",
+    "build-forever": "veupathdb-react-scripts build-forever",
     "clean": "rm -rf lib"
   },
   "eslintConfig": {

--- a/packages/libs/wdk-client/package.json
+++ b/packages/libs/wdk-client/package.json
@@ -6,7 +6,8 @@
     "test": "jest",
     "clean": "rm -rf ./lib",
     "build": "veupathdb-react-scripts prepare src",
-    "build-npm-modules": "npm-run-all build"
+    "build-npm-modules": "npm-run-all build",
+    "build-forever": "veupathdb-react-scripts build-forever src"
   },
   "repository": {
     "type": "git",

--- a/packages/libs/web-common/package.json
+++ b/packages/libs/web-common/package.json
@@ -12,6 +12,7 @@
     "generate-icons": "mkdir -p dist && icon-font-generator icons/* -o dist -n ebrc-icons -p ebrc-icon --normalize --center --csstp ./templates/icons-css.hbs",
     "build": "veupathdb-react-scripts prepare src",
     "build-npm-modules": "npm-run-all build generate-icons",
+    "build-forever": "veupathdb-react-scripts build-forever src",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "eslintConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8899,6 +8899,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@veupathdb/react-scripts@workspace:packages/configs/react-scripts"
   dependencies:
+    chokidar: ^4.0.3
     dotenv: ^10.0.0
     dotenv-expand: ^5.1.0
     fs-extra: ^9.1.0
@@ -13941,6 +13942,15 @@ __metadata:
     fsevents:
       optional: true
   checksum: 0c43e89cbf0268ef1e1f41ce8ec5233c7ba022c6f3282c2ef6530e351d42396d389a1148c5a040f291cf1f4083a4c6b2f51dad3f31c726442ea9a337de316bcf
+  languageName: node
+  linkType: hard
+
+"chokidar@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "chokidar@npm:4.0.3"
+  dependencies:
+    readdirp: ^4.0.1
+  checksum: a8765e452bbafd04f3f2fad79f04222dd65f43161488bb6014a41099e6ca18d166af613d59a90771908c1c823efa3f46ba36b86ac50b701c20c1b9908c5fe36e
   languageName: node
   linkType: hard
 
@@ -32453,6 +32463,13 @@ __metadata:
     micromatch: ^3.1.10
     readable-stream: ^2.0.2
   checksum: 3879b20f1a871e0e004a14fbf1776e65ee0b746a62f5a416010808b37c272ac49b023c47042c7b1e281cba75a449696635bc64c397ed221ea81d853a8f2ed79a
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:^4.0.1":
+  version: 4.1.2
+  resolution: "readdirp@npm:4.1.2"
+  checksum: 3242ee125422cb7c0e12d51452e993f507e6ed3d8c490bc8bf3366c5cdd09167562224e429b13e9cb2b98d4b8b2b11dc100d3c73883aa92d657ade5a21ded004
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Adds new `build-forever` command to `veupathdb-react-scripts` for continuous library development
- Provides file watching with automatic rebuild on source changes
- Added `build-forever` script to all relevant library packages

## What's New

### New `build-forever` Command
```bash
yarn workspace @veupathdb/wdk-client build-forever
yarn workspace @veupathdb/components build-forever
# etc.

Features

- File Watching: Uses chokidar for reliable cross-platform file monitoring
- Auto Rebuild: Triggers TypeScript compilation + asset copying on changes
- Debounced: Prevents build storms with stability threshold (2s)
- Smart Ignoring: Skips dotfiles and node_modules
- Build Status: Clear console output with timestamps and status indicators

Architecture

- Business logic extracted to build-forever.js script following existing patterns
- Reuses existing compile and copy-assets functionality
- Consistent with other veupathdb-react-scripts commands

Developer Workflow Improvement

Before: Manual rebuild required when developing libraries
# Edit library code...
cd packages/libs/wdk-client
yarn build-npm-modules  # Manual step every time

After: Automatic rebuild on save
yarn workspace @veupathdb/wdk-client build-forever
# Edit library code... builds happen automatically

Package Coverage

Added build-forever scripts to all veupathdb-react-scripts packages:
- ✅ @veupathdb/components
- ✅ @veupathdb/wdk-client
- ✅ @veupathdb/web-common
- ✅ @veupathdb/eda
- ✅ @veupathdb/study-data-access
- ✅ @veupathdb/blast-summary-view
- ✅ @veupathdb/multi-blast
- ✅ @veupathdb/preferred-organisms
- ✅ @veupathdb/user-datasets

Note: @veupathdb/http-utils and @veupathdb/coreui use custom build processes and don't support this feature.

Test Plan

- Test basic functionality with wdk-client package
- Test with different source directory configurations
- Verify file watching works across different file types (.ts, .tsx, .scss, etc.)
- Test error handling when builds fail
- Verify cleanup on Ctrl+C
