### PR TITLE
Replace literal utf-8 glyph characters with escape codes

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.scss
@@ -128,10 +128,10 @@ ul.ai-topic {
   }
 
   li.ai-floater-inactive::marker {
-    content: '●  ';
+    content: '\25CF  '; /* '●  ' */
   }
   li.ai-floater-active::marker {
-    content: '▶  ';
+    content: '\25B6  '; /* '▶  ' */
   }
 }
 


### PR DESCRIPTION
This was the problem:

<img width="322" height="390" alt="image" src="https://github.com/user-attachments/assets/8a46b436-5dc7-4c23-8419-5627f7f426a9" />

It could probably be solved with server configuration (because it worked fine on production) but this is a more robust solution.

There may be other bare/literal special characters in `web-monorepo` - probably more likely code than CSS - we should keep an eye out for any issues.