### PR TITLE
Suggested subscriptions update-and-submit-now approach

### DIFF
--- a/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.tsx
+++ b/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.tsx
@@ -19,11 +19,6 @@ type UserProfileProps = Omit<
   | 'onSubmit'
 > & {
   globalData: { user?: User; config?: ServiceConfig };
-  userEvents: {
-    submitProfileForm: (userData: UserProfileFormData) => void;
-    updateProfileForm: (newState: UserProfileFormData) => void;
-    resetProfileForm?: (formData: UserProfileFormData) => void;
-  };
   singleFormMode?: boolean;
 };
 

--- a/packages/libs/wdk-client/src/Views/User/Profile/UserRegistration.tsx
+++ b/packages/libs/wdk-client/src/Views/User/Profile/UserRegistration.tsx
@@ -130,7 +130,8 @@ const UserRegistration: React.FC<UserRegistrationProps> = (props) => (
       formStatus={props.formStatus}
       errorMessage={props.errorMessage}
       userEvents={{
-        updateProfileForm: props.userEvents.updateProfileForm,
+        ...props.userEvents,
+        submitProfileForm: props.userEvents.submitRegistrationForm,
       }}
       shouldHideForm={!props.globalData.user?.isGuest}
       hiddenFormMessage="You must log out before registering a new user."

--- a/packages/libs/wdk-client/src/Views/User/UserFormContainer.tsx
+++ b/packages/libs/wdk-client/src/Views/User/UserFormContainer.tsx
@@ -33,6 +33,7 @@ export interface UserFormContainerProps {
   formStatus: 'new' | 'modified' | 'pending' | 'success' | 'error';
   errorMessage?: string;
   userEvents: {
+    submitProfileForm: (userData: UserProfileFormData) => void;
     updateProfileForm: (newState: UserProfileFormData) => void;
     resetProfileForm?: (formData: UserProfileFormData) => void;
   };
@@ -82,14 +83,20 @@ function UserFormContainer(props: UserFormContainerProps) {
     onEmailFieldChange('confirmEmail', newValue);
   };
 
-  function onPropertyChange(field: string) {
+  function onPropertyChange(field: string, submitNow: boolean = false) {
     return (newValue: any): void => {
       const previousState = currentUserFormData;
-      const newProps = { ...previousState.properties, [field]: newValue };
-      props.userEvents.updateProfileForm({
+      const newUserFormData = {
         ...previousState,
-        properties: newProps,
-      });
+        properties: {
+          ...previousState.properties,
+          [field]: newValue,
+        },
+      };
+      props.userEvents.updateProfileForm(newUserFormData);
+      if (submitNow && props.userEvents.submitProfileForm) {
+        props.userEvents.submitProfileForm(newUserFormData);
+      }
     };
   }
 

--- a/packages/libs/wdk-client/src/Views/User/UserFormContainer.tsx
+++ b/packages/libs/wdk-client/src/Views/User/UserFormContainer.tsx
@@ -94,7 +94,7 @@ function UserFormContainer(props: UserFormContainerProps) {
         },
       };
       props.userEvents.updateProfileForm(newUserFormData);
-      if (submitNow && props.userEvents.submitProfileForm) {
+      if (submitNow) {
         props.userEvents.submitProfileForm(newUserFormData);
       }
     };


### PR DESCRIPTION
The `onPropertyChange` enhancement I was suggesting during our call should work, I think.

I haven't done any testing but this all compiles.

Approximate usage in the `UserSubscriptionManagement` component (to which `formStatus` and `onPropertyChange` are passed as new props) is like this

```typescript
    const handleLeaveGroup = () => {
      // Call onPropertyChange with submitNow=true for atomic update+submit operation
      onPropertyChange('subscriptionToken', true)(''); // Clear the field and submit
      setShowConfirmModal(false);
    };
```


```tsx
                <div style={{ display: 'flex', gap: '1em', marginTop: '1em' }}>
                  <SaveButton
                    formStatus={formStatus}
                    onPress={handleLeaveGroup}
                    customText={{
                      save: 'Yes, Leave',
                      saving: 'Leaving...',
                      saved: 'Left Organization'
                    }}
                    themeRole="primary"
                  />

                  <button 
                    onClick={() => setShowConfirmModal(false)}
                    style={{
                      background: '#6c757d',
                      color: 'white',
                      border: 'none',
                      padding: '0.5em 1em',
                      borderRadius: '4px'
                    }}
                  >
                    Cancel
                  </button>
                </div>
```