### PR TITLE
Port useEntityCounts to react-query

### DIFF
--- a/packages/libs/eda/src/lib/core/hooks/entityCounts.ts
+++ b/packages/libs/eda/src/lib/core/hooks/entityCounts.ts
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import { Filter } from '../types/filter';
 import {
   useStudyEntities,
@@ -27,23 +26,13 @@ export function useEntityCounts(filters?: Filter[]) {
       return {
         [STUB_ENTITY.id]: 0,
       };
+    // Errors propagate to react-query's retry/error handling via useCachedPromise
     const countsEntries = await Promise.all(
       entities.map(
         (entity): Promise<[string, number]> =>
           subsettingClient
             .getEntityCount(id, entity.id, debouncedFilters ?? [])
-            .then(
-              ({ count }) => [entity.id, count],
-              (error) => {
-                console.warn(
-                  'Could not load count for entity',
-                  entity.id,
-                  entity.displayName
-                );
-                console.error(error);
-                return [entity.id, 0];
-              }
-            )
+            .then(({ count }) => [entity.id, count])
       )
     );
     return Object.fromEntries(countsEntries);


### PR DESCRIPTION
I noticed in the notebook, 28 requests to the entity counts endpoint were made, many failing. Only 2 were actually needed. `useCachedPromise` which wraps `useQuery` from `react-query` solves this I think. Needs proper testing throughout EDA though. Hence the separate PR so we can undo the change more easily later. Going to merge soon but leaving this on the radar.

Also removed the error fallback to zero counts. This was causing problems in the notebook. Zero counts were gating compute buttons.