### PR TITLE
Fix UserMenu issues in non-genomics sites

### DIFF
--- a/packages/libs/web-common/src/App/Header/HeaderNav.jsx
+++ b/packages/libs/web-common/src/App/Header/HeaderNav.jsx
@@ -228,7 +228,11 @@ class HeaderNav extends React.Component {
           )}
           <div style={{ display: 'flex' }}>
             <IconMenu items={iconMenu} />
-            <UserMenu webAppUrl={webAppUrl} actions={actions} user={user} />
+            {user && !user.isGuest ? (
+              <UserMenu webAppUrl={webAppUrl} user={user} actions={actions} />
+            ) : (
+              <UserMenuGuest webAppUrl={webAppUrl} actions={actions} />
+            )}
           </div>
         </div>
       </div>

--- a/packages/libs/web-common/src/App/Header/HeaderNav.scss
+++ b/packages/libs/web-common/src/App/Header/HeaderNav.scss
@@ -176,10 +176,14 @@ $red: #dd314e;
     height: 100%;
     flex-direction: row;
     align-items: center;
+    transform: unset;
 
-    .UserMenu-Icon {
+    .UserMenu-Icon,
+    .UserMenu-LoggedInIcon,
+    .UserMenu-GuestIcon {
       font-size: 25px;
       margin-right: 10px;
+      margin-bottom: 2px;
     }
   }
 


### PR DESCRIPTION
We were not conditionally rendering the `UserMenu` and new `UserMenuGuest` components properly because we had missed `HeaderNav.jsx` which seems to be different between genomics and non-genomics.

I noticed that the width-responsiveness of the ClinEpi header is broken (I'd fixed this a few weeks ago for genomics) and so I'll add this to this PR

- [ ] fix `UserMenu` issues
- [ ] fix width responsive issues of ClinEpi header (`UserMenu` disappearing at some widths)


