### PR TITLE
Clustal button styling fix. Remove CSS variable and use theme hook in code instead.

### DIFF
--- a/packages/libs/web-common/src/components/records/ClustalAlignmentForm.tsx
+++ b/packages/libs/web-common/src/components/records/ClustalAlignmentForm.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, FormEvent } from 'react';
 import { Dialog } from '@veupathdb/wdk-client/lib/Components';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
+import useUITheme from '@veupathdb/coreui/lib/components/theming/useUITheme';
 
 interface ClustalAlignmentFormProps {
   action: string;
@@ -22,6 +23,7 @@ export default function ClustalAlignmentForm({
   warnThreshold,
   blockThreshold,
 }: ClustalAlignmentFormProps) {
+  const theme = useUITheme();
   const [showModal, setShowModal] = useState(false);
   const [evaluatedWarnThreshold, setEvaluatedWarnThreshold] =
     useState<number | null>(null);
@@ -156,7 +158,9 @@ export default function ClustalAlignmentForm({
                 className="btn"
                 onClick={handleConfirm}
                 style={{
-                  backgroundColor: 'var(--coreui-color-primary)',
+                  backgroundColor: theme
+                    ? theme.palette.primary.hue[theme.palette.primary.level]
+                    : '#4D4D4D',
                   color: 'white',
                   fontWeight: 600,
                 }}


### PR DESCRIPTION
We were successfully using the emotion-provided CSS variable `--coreui-color-primary` in dev.

But for some (unknown) reason, this doesn't work in production. Presumably the webpack bundling is different or something, but whatever. Life is too short.

So we just use the theme hook instead.