### PR TITLE
Remove state mutations which caused duplicate dataPlotter requests

### DIFF
--- a/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
+++ b/packages/libs/wdk-client/src/Views/Records/RecordTable/RecordTable.jsx
@@ -38,23 +38,26 @@ const maxColumns = 4;
 const defaultSortId = '@@defaultSortIndex@@';
 const defaultSortColumn = [{ name: defaultSortId, isDisplayable: false }];
 
-const getSortIndex = (rowData) => rowData[defaultSortId];
-
-const addDefaultSortId = (row, index) =>
-  Object.assign({}, row, { [defaultSortId]: index });
-
 const getColumns = (tableField) =>
   defaultSortColumn.concat(tableField.attributes.map((attr) => attr));
 
 const getDisplayableAttributes = (tableField) =>
   tableField.attributes.filter((attr) => attr.isDisplayable);
 
-const getOrderedData = (tableValue, tableField) =>
-  orderBy(
+const getOrderedData = (tableValue, tableField, sortIndexMap) => {
+  const orderedRows = orderBy(
     tableValue,
     tableField.clientSortSpec.map(property('itemName')),
     tableField.clientSortSpec.map(property('direction')).map(toLower)
-  ).map(addDefaultSortId);
+  );
+
+  // Store sort indices in WeakMap without mutating row objects
+  orderedRows.forEach((row, index) => {
+    sortIndexMap.set(row, index);
+  });
+
+  return orderedRows;
+};
 
 /**
  * Renders a record table
@@ -62,6 +65,9 @@ const getOrderedData = (tableValue, tableField) =>
 class RecordTable extends Component {
   constructor(props) {
     super(props);
+    // Instance-level WeakMap to store sort indices without mutating row objects
+    this.sortIndexMap = new WeakMap();
+
     this.getColumns = createSelector((props) => props.table, getColumns);
     this.getDisplayableAttributes = createSelector(
       (props) => props.table,
@@ -70,7 +76,8 @@ class RecordTable extends Component {
     this.getOrderedData = createSelector(
       (props) => props.value,
       (props) => props.table,
-      getOrderedData
+      (tableValue, tableField) =>
+        getOrderedData(tableValue, tableField, this.sortIndexMap)
     );
     this.onSort = this.onSort.bind(this);
     this.onSearchTermChange = this.onSearchTermChange.bind(this);
@@ -183,11 +190,17 @@ class RecordTable extends Component {
 
     // Manipulate rows to match Mesa properties; this really only pertains to the
     // link properties that differ between DataTable and Mesa
-    const mesaReadyRows = data.map((d) => {
-      let newData = { ...d };
+    const mesaReadyRows = data.map((d, index) => {
       const columnsWithLinks = mesaReadyColumns.filter(
         (c) => c.key in d && 'type' in c && c.type === 'link'
       );
+
+      // Only create new object if there are link columns to process
+      if (columnsWithLinks.length === 0) {
+        return d; // Return original object unchanged
+      }
+
+      let newData = { ...d };
       columnsWithLinks.forEach((col) => {
         const linkPropertyName = col.key;
         const linkObject = d[linkPropertyName];
@@ -199,6 +212,7 @@ class RecordTable extends Component {
           },
         };
       });
+      this.sortIndexMap.set(newData, index);
       return newData;
     });
 
@@ -293,7 +307,7 @@ class RecordTable extends Component {
         toolbar: isOrthologTableWithData ? false : true,
         childRow: childRow ? this.wrappedChildRow : undefined,
         className: 'wdk-DataTableContainer',
-        getRowId: getSortIndex,
+        getRowId: (rowData) => this.sortIndexMap.get(rowData),
         showCount: mesaReadyRows.length > 2,
         ...(isOrthologTableWithData
           ? {


### PR DESCRIPTION
Fixes #1460 

I didn't convert the culprit to TSX, sorry, but this should solve the issue (see issue for how to test/reproduce).

This will need extensive testing as it affects ALL RecordTable components. However, it should improve performance across the site as we were re-rendering table child rows unnecessarily due to rowData reference instability.
