### PR TITLE
Debug Jenkins build error after Node v24 upgrade

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 24
           cache: yarn
       - run: yarn
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '24'
           cache: 'yarn'
       - uses: nrwl/nx-set-shas@v3.0.0
       - run: yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN apk add libstdc++
 
 # Install NodeJS as well as yarn
 RUN cd /opt \
-  && wget https://unofficial-builds.nodejs.org/download/release/v16.17.1/node-v16.17.1-linux-x64-musl.tar.gz -O node-v16.17.1-linux-x64-musl.tar.gz \
-  && tar -xf node-v16.17.1-linux-x64-musl.tar.gz \
-  && rm node-v16.17.1-linux-x64-musl.tar.gz \
-  && mv node-v16.17.1-linux-x64-musl node \
+  && wget https://unofficial-builds.nodejs.org/download/release/v24.11.0/node-v24.11.0-linux-x64-musl.tar.gz -O node-v24.11.0-linux-x64-musl.tar.gz \
+  && tar -xf node-v24.11.0-linux-x64-musl.tar.gz \
+  && rm node-v24.11.0-linux-x64-musl.tar.gz \
+  && mv node-v24.11.0-linux-x64-musl node \
   && npm i -g yarn \
   && mkdir /project
 

--- a/packages/configs/cra-template/template/.github/workflows/compile.yml
+++ b/packages/configs/cra-template/template/.github/workflows/compile.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Check TypeScript compilation
         run: |
           yarn install

--- a/packages/configs/cra-template/template/.github/workflows/npm-publish.yml
+++ b/packages/configs/cra-template/template/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Build NPM packages
         run: |
             yarn install

--- a/packages/libs/blast-summary-view/.github/workflows/compile.yml
+++ b/packages/libs/blast-summary-view/.github/workflows/compile.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Check TypeScript compilation
         run: |
           yarn install

--- a/packages/libs/blast-summary-view/.github/workflows/npm-publish.yml
+++ b/packages/libs/blast-summary-view/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Build NPM packages
         run: |
             yarn install

--- a/packages/libs/components/.github/workflows/deploy-to-gh-pages.yml
+++ b/packages/libs/components/.github/workflows/deploy-to-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install and Build 🔧
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 24
       - run: |
           yarn install
           yarn build-storybook

--- a/packages/libs/components/.github/workflows/npm-version-publish.yml
+++ b/packages/libs/components/.github/workflows/npm-version-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 24
       - run: |
           yarn install
           yarn build-npm-modules

--- a/packages/libs/coreui/.github/workflows/npm-publish.yml
+++ b/packages/libs/coreui/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - run: yarn install
       - run: yarn build-npm-modules
       - name: Store Dist Folder
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
           registry-url: https://registry.npmjs.org/
       - name: Retrieve Dist Folder
         uses: actions/download-artifact@v2

--- a/packages/libs/eda/.github/workflows/npm-version-publish-patch.yml
+++ b/packages/libs/eda/.github/workflows/npm-version-publish-patch.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 24
       - run: |
           yarn install
           yarn build-npm-modules

--- a/packages/libs/eda/.github/workflows/npm-version-publish.yml
+++ b/packages/libs/eda/.github/workflows/npm-version-publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 24
       - run: |
           yarn install
           yarn build-npm-modules

--- a/packages/libs/eda/.github/workflows/pr-check-ts.yml
+++ b/packages/libs/eda/.github/workflows/pr-check-ts.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '24'
 
       # Runs a set of commands using the runners shell
       - name: Check TypeScript compilation

--- a/packages/libs/http-utils/.github/workflows/npm-version-publish.yml
+++ b/packages/libs/http-utils/.github/workflows/npm-version-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 24
       - run: |
           yarn install
           yarn build-npm-modules

--- a/packages/libs/multi-blast/.github/workflows/compile.yml
+++ b/packages/libs/multi-blast/.github/workflows/compile.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Check TypeScript compilation
         run: |
           yarn install

--- a/packages/libs/multi-blast/.github/workflows/npm-publish.yml
+++ b/packages/libs/multi-blast/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Build NPM packages
         run: |
             yarn install

--- a/packages/libs/preferred-organisms/.github/workflows/compile.yml
+++ b/packages/libs/preferred-organisms/.github/workflows/compile.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Check TypeScript compilation
         run: |
           yarn install

--- a/packages/libs/preferred-organisms/.github/workflows/npm-publish.yml
+++ b/packages/libs/preferred-organisms/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Build NPM packages
         run: |
             yarn install

--- a/packages/libs/study-data-access/.github/workflows/npm-version-publish.yml
+++ b/packages/libs/study-data-access/.github/workflows/npm-version-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 24
       - run: |
           yarn install
           yarn build-npm-modules

--- a/packages/libs/user-datasets/.github/workflows/compile.yml
+++ b/packages/libs/user-datasets/.github/workflows/compile.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Check TypeScript compilation
         run: |
           yarn install

--- a/packages/libs/user-datasets/.github/workflows/npm-publish.yml
+++ b/packages/libs/user-datasets/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 24
       - name: Build NPM packages
         run: |
             yarn install


### PR DESCRIPTION
Updated all Node.js versions from 14/16 to 24 to match the volta and engines configuration in package.json (requires Node >=24.0.0).

Root cause: The regexp-tree dependency (used by browserslist-useragent-regexp) fails to load its generated parser module on Node 14/16, causing the error: "Cannot find module './generated/regexp-tree'"

Changes:
- Updated Dockerfile from Node 16.17.1 to 24.11.0 (fixes Jenkins builds)
- Updated .github/workflows/cache.yml from Node 14 to 24
- Updated .github/workflows/pr-check.yml from Node 14 to 24
- Updated all package workflow files from Node 14 to 24

This ensures consistent Node.js version across all build environments (local volta, GitHub Actions, and Jenkins/Docker builds).