### PR TITLE
`subscriptionGroups` fetching refactor/deduping

### DIFF
--- a/packages/libs/wdk-client/src/Hooks/SubscriptionGroups.ts
+++ b/packages/libs/wdk-client/src/Hooks/SubscriptionGroups.ts
@@ -1,0 +1,28 @@
+import { useWdkService } from './WdkServiceHook';
+import { SubscriptionGroup } from '../Service/Mixins/OauthService';
+
+/**
+ * Hook to fetch subscription groups from the API.
+ *
+ * @returns undefined while loading, SubscriptionGroup[] when loaded, or undefined on error
+ *
+ * Usage patterns:
+ * - undefined: Still loading or API error - can show loading state
+ * - []: Successfully loaded but no groups available
+ * - SubscriptionGroup[]: Successfully loaded with groups
+ *
+ * This hook is used by:
+ * - UserAccountForm: Shows loading spinner when undefined
+ * - UserMenu: Prevents showing wrong subscription status during load
+ * - Announcements: Used for subscription-based banner logic
+ */
+export function useSubscriptionGroups(): SubscriptionGroup[] | undefined {
+  return useWdkService(
+    (wdkService) =>
+      wdkService.getSubscriptionGroups().catch((error) => {
+        console.error('Failed to fetch subscription groups:', error);
+        return undefined;
+      }),
+    []
+  );
+}

--- a/packages/libs/wdk-client/src/Views/User/UserAccountForm.tsx
+++ b/packages/libs/wdk-client/src/Views/User/UserAccountForm.tsx
@@ -10,6 +10,7 @@ import ProfileNavigationSection, {
   useCurrentProfileNavigationSection,
 } from '../../Views/User/ProfileNavigationSection';
 import { useWdkService } from '../../Hooks/WdkServiceHook';
+import { useSubscriptionGroups } from '../../Hooks/SubscriptionGroups';
 import { User, UserPreferences } from '../../Utils/WdkUser';
 import {
   SaveButton,
@@ -97,14 +98,7 @@ function UserAccountForm(props: UserAccountFormProps) {
     []
   );
 
-  const subscriptionGroups = useWdkService(
-    (wdkService) =>
-      wdkService.getSubscriptionGroups().catch((error) => {
-        console.error(error);
-        return [] as SubscriptionGroup[];
-      }),
-    []
-  );
+  const subscriptionGroups = useSubscriptionGroups();
 
   // Section switch handler
   const handleSectionChange = (

--- a/packages/libs/web-common/src/App/UserMenu/UserMenu.tsx
+++ b/packages/libs/web-common/src/App/UserMenu/UserMenu.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 import { IconAlt as Icon } from '@veupathdb/wdk-client/lib/Components';
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
-import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
+import { useSubscriptionGroups } from '@veupathdb/wdk-client/lib/Hooks/SubscriptionGroups';
 import { SubscriptionGroup } from '@veupathdb/wdk-client/lib/Service/Mixins/OauthService';
 
 import './UserMenu.scss';
@@ -35,18 +35,12 @@ const UserMenu: React.FC<UserMenuProps> = ({ user, actions }) => {
   const { isGuest, properties = {} } = user;
   const iconClass = 'user-circle' + (isGuest ? '-o' : '');
 
-  const subscriptionGroups =
-    useWdkService(
-      (wdkService) =>
-        wdkService.getSubscriptionGroups().catch((e) => {
-          console.error(e);
-          return [] as SubscriptionGroup[];
-        }),
-      []
-    ) || [];
+  const subscriptionGroups = useSubscriptionGroups();
 
+  // Don't determine subscription status while still loading
   const isSubscribed =
     !isGuest &&
+    subscriptionGroups != null &&
     subscriptionGroups.filter(
       (g: SubscriptionGroup) =>
         g.subscriptionToken === user.properties['subscriptionToken']
@@ -117,20 +111,26 @@ const UserMenu: React.FC<UserMenuProps> = ({ user, actions }) => {
             </div>
           );
         })}
-        <hr style={{ margin: '10px 0', borderColor: '#ccc' }} />
-        {isSubscribed ? (
-          <div className="UserMenu-Pane-Item">
-            <Icon fa="check-circle UserMenu-Pane-Item-Icon UserMenu-StatusIcon--success" />
-            Subscribed
-          </div>
-        ) : (
-          <Link
-            to="/user/profile/#subscription"
-            className="UserMenu-Pane-Item UserMenu-Pane-Item--interactive"
-          >
-            <Icon fa="exclamation-triangle UserMenu-Pane-Item-Icon UserMenu-StatusIcon--warning" />
-            Unsubscribed
-          </Link>
+        {subscriptionGroups ==
+        null ? // Still loading subscription data - don't show subscription status
+        null : (
+          <>
+            <hr style={{ margin: '10px 0', borderColor: '#ccc' }} />
+            {isSubscribed ? (
+              <div className="UserMenu-Pane-Item">
+                <Icon fa="check-circle UserMenu-Pane-Item-Icon UserMenu-StatusIcon--success" />
+                Subscribed
+              </div>
+            ) : (
+              <Link
+                to="/user/profile/#subscription"
+                className="UserMenu-Pane-Item UserMenu-Pane-Item--interactive"
+              >
+                <Icon fa="exclamation-triangle UserMenu-Pane-Item-Icon UserMenu-StatusIcon--warning" />
+                Unsubscribed
+              </Link>
+            )}
+          </>
         )}
       </div>
     );
@@ -139,10 +139,15 @@ const UserMenu: React.FC<UserMenuProps> = ({ user, actions }) => {
   return (
     <div className={'box UserMenu' + (!isGuest ? ' UserMenu--expanded' : '')}>
       <div className="UserMenu-IconContainer">
-        {isSubscribed && <UserCheck className="UserMenu-StatusIcon" />}
-        {!isSubscribed && (
+        {isGuest ? (
           <Icon className="UserMenu-Icon" fa={iconClass} />
-          // Replace with <UserWarn className="UserMenu-StatusIcon"/>
+        ) : subscriptionGroups == null ? (
+          // Still loading - show default user icon
+          <Icon className="UserMenu-Icon" fa={iconClass} />
+        ) : isSubscribed ? (
+          <UserCheck className="UserMenu-StatusIcon" />
+        ) : (
+          <UserWarn className="UserMenu-StatusIcon" />
         )}
       </div>
       <span

--- a/packages/libs/web-common/src/components/Announcements.tsx
+++ b/packages/libs/web-common/src/components/Announcements.tsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 
 import { Link, IconAlt } from '@veupathdb/wdk-client/lib/Components';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
+import { useSubscriptionGroups } from '@veupathdb/wdk-client/lib/Hooks/SubscriptionGroups';
 import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 import { SubscriptionGroup } from '@veupathdb/wdk-client/lib/Service/Mixins/OauthService';
@@ -27,7 +28,7 @@ interface AnnouncementsProps {
 interface AnnouncementRenderProps extends ServiceConfig {
   location: ReturnType<typeof useLocation>;
   currentUser: User;
-  subscriptionGroups: SubscriptionGroup[];
+  subscriptionGroups: SubscriptionGroup[] | undefined;
   onClose?: () => void;
 }
 
@@ -149,7 +150,12 @@ const siteAnnouncements: SiteAnnouncement[] = [
       subscriptionGroups,
       onClose,
     }: AnnouncementRenderProps) => {
-      if (!currentUser || subscriptionGroups.length === 0) return null;
+      if (
+        !currentUser ||
+        subscriptionGroups == null ||
+        subscriptionGroups.length === 0
+      )
+        return null;
 
       const isSubscribed =
         !currentUser.isGuest &&
@@ -1298,15 +1304,7 @@ function Announcements({
     [closedBanners, setClosedBanners]
   );
 
-  const subscriptionGroups: SubscriptionGroup[] =
-    useWdkService(
-      (wdkService) =>
-        wdkService.getSubscriptionGroups().catch((e) => {
-          console.error(e);
-          return [] as SubscriptionGroup[];
-        }),
-      []
-    ) || [];
+  const subscriptionGroups = useSubscriptionGroups();
 
   if (data == null) return null;
 


### PR DESCRIPTION
Made a hook and will implement react-query to avoid 3x duplicate backend calls from the user/profile page subscription tab (and 2 duplicate calls on the homepage and other pages).

@asizemore - I had to modify `UserMenu` a bit to test the four-way rendering and check that the warning icon doesn't appear momentarily. I also conditionally rendered the `<hr>` and bottom section. I'll handle any merge conflicts!