### PR TITLE
Safety checks on user.properties to avoid runtime error on ClinEpiDB

### DIFF
--- a/packages/libs/wdk-client/src/Utils/Subscriptions.ts
+++ b/packages/libs/wdk-client/src/Utils/Subscriptions.ts
@@ -9,11 +9,11 @@ export function userIsSubscribed(
     !user.isGuest &&
     subscriptionGroups?.find(
       (g: SubscriptionGroup) =>
-        g.subscriptionToken === user.properties['subscriptionToken']
+        g.subscriptionToken === user.properties?.['subscriptionToken']
     ) != null
   );
 }
 
 export function userIsClassParticipant(user: User): boolean {
-  return !user.isGuest && user.properties['groupType'] === 'class';
+  return !user.isGuest && user.properties?.['groupType'] === 'class';
 }


### PR DESCRIPTION
`user.properties` should never be null according to TypeScript but unfortunately it is sometimes. `UsersService.getCurrentUser` does no validation of the response.

Seems we need the check in ClinEpi and maybe the other non-genomics sites.