### PR TITLE
Filter Browser Extension Errors from Client Error Reports

### DIFF
--- a/packages/libs/wdk-client/src/StoreModules/UnhandledErrorStoreModule.ts
+++ b/packages/libs/wdk-client/src/StoreModules/UnhandledErrorStoreModule.ts
@@ -49,6 +49,63 @@ function ignoreError(message: string): boolean {
   );
 }
 
+/**
+ * Checks if an error originates from a browser extension or third-party script.
+ * Returns true if the error should be filtered out (not reported).
+ */
+function isThirdPartyError(error: Error | string, filename?: string): boolean {
+  // Extension URL patterns
+  const extensionProtocols = [
+    'chrome-extension://',
+    'moz-extension://',
+    'safari-extension://',
+    'safari-web-extension://',
+  ];
+
+  // Check if filename contains extension protocol
+  if (filename) {
+    if (extensionProtocols.some((protocol) => filename.includes(protocol))) {
+      return true;
+    }
+    // Filter errors from non-same-origin sources
+    // Errors from our app should have relative paths or our domain
+    if (
+      filename.startsWith('http') &&
+      !filename.includes(window.location.hostname)
+    ) {
+      return true;
+    }
+  }
+
+  // Check error stack trace for extension URLs
+  if (error instanceof Error && error.stack) {
+    if (
+      extensionProtocols.some((protocol) => error.stack!.includes(protocol))
+    ) {
+      return true;
+    }
+  }
+
+  // Check error message for extension-related patterns
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  if (extensionProtocols.some((protocol) => errorMessage.includes(protocol))) {
+    return true;
+  }
+
+  // Common patterns from browser extensions
+  const extensionPatterns = [
+    '__firefox__',
+    '__chrome__',
+    '__safari__',
+    'webkit-masked-url',
+  ];
+  if (extensionPatterns.some((pattern) => errorMessage.includes(pattern))) {
+    return true;
+  }
+
+  return false;
+}
+
 export function observe(
   action$: ActionsObservable<Action>,
   state$: StateObservable<RootState>,
@@ -61,7 +118,9 @@ export function observe(
   ).pipe(
     filter((event: PromiseRejectionEvent) => {
       return (
-        !ignoreError(String(event.reason)) && !wdkService.getIsInvalidating()
+        !ignoreError(String(event.reason)) &&
+        !isThirdPartyError(event.reason) &&
+        !wdkService.getIsInvalidating()
       );
     }),
     map((event: PromiseRejectionEvent) => notifyUnhandledError(event.reason))
@@ -72,7 +131,11 @@ export function observe(
     'error'
   ).pipe(
     filter((event: ErrorEvent) => {
-      return !ignoreError(event.message) && !wdkService.getIsInvalidating();
+      return (
+        !ignoreError(event.message) &&
+        !isThirdPartyError(event.error ?? event.message, event.filename) &&
+        !wdkService.getIsInvalidating()
+      );
     }),
     map((event: ErrorEvent) => {
       return notifyUnhandledError(event.error ?? event.message);


### PR DESCRIPTION
[This is a largely Claude-generated PR.]

## Problem

We've been receiving client error reports for errors that don't originate from our application code. For example, errors related to "Zotero" (a browser extension for managing citations) have been appearing in our error logs, even though Zotero is not part of our codebase (frontend or backend).

These errors come from:
- Browser extensions (Chrome, Firefox, Safari extensions like Zotero, ad blockers, password managers, etc.)
- Third-party scripts loaded from external domains
- Cross-origin resources that fail or throw errors

This noise makes it harder to identify and fix genuine application errors.

## Solution

Added filtering logic to `UnhandledErrorStoreModule.ts` that detects and excludes third-party errors before they're reported to the server.

### Changes Made

**File:** `packages/libs/wdk-client/src/StoreModules/UnhandledErrorStoreModule.ts`

1. **New `isThirdPartyError()` function** - Detects browser extension and third-party errors by checking:
   - Extension URL protocols (`chrome-extension://`, `moz-extension://`, `safari-extension://`)
   - Cross-origin script filenames (errors from domains other than ours)
   - Stack traces containing extension URLs
   - Extension-specific patterns in error messages

2. **Updated error event listeners** - Both the promise rejection handler and global error handler now filter out third-party errors before creating error reports

### What Gets Filtered

✅ **Browser extensions** (Zotero, LastPass, Grammarly, ad blockers, etc.)
✅ **Third-party scripts** from external domains/CDNs
✅ **Cross-origin errors** that don't come from our application

### What Still Gets Reported

✅ **All genuine application errors** from our own codebase
✅ **Errors from our same-origin scripts**
✅ **All previously-filtered errors** (ResizeObserver, WebGL, etc.)

## Testing

- TypeScript compilation passes
- Build completes successfully
- No breaking changes to error reporting infrastructure
- Existing error boundary and reporting mechanisms unchanged

## Impact

After deployment, we should see a significant reduction in false-positive error reports. This will improve:
- Signal-to-noise ratio in error logs
- Ability to identify real application issues
- Server load from unnecessary error submissions

## Future Enhancements

If we identify specific extension error patterns in production logs, we can easily add them to the filtering logic.
