### PR TITLE
Downgrade prettier to 2.x and removed YARN_IGNORE_PATH gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^13.2.0",
     "nx": "16.3.2",
-    "prettier": "^3.0.0"
+    "prettier": "^2.0.0"
   },
   "prettier": "@veupathdb/prettier-config",
   "browserslist": [

--- a/tools/scripts/check-package-manager.mjs
+++ b/tools/scripts/check-package-manager.mjs
@@ -27,17 +27,7 @@ const isCI = process.env.CI === 'true' || process.env.CI === '1';
 
 if (!isCI) {
   // Check for required development environment variables
-  const ignorePathSet = process.env.YARN_IGNORE_PATH === 'true' || process.env.YARN_IGNORE_PATH === '1';
   const ageGateValue = parseInt(process.env.YARN_NPM_MINIMAL_AGE_GATE || '0', 10);
-
-  if (!ignorePathSet) {
-    console.error('\x1b[31m%s\x1b[0m', '❌ Error: YARN_IGNORE_PATH is not set to true');
-    console.error('\x1b[33m%s\x1b[0m', '\nYou are likely using the bundled Yarn 3.3.1 instead of Yarn 4.12.0 via corepack.');
-    console.error('\x1b[2m%s\x1b[0m', 'Add to your shell profile (~/.bashrc, ~/.zshrc, etc.):');
-    console.error('\x1b[2m%s\x1b[0m', '  export YARN_IGNORE_PATH=true');
-    console.error('\x1b[2m%s\x1b[0m', '\nSee README.adoc "Required Environment Variables for Development" section.');
-    process.exit(1);
-  }
 
   if (ageGateValue === 0) {
     console.warn('\x1b[33m%s\x1b[0m', '⚠️  Warning: YARN_NPM_MINIMAL_AGE_GATE is not set');

--- a/yarn.lock
+++ b/yarn.lock
@@ -27305,7 +27305,7 @@ __metadata:
     husky: "npm:^8.0.3"
     lint-staged: "npm:^13.2.0"
     nx: "npm:16.3.2"
-    prettier: "npm:^3.0.0"
+    prettier: "npm:^2.0.0"
     webpack: "npm:^5.84.1"
     webpack-cli: "npm:^6.0.1"
   languageName: unknown
@@ -31113,21 +31113,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.8.7":
+"prettier@npm:^2.0.0, prettier@npm:^2.8.7":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:
     prettier: bin-prettier.js
   checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.0.0":
-  version: 3.7.1
-  resolution: "prettier@npm:3.7.1"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 10/59fa89769246d395de30dec976e0ad31c8d2fe3889733765d89398c95c2b9d6cd341553a850fe14fe187407c9bfb2262a2ab1823c6de1f0205a968e2012f0f11
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The prettier downgrade fixes the trailing comma issue.

The `YARN_IGNORE_PATH` check was removed because this looks like a bug. We stopped expecting this variable to be set in the PR here: https://github.com/VEuPathDB/web-monorepo/pull/1569 but forgot to remove the check in `tools/scripts/check-package-manager.mjs`. Should be sorted now.