### PR TITLE
Improve Account page styling

### DIFF
--- a/packages/libs/wdk-client/src/Views/User/Password/UserPassword.jsx
+++ b/packages/libs/wdk-client/src/Views/User/Password/UserPassword.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { wrappable } from '../../../Utils/ComponentUtils';
 import ChangePasswordLink from '../../../Views/User/Password/ChangePasswordLink';
+import { Button } from '@material-ui/core';
 
 /**
  * This React stateless function provides a link to the password change form inside a password change fieldset
@@ -11,17 +12,9 @@ import ChangePasswordLink from '../../../Views/User/Password/ChangePasswordLink'
  */
 const UserPassword = (props) => {
   return (
-    <fieldset>
-      <legend>Password</legend>
-      <div>
-        <ChangePasswordLink
-          userEmail={props.user.email}
-          changePasswordUrl={props.wdkConfig.changePasswordUrl}
-        >
-          Change your password
-        </ChangePasswordLink>
-      </div>
-    </fieldset>
+    <Button variant="outlined" color="primary" component={ChangePasswordLink}>
+      Change your password
+    </Button>
   );
 };
 

--- a/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.scss
+++ b/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.scss
@@ -187,5 +187,6 @@
 }
 
 .UserAccountSectionContent {
-  width: 50%;
+  width: 70%;
+  max-width: 700px;
 }

--- a/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.scss
+++ b/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.scss
@@ -39,6 +39,7 @@
   &-profileForm h2 {
     margin-top: 0;
     padding-top: 0;
+    margin-bottom: 0.5em;
   }
 
   &-profileForm h3 {
@@ -50,11 +51,20 @@
     font-weight: 400;
   }
 
+  &-profileForm select {
+    font-size: 1.1em;
+  }
+
   &-profileForm i {
     color: red;
     font-size: 0.666em;
     margin-right: 0.4em;
     vertical-align: top;
+  }
+
+  &-profileForm input {
+    background-color: white !important;
+    font-size: 1.1em;
   }
 
   &-profileForm fieldset > div {

--- a/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.scss
+++ b/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.scss
@@ -32,14 +32,22 @@
     background: rgba(0, 125, 0, 0.4);
   }
 
-  &-profileForm fieldset {
-    margin-bottom: 2em;
-    display: inline;
+  &-profileForm {
+    margin-left: 2em;
   }
 
-  &-profileForm legend {
-    font-size: 14px;
-    font-weight: bold;
+  &-profileForm h2 {
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  &-profileForm h3 {
+    margin-top: 1.5em;
+    margin-bottom: 0.5em;
+  }
+
+  &-profileForm h4 {
+    font-weight: 400;
   }
 
   &-profileForm i {

--- a/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.scss
+++ b/packages/libs/wdk-client/src/Views/User/Profile/UserProfile.scss
@@ -185,3 +185,7 @@
 .wdk-DialogContent.wdk-ProfileContent {
   min-width: 400px;
 }
+
+.UserAccountSectionContent {
+  width: 50%;
+}

--- a/packages/libs/wdk-client/src/Views/User/ProfileNavigationSection.tsx
+++ b/packages/libs/wdk-client/src/Views/User/ProfileNavigationSection.tsx
@@ -90,12 +90,6 @@ const ProfileNavigationSection: React.FC<ProfileNavigationSectionProps> = ({
 
   const theme = useUITheme();
 
-  const activeSectionStyle = {
-    // Use a light version of the primary color if defined, otherwise use this nice
-    // light blue.
-    backgroundColor: theme ? theme?.palette.primary.hue[200] : '#d5eaf5',
-  };
-
   return (
     <>
       <div className="wdk-ProfileNavigationSection">

--- a/packages/libs/wdk-client/src/Views/User/UserAccountForm.tsx
+++ b/packages/libs/wdk-client/src/Views/User/UserAccountForm.tsx
@@ -163,9 +163,6 @@ function UserAccountForm(props: UserAccountFormProps) {
                 vocabulary={vocabulary}
                 highlightMissingFields={props.highlightMissingFields}
               />
-              <p>
-                <i className="fa fa-asterisk"></i> = required
-              </p>
               {saveButton}
             </form>
             {/*

--- a/packages/libs/wdk-client/src/Views/User/UserAccountForm.tsx
+++ b/packages/libs/wdk-client/src/Views/User/UserAccountForm.tsx
@@ -21,6 +21,7 @@ import { FormStatus } from '../../../../coreui/lib/components/buttons/SaveButton
 import Loading from '../../Components/Loading';
 import './UserAccountForm.scss';
 import { UserProfileFormData } from '../../StoreModules/UserProfileStoreModule';
+import { UserSecurityForm } from './UserSecurityForm';
 
 // Props interface
 export interface UserAccountFormProps {
@@ -226,7 +227,7 @@ function UserAccountForm(props: UserAccountFormProps) {
       case 'security':
         return (
           <div className="wdk-UserProfile-profileForm">
-            <UserPassword user={user} wdkConfig={wdkConfig} />
+            <UserSecurityForm {...props} />
           </div>
         );
       default:

--- a/packages/libs/wdk-client/src/Views/User/UserIdentity.jsx
+++ b/packages/libs/wdk-client/src/Views/User/UserIdentity.jsx
@@ -5,6 +5,8 @@ import TextArea from '../../Components/InputControls/TextArea';
 import TextBox from '../../Components/InputControls/TextBox';
 import SingleSelect from '../../Components/InputControls/SingleSelect';
 import { wrappable } from '../../Utils/ComponentUtils';
+import { Grid } from '@material-ui/core';
+import './Profile/UserProfile.scss';
 
 /**
  * This React stateless function displays the user identification fieldset of the form.
@@ -14,15 +16,28 @@ import { wrappable } from '../../Utils/ComponentUtils';
  */
 const UserIdentity = (props) => {
   let { user, onPropertyChange, vocabulary, highlightMissingFields } = props;
+
   return (
     <>
+      <h2>Profile</h2>
       <PrivacyPolicyLink />
-      <fieldset>
-        <legend>Identification</legend>
-        <div>
-          <label htmlFor="userEmail">
-            <i className="fa fa-asterisk"></i>Email:
-          </label>
+      <h3>Contact</h3>
+      <p>
+        <i className="fa fa-asterisk"></i> = required
+      </p>
+
+      <Grid
+        container
+        justifyContent="flex-start"
+        spacing={1}
+        alignItems="center"
+      >
+        <Grid item xs={3}>
+          <h4>
+            <i className="fa fa-asterisk"></i>Email:{' '}
+          </h4>
+        </Grid>
+        <Grid item xs={9}>
           <TextBox
             type="email"
             id="userEmail"
@@ -38,11 +53,13 @@ const UserIdentity = (props) => {
                 : ''
             }
           />
-        </div>
-        <div>
-          <label htmlFor="confirmUserEmail">
+        </Grid>
+        <Grid item xs={3}>
+          <h4>
             <i className="fa fa-asterisk"></i>Retype Email:
-          </label>
+          </h4>
+        </Grid>
+        <Grid item xs={9}>
           <TextBox
             type="email"
             id="confirmUserEmail"
@@ -58,7 +75,16 @@ const UserIdentity = (props) => {
                 : ''
             }
           />
-        </div>
+        </Grid>
+      </Grid>
+      <h3>Information</h3>
+      <Grid
+        container
+        spacing={1}
+        justifyContent="flex-start"
+        alignItems="center"
+        style={{ marginBottom: '3em' }}
+      >
         {props.propDefs
           .filter((def) => def.name !== 'subscriptionToken')
           .map((propDef) => {
@@ -73,66 +99,70 @@ const UserIdentity = (props) => {
             } = propDef;
             let value = user.properties[name] ? user.properties[name] : '';
             return (
-              <div key={name}>
-                <label htmlFor={name}>
-                  {isRequired ? <i className="fa fa-asterisk"></i> : ''}
-                  {displayName}:
-                </label>
-                {inputType === 'text' ? (
-                  <TextBox
-                    id={name}
-                    name={name}
-                    placeholder={suggestText}
-                    value={value}
-                    required={isRequired}
-                    onChange={onPropertyChange(name)}
-                    maxLength="255"
-                    size="80"
-                    className={
-                      highlightMissingFields && isRequired && !value
-                        ? 'field-required-empty'
-                        : ''
-                    }
-                  />
-                ) : inputType === 'textbox' ? (
-                  <TextArea
-                    id={name}
-                    name={name}
-                    placeholder={suggestText}
-                    value={value}
-                    required={isRequired}
-                    onChange={onPropertyChange(name)}
-                    maxLength="3000"
-                    style={{ width: '40em', height: '5em' }}
-                    className={
-                      highlightMissingFields && isRequired && !value
-                        ? 'field-required-empty'
-                        : ''
-                    }
-                  />
-                ) : inputType === 'select' ? (
-                  <SingleSelect
-                    id={name}
-                    name={name}
-                    value={value}
-                    required={isRequired}
-                    onChange={onPropertyChange(name)}
-                    items={[{ value: '', display: '--' }].concat(
-                      vocabulary[name]
-                    )}
-                    className={
-                      highlightMissingFields && isRequired && !value
-                        ? 'field-required-empty'
-                        : ''
-                    }
-                  />
-                ) : (
-                  <em>Unknown input type: {inputType}</em>
-                )}
-              </div>
+              <>
+                <Grid item key={name} xs={3}>
+                  <h4>
+                    {isRequired ? <i className="fa fa-asterisk"></i> : ''}
+                    {displayName}:
+                  </h4>
+                </Grid>
+                <Grid item xs={9} key={name + '_input'}>
+                  {inputType === 'text' ? (
+                    <TextBox
+                      id={name}
+                      name={name}
+                      placeholder={suggestText}
+                      value={value}
+                      required={isRequired}
+                      onChange={onPropertyChange(name)}
+                      maxLength="255"
+                      size="80"
+                      className={
+                        highlightMissingFields && isRequired && !value
+                          ? 'field-required-empty'
+                          : ''
+                      }
+                    />
+                  ) : inputType === 'textbox' ? (
+                    <TextArea
+                      id={name}
+                      name={name}
+                      placeholder={suggestText}
+                      value={value}
+                      required={isRequired}
+                      onChange={onPropertyChange(name)}
+                      maxLength="3000"
+                      style={{ width: '40em', height: '5em' }}
+                      className={
+                        highlightMissingFields && isRequired && !value
+                          ? 'field-required-empty'
+                          : ''
+                      }
+                    />
+                  ) : inputType === 'select' ? (
+                    <SingleSelect
+                      id={name}
+                      name={name}
+                      value={value}
+                      required={isRequired}
+                      onChange={onPropertyChange(name)}
+                      items={[{ value: '', display: '--' }].concat(
+                        vocabulary[name]
+                      )}
+                      className={
+                        highlightMissingFields && isRequired && !value
+                          ? 'field-required-empty'
+                          : ''
+                      }
+                    />
+                  ) : (
+                    <em>Unknown input type: {inputType}</em>
+                  )}
+                </Grid>
+              </>
             );
           })}
-      </fieldset>
+      </Grid>
     </>
   );
 };
@@ -161,7 +191,7 @@ export default wrappable(UserIdentity);
 
 function PrivacyPolicyLink() {
   return (
-    <div style={{ paddingBottom: '2em' }}>
+    <div>
       Review our&nbsp;
       <Link
         title="View the privacy policy in a new tab"

--- a/packages/libs/wdk-client/src/Views/User/UserIdentity.jsx
+++ b/packages/libs/wdk-client/src/Views/User/UserIdentity.jsx
@@ -32,12 +32,12 @@ const UserIdentity = (props) => {
         spacing={1}
         alignItems="center"
       >
-        <Grid item xs={2}>
+        <Grid item xs={6} md={4} lg={3}>
           <h4>
             <i className="fa fa-asterisk"></i>Email:{' '}
           </h4>
         </Grid>
-        <Grid item xs={9}>
+        <Grid item xs={6} md={8} lg={9}>
           <TextBox
             type="email"
             id="userEmail"
@@ -54,12 +54,12 @@ const UserIdentity = (props) => {
             }
           />
         </Grid>
-        <Grid item xs={2}>
+        <Grid item xs={6} md={4} lg={3}>
           <h4>
             <i className="fa fa-asterisk"></i>Retype Email:
           </h4>
         </Grid>
-        <Grid item xs={9}>
+        <Grid item xs={6} md={8} lg={9}>
           <TextBox
             type="email"
             id="confirmUserEmail"
@@ -100,13 +100,13 @@ const UserIdentity = (props) => {
             let value = user.properties[name] ? user.properties[name] : '';
             return (
               <>
-                <Grid item key={name} xs={2}>
+                <Grid item key={name} xs={6} md={4} lg={3}>
                   <h4>
                     {isRequired ? <i className="fa fa-asterisk"></i> : ''}
                     {displayName}:
                   </h4>
                 </Grid>
-                <Grid item xs={9} key={name + '_input'}>
+                <Grid item xs={6} md={8} lg={9} key={name + '_input'}>
                   {inputType === 'text' ? (
                     <TextBox
                       id={name}

--- a/packages/libs/wdk-client/src/Views/User/UserIdentity.jsx
+++ b/packages/libs/wdk-client/src/Views/User/UserIdentity.jsx
@@ -21,10 +21,10 @@ const UserIdentity = (props) => {
     <>
       <h2>Profile</h2>
       <PrivacyPolicyLink />
-      <h3>Contact</h3>
       <p>
         <i className="fa fa-asterisk"></i> = required
       </p>
+      <h3>Contact</h3>
 
       <Grid
         container
@@ -32,7 +32,7 @@ const UserIdentity = (props) => {
         spacing={1}
         alignItems="center"
       >
-        <Grid item xs={3}>
+        <Grid item xs={2}>
           <h4>
             <i className="fa fa-asterisk"></i>Email:{' '}
           </h4>
@@ -54,7 +54,7 @@ const UserIdentity = (props) => {
             }
           />
         </Grid>
-        <Grid item xs={3}>
+        <Grid item xs={2}>
           <h4>
             <i className="fa fa-asterisk"></i>Retype Email:
           </h4>
@@ -100,7 +100,7 @@ const UserIdentity = (props) => {
             let value = user.properties[name] ? user.properties[name] : '';
             return (
               <>
-                <Grid item key={name} xs={3}>
+                <Grid item key={name} xs={2}>
                   <h4>
                     {isRequired ? <i className="fa fa-asterisk"></i> : ''}
                     {displayName}:

--- a/packages/libs/wdk-client/src/Views/User/UserSecurityForm.tsx
+++ b/packages/libs/wdk-client/src/Views/User/UserSecurityForm.tsx
@@ -28,7 +28,7 @@ export const UserSecurityForm = (
   return (
     <>
       <h2>Security</h2>
-      <h3 style={{ marginTop: 0 }}>Authentication</h3>
+      <h3 style={{ paddingTop: 0 }}>Authentication</h3>
       <Grid
         container
         spacing={1}
@@ -42,6 +42,7 @@ export const UserSecurityForm = (
           <OutlinedButton
             text="Change your password"
             onPress={() => (window.location.href = url)}
+            themeRole="primary"
           />
         </Grid>
       </Grid>

--- a/packages/libs/wdk-client/src/Views/User/UserSecurityForm.tsx
+++ b/packages/libs/wdk-client/src/Views/User/UserSecurityForm.tsx
@@ -1,0 +1,50 @@
+import './Profile/UserProfile.scss';
+import { UserAccountFormProps } from './UserAccountForm';
+import Grid from '@material-ui/core/Grid/Grid';
+import { OutlinedButton } from '@veupathdb/coreui';
+
+/**
+ * React component that renders the Security tab of the Account page.
+ */
+export const UserSecurityForm = (
+  props: Pick<UserAccountFormProps, 'wdkConfig' | 'user'>
+) => {
+  const { wdkConfig, user } = props;
+
+  let url = '';
+  if (
+    wdkConfig.changePasswordUrl != null &&
+    wdkConfig.changePasswordUrl != ''
+  ) {
+    // Use prop URL and add optional query params to help it out
+    // Expect something like: changePassword.html?returnUrl={{returnUrl}}&suggestedUsername={{suggestedUsername}}
+    url = wdkConfig.changePasswordUrl
+      .replace('{{returnUrl}}', encodeURIComponent(window.location.href))
+      .replace('{{suggestedUsername}}', encodeURIComponent(user.email));
+  } else {
+    url = `/user/profile/password`;
+  }
+
+  return (
+    <>
+      <h2>Security</h2>
+      <h3 style={{ marginTop: 0 }}>Authentication</h3>
+      <Grid
+        container
+        spacing={1}
+        alignItems="center"
+        justifyContent="flex-start"
+      >
+        <Grid item xs={6}>
+          <h4>Password:</h4>
+        </Grid>
+        <Grid item xs={6}>
+          <OutlinedButton
+            text="Change your password"
+            onPress={() => (window.location.href = url)}
+          />
+        </Grid>
+      </Grid>
+    </>
+  );
+};

--- a/packages/libs/wdk-client/src/Views/User/UserSubscriptionManagement.tsx
+++ b/packages/libs/wdk-client/src/Views/User/UserSubscriptionManagement.tsx
@@ -102,216 +102,212 @@ const UserSubscriptionManagement: React.FC<UserSubscriptionManagementProps> = ({
 
   return (
     <div className="wdk-UserProfile-profileForm">
-      <fieldset>
-        <legend>My Subscription Status</legend>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.5em' }}>
-          <h4>Status: </h4>
-          {validGroup ? (
-            <>
+      <h2>Subscription</h2>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.5em' }}>
+        <h4>Status: </h4>
+        {validGroup ? (
+          <>
+            <Icon
+              fa="check-circle wdk-UserProfile-StatusIcon--success"
+              style={{ color: success[600], fontSize: '1.2em' }}
+            />
+            <h4 style={{ fontWeight: 400 }}>Subscribed</h4>
+          </>
+        ) : (
+          <>
+            {showSubscriptionProds && (
               <Icon
-                fa="check-circle wdk-UserProfile-StatusIcon--success"
-                style={{ color: success[600], fontSize: '1.2em' }}
+                fa="exclamation-triangle"
+                className="wdk-UserProfile-StatusIcon--warning"
+                style={{ color: warning[600], fontSize: '1.2em' }}
               />
-              <h4 style={{ fontWeight: 400 }}>Subscribed</h4>
-            </>
-          ) : (
-            <>
-              {showSubscriptionProds && (
-                <Icon
-                  fa="exclamation-triangle"
-                  className="wdk-UserProfile-StatusIcon--warning"
-                  style={{ color: warning[600], fontSize: '1.2em' }}
-                />
-              )}
-              <h4 style={{ fontWeight: 400 }}>Not subscribed</h4>
-            </>
-          )}
-        </div>
-        {/* Show subscription status only when form is clean (saved state) */}
-        {validGroup &&
-          (formStatus === 'new' ||
-            formStatus === 'modified' ||
-            formStatus === 'pending') && (
-            <div>
-              <h3>Group Subscription</h3>
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'max-content 1fr',
-                  rowGap: '0.5em',
-                  columnGap: '1em',
-                  alignItems: 'baseline',
-                  marginBottom: '1em',
-                  minWidth: 800, // accommodate the really long names.
-                }}
-              >
-                <h4>Group name:</h4>
-                <h4 style={{ fontWeight: 400 }}>{validGroup.groupName}</h4>
-                <h4>PI(s) or Group lead(s):</h4>
-                {validGroup.groupLeads.length > 0 ? (
-                  <h4 style={{ fontWeight: 400 }}>
-                    {validGroup.groupLeads
-                      .map((lead) => `${lead.name} (${lead.organization})`)
-                      .join(', ')}
-                  </h4>
-                ) : (
-                  <h4 style={{ fontStyle: 'italic', fontWeight: 400 }}>
-                    None provided
-                  </h4>
-                )}
-              </div>
-              <form>
-                <OutlinedButton
-                  text="Leave this group"
-                  onPress={() => setShowConfirmModal(true)}
-                  themeRole="primary"
-                />
-              </form>
-            </div>
-          )}
-
-        {/* Show group selection when no saved group OR when there are unsaved changes AND when the modal is not there */}
-        {(!validGroup || formStatus !== 'new') && !showConfirmModal && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '2em' }}>
-            <Banner
-              banner={{
-                type: 'info',
-                message: showSubscriptionProds ? (
-                  <div>
-                    If you are a PI or group manager,{' '}
-                    <Link to="/static-content/subscriptions.html">
-                      create a subscription
-                    </Link>
-                    .
-                  </div>
-                ) : (
-                  `Please note, subscriptions are not required for ${projectId}.`
-                ),
-              }}
-            />
-            <NumberedHeader
-              number={1}
-              text="Find your group or lab"
-              color={
-                theme?.palette.primary.hue[theme?.palette.primary.level] ??
-                'blue'
-              }
-            />
+            )}
+            <h4 style={{ fontWeight: 400 }}>Not subscribed</h4>
+          </>
+        )}
+      </div>
+      {/* Show subscription status only when form is clean (saved state) */}
+      {validGroup &&
+        (formStatus === 'new' ||
+          formStatus === 'modified' ||
+          formStatus === 'pending') && (
+          <div>
+            <h3>Group Subscription</h3>
             <div
               style={{
-                marginLeft: '1.5em',
+                display: 'grid',
+                gridTemplateColumns: 'max-content 1fr',
+                rowGap: '0.5em',
+                columnGap: '1em',
+                alignItems: 'baseline',
                 marginBottom: '1em',
-                marginRight: '1em',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '1em',
+                minWidth: 800, // accommodate the really long names.
               }}
             >
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'baseline',
-                  gap: '1em',
-                  marginRight: '0.5em',
-                }}
-              >
-                <h4>Group name:</h4>
-                <Select<Option, any>
-                  isMulti={false}
-                  isSearchable
-                  options={groupVocab2}
-                  value={selectedGroup}
-                  onChange={(option: ValueType<Option, any>) => {
-                    const value =
-                      option == null || Array.isArray(option)
-                        ? ''
-                        : (option as Option).value;
-                    setLocalSelection(value);
-                    onPropertyChange(tokenField)(value);
-                  }}
-                  formatOptionLabel={(option) => option.label}
-                  form="DO_NOT_SUBMIT_ON_ENTER"
-                  className="wdk-UserProfile-TypeAheadSelect"
-                  styles={{
-                    valueContainer: (provided) => ({
-                      ...provided,
-                      cursor: 'text',
-                    }),
-                    indicatorsContainer: (provided) => ({
-                      ...provided,
-                      cursor: 'pointer', // Keep dropdown arrow as pointer
-                    }),
-                  }}
-                  theme={(selectTheme) => ({
-                    ...selectTheme,
-                    colors: {
-                      ...selectTheme.colors,
-                      primary25:
-                        theme?.palette.primary.hue[200] ??
-                        selectTheme.colors.primary25,
-                      primary:
-                        theme?.palette.primary.hue[
-                          theme.palette.primary.level
-                        ] ?? selectTheme.colors.primary,
-                    },
-                  })}
-                />
-              </div>
-              <span
-                style={{
-                  fontStyle: 'italic',
-                  fontSize: '1.1em',
-                  color: colors.gray[700],
-                }}
-              >
-                Don't see your group listed? Ask your group lead or
-                administrator to{' '}
-                <Link to="/static-content/subscriptions.html">
-                  create a subscription
-                </Link>
-                .
-              </span>
-            </div>
-
-            <NumberedHeader
-              number={2}
-              text="Associate your account with your group"
-              color={
-                localSelection
-                  ? theme?.palette.primary.hue[theme?.palette.primary.level] ??
-                    'blue'
-                  : colors.gray[500]
-              }
-            />
-            <div
-              style={{
-                marginLeft: '1.5em',
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '1em',
-                marginRight: '1em',
-                color: localSelection ? colors.gray[900] : colors.gray[500],
-                fontSize: '1.2em',
-              }}
-            >
-              <span>
-                Click the Save button to associate your VEuPathDB account with
-                the group:
-              </span>
-              {selectedGroup.label && selectedGroup.label !== '--' ? (
-                <span style={{ fontWeight: 600 }}>{selectedGroup.label}</span>
+              <h4>Group name:</h4>
+              <h4 style={{ fontWeight: 400 }}>{validGroup.groupName}</h4>
+              <h4>PI(s) or Group lead(s):</h4>
+              {validGroup.groupLeads.length > 0 ? (
+                <h4 style={{ fontWeight: 400 }}>
+                  {validGroup.groupLeads
+                    .map((lead) => `${lead.name} (${lead.organization})`)
+                    .join(', ')}
+                </h4>
               ) : (
-                <span style={{ fontStyle: 'italic' }}>No group selected</span>
+                <h4 style={{ fontStyle: 'italic', fontWeight: 400 }}>
+                  None provided
+                </h4>
               )}
-              {saveButton}
             </div>
-            <span style={{ marginTop: '3em', color: colors.gray[700] }}>
-              Questions? <Link to="/contact-us">Contact us</Link> if you need
-              help joining a subscription.
-            </span>
+            <form>
+              <OutlinedButton
+                text="Leave this group"
+                onPress={() => setShowConfirmModal(true)}
+                themeRole="primary"
+              />
+            </form>
           </div>
         )}
-      </fieldset>
+
+      {/* Show group selection when no saved group OR when there are unsaved changes AND when the modal is not there */}
+      {(!validGroup || formStatus !== 'new') && !showConfirmModal && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2em' }}>
+          <Banner
+            banner={{
+              type: 'info',
+              message: showSubscriptionProds ? (
+                <div>
+                  If you are a PI or group manager,{' '}
+                  <Link to="/static-content/subscriptions.html">
+                    create a subscription
+                  </Link>
+                  .
+                </div>
+              ) : (
+                `Please note, subscriptions are not required for ${projectId}.`
+              ),
+            }}
+          />
+          <NumberedHeader
+            number={1}
+            text="Find your group or lab"
+            color={
+              theme?.palette.primary.hue[theme?.palette.primary.level] ?? 'blue'
+            }
+          />
+          <div
+            style={{
+              marginLeft: '1.5em',
+              marginBottom: '1em',
+              marginRight: '1em',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '1em',
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: '1em',
+                marginRight: '0.5em',
+              }}
+            >
+              <h4>Group name:</h4>
+              <Select<Option, any>
+                isMulti={false}
+                isSearchable
+                options={groupVocab2}
+                value={selectedGroup}
+                onChange={(option: ValueType<Option, any>) => {
+                  const value =
+                    option == null || Array.isArray(option)
+                      ? ''
+                      : (option as Option).value;
+                  setLocalSelection(value);
+                  onPropertyChange(tokenField)(value);
+                }}
+                formatOptionLabel={(option) => option.label}
+                form="DO_NOT_SUBMIT_ON_ENTER"
+                className="wdk-UserProfile-TypeAheadSelect"
+                styles={{
+                  valueContainer: (provided) => ({
+                    ...provided,
+                    cursor: 'text',
+                  }),
+                  indicatorsContainer: (provided) => ({
+                    ...provided,
+                    cursor: 'pointer', // Keep dropdown arrow as pointer
+                  }),
+                }}
+                theme={(selectTheme) => ({
+                  ...selectTheme,
+                  colors: {
+                    ...selectTheme.colors,
+                    primary25:
+                      theme?.palette.primary.hue[200] ??
+                      selectTheme.colors.primary25,
+                    primary:
+                      theme?.palette.primary.hue[theme.palette.primary.level] ??
+                      selectTheme.colors.primary,
+                  },
+                })}
+              />
+            </div>
+            <span
+              style={{
+                fontStyle: 'italic',
+                fontSize: '1.1em',
+                color: colors.gray[700],
+              }}
+            >
+              Don't see your group listed? Ask your group lead or administrator
+              to{' '}
+              <Link to="/static-content/subscriptions.html">
+                create a subscription
+              </Link>
+              .
+            </span>
+          </div>
+
+          <NumberedHeader
+            number={2}
+            text="Associate your account with your group"
+            color={
+              localSelection
+                ? theme?.palette.primary.hue[theme?.palette.primary.level] ??
+                  'blue'
+                : colors.gray[500]
+            }
+          />
+          <div
+            style={{
+              marginLeft: '1.5em',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '1em',
+              marginRight: '1em',
+              color: localSelection ? colors.gray[900] : colors.gray[500],
+              fontSize: '1.2em',
+            }}
+          >
+            <span>
+              Click the Save button to associate your VEuPathDB account with the
+              group:
+            </span>
+            {selectedGroup.label && selectedGroup.label !== '--' ? (
+              <span style={{ fontWeight: 600 }}>{selectedGroup.label}</span>
+            ) : (
+              <span style={{ fontStyle: 'italic' }}>No group selected</span>
+            )}
+          </div>
+          {saveButton}
+          <span style={{ marginTop: '3em', color: colors.gray[700] }}>
+            Questions? <Link to="/contact-us">Contact us</Link> if you need help
+            joining a subscription.
+          </span>
+        </div>
+      )}
       {/* Confirmation modal overlay */}
       <Dialog
         open={showConfirmModal}

--- a/packages/libs/wdk-client/src/Views/User/UserSubscriptionManagement.tsx
+++ b/packages/libs/wdk-client/src/Views/User/UserSubscriptionManagement.tsx
@@ -302,7 +302,7 @@ const UserSubscriptionManagement: React.FC<UserSubscriptionManagementProps> = ({
             )}
           </div>
           {saveButton}
-          <span style={{ marginTop: '3em', color: colors.gray[700] }}>
+          <span style={{ marginTop: '2em', color: colors.gray[700] }}>
             Questions? <Link to="/contact-us">Contact us</Link> if you need help
             joining a subscription.
           </span>

--- a/packages/libs/web-common/src/components/ApiApplicationSpecificProperties.jsx
+++ b/packages/libs/web-common/src/components/ApiApplicationSpecificProperties.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CheckboxList } from '@veupathdb/wdk-client/lib/Components';
+import { LinksPosition } from '@veupathdb/coreui/lib/components/inputs/checkboxes/CheckboxTree/CheckboxTree';
 import { useSelector } from 'react-redux';
 
 /**
@@ -90,16 +91,20 @@ function ApiApplicationSpecificProperties(props) {
       : EMAIL_PREFERENCE_DATA_GENOMICS;
 
   return (
-    <fieldset>
-      <legend>Preferences</legend>
+    <>
+      <h2>Preferences</h2>
+      <h3 style={{ paddingTop: 0 }}>Email notifications</h3>
       <p>Send me email alerts about new updates and features:</p>
-      <CheckboxList
-        name="emailAlerts"
-        items={emailPrefData}
-        value={emailPrefValue}
-        onChange={onEmailPreferenceChange}
-      />
-    </fieldset>
+      <div style={{ width: '400px', margin: '2em 1em' }}>
+        <CheckboxList
+          name="emailAlerts"
+          items={emailPrefData}
+          value={emailPrefValue}
+          onChange={onEmailPreferenceChange}
+          linksPosition={LinksPosition.Top}
+        />
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Resolves #1474 

So far, updated Account page so that they match the mockups.
Note that the email preferences is a wrapped component. It's not used anywhere else, though, so I propose we just unwrap it and use as-is.

To Do (still)

- [ ]  Still need to check registration page
- [ ] Subheading below Account should not show while `subscriptionGroups` is loading but we should reserve the white space.

Testing
I attempted to use a fancy responsive grid. Not sure it's super great so please test and adjust sizing as needed. 

