### PR TITLE
Volcano plot: effect direction filter + review step improvements

### DIFF
--- a/packages/libs/components/src/plots/VolcanoPlot.tsx
+++ b/packages/libs/components/src/plots/VolcanoPlot.tsx
@@ -104,6 +104,9 @@ export interface VolcanoPlotProps {
    * at which points can be plotted. This information will also be shown in tooltips for floored points.
    */
   statisticsFloors?: StatisticsFloors;
+  /** Controls which directions of effect are highlighted. 'up only' hides the negative threshold line;
+   * 'down only' hides the positive threshold line. Defaults to 'up and down'. */
+  effectDirection?: 'up and down' | 'up only' | 'down only';
 }
 
 const EmptyVolcanoPlotStats: VolcanoPlotStats = [];
@@ -224,6 +227,7 @@ function VolcanoPlot(props: VolcanoPlotProps, ref: Ref<PlotRef>) {
     showSpinner = false,
     rawDataMinMaxValues,
     statisticsFloors = DefaultStatisticsFloors,
+    effectDirection = 'up and down',
   } = props;
 
   // Use ref forwarding to enable screenshotting of the plot for thumbnail versions.
@@ -336,8 +340,10 @@ function VolcanoPlot(props: VolcanoPlotProps, ref: Ref<PlotRef>) {
    * Check whether each threshold line is within the graph's axis ranges so we can
    * prevent the line from rendering outside the graph.
    */
-  const showNegativeFoldChangeThresholdLine = -effectSizeThreshold > xAxisMin;
-  const showPositiveFoldChangeThresholdLine = effectSizeThreshold < xAxisMax;
+  const showNegativeFoldChangeThresholdLine =
+    effectDirection !== 'up only' && -effectSizeThreshold > xAxisMin;
+  const showPositiveFoldChangeThresholdLine =
+    effectDirection !== 'down only' && effectSizeThreshold < xAxisMax;
   const showSignificanceThresholdLine =
     -Math.log10(Number(significanceThreshold)) > yAxisMin &&
     -Math.log10(Number(significanceThreshold)) < yAxisMax;

--- a/packages/libs/eda/src/lib/core/components/FilterChipList.tsx
+++ b/packages/libs/eda/src/lib/core/components/FilterChipList.tsx
@@ -3,7 +3,8 @@ import { StudyEntity } from '..';
 import { makeStyles } from '@material-ui/core/styles';
 import { Filter } from '../types/filter';
 import { findEntityAndVariable } from '../utils/study-metadata';
-import { ReactNode, Fragment } from 'react';
+import { formatFilterValue } from '../utils/filter-display';
+import { ReactNode } from 'react';
 import { VariableLink, VariableLinkConfig } from './VariableLink';
 import { colors, Warning } from '@veupathdb/coreui';
 
@@ -50,50 +51,10 @@ export default function FilterChipList(props: Props) {
             findEntityAndVariable(props.entities, filter) ?? {};
 
           if (entity && variable) {
-            // The string to be displayed for the filter's value
-            let filterValueDisplay: ReactNode;
-
-            // Set filterValueDisplay based on the filter's type
-            switch (filter.type) {
-              case 'stringSet':
-                filterValueDisplay = filter.stringSet.join(' | ');
-                break;
-              case 'numberSet':
-                filterValueDisplay = filter.numberSet.join(' | ');
-                break;
-              case 'dateSet':
-                filterValueDisplay = filter.dateSet.join(' | ');
-                break;
-              case 'numberRange':
-                filterValueDisplay = `from ${filter.min} to ${filter.max}, inclusive`;
-                break;
-              case 'dateRange':
-                filterValueDisplay = `from ${filter.min.split('T')[0]} to ${
-                  filter.max.split('T')[0]
-                }, inclusive`;
-                break;
-              case 'multiFilter':
-                filterValueDisplay = filter.subFilters
-                  .map((subFilter) => {
-                    const entAndVar = findEntityAndVariable(props.entities, {
-                      entityId: filter.entityId,
-                      variableId: subFilter.variableId,
-                    });
-                    if (entAndVar == null) return '';
-                    return `${
-                      entAndVar.variable.displayName
-                    } = ${subFilter.stringSet.join(' | ')}`;
-                  })
-                  .flatMap((text, index) => (
-                    <Fragment key={`filter-chip-multivalue-${text}`}>
-                      {text}
-                      {index < filter.subFilters.length ? <br /> : null}
-                    </Fragment>
-                  ));
-                break;
-              default:
-                filterValueDisplay = '';
-            }
+            const filterValueDisplay: ReactNode = formatFilterValue(
+              filter,
+              props.entities
+            );
 
             const tooltipText = (
               <>

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -27,6 +27,7 @@ import { useVizConfig } from '../../../hooks/visualizations';
 import { createVisualizationPlugin } from '../VisualizationPlugin';
 import LabelledGroup from '@veupathdb/components/lib/components/widgets/LabelledGroup';
 import { NumberInput } from '@veupathdb/components/lib/components/widgets/NumberAndDateInputs';
+import RadioButtonGroup from '@veupathdb/components/lib/components/widgets/RadioButtonGroup';
 
 import { LayoutOptions, TitleOptions } from '../../layouts/types';
 import { RequestOptions } from '../options/types';
@@ -121,6 +122,11 @@ export const VolcanoPlotConfig = t.partial({
   markerBodyOpacity: t.number,
   independentAxisRange: NumberRange,
   dependentAxisRange: NumberRange,
+  effectDirection: t.union([
+    t.literal('up and down'),
+    t.literal('up only'),
+    t.literal('down only'),
+  ]),
 });
 
 export interface VolcanoPlotOptions
@@ -335,17 +341,27 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
               pointID.split('.')[0],
               entities
             );
+          let sigColor = assignSignificanceColor(
+            Number(d.effectSize),
+            Number(d.pValue),
+            significanceThreshold,
+            effectSizeThreshold,
+            significanceColors
+          );
+          const effectDirection = vizConfig.effectDirection ?? 'up and down';
+          if (effectDirection === 'up only' && Number(d.effectSize) < 0) {
+            sigColor = significanceColors['inconclusive'];
+          } else if (
+            effectDirection === 'down only' &&
+            Number(d.effectSize) > 0
+          ) {
+            sigColor = significanceColors['inconclusive'];
+          }
           return {
             ...remainingProperties,
             pointIDs: pointID ? [pointID] : undefined,
             displayLabels: displayLabel ? [displayLabel] : undefined,
-            significanceColor: assignSignificanceColor(
-              Number(d.effectSize),
-              Number(d.pValue),
-              significanceThreshold,
-              effectSizeThreshold,
-              significanceColors
-            ),
+            significanceColor: sigColor,
           };
         })
         // Sort data in ascending order for tooltips to work most effectively
@@ -398,6 +414,7 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
     significanceThreshold,
     effectSizeThreshold,
     entities,
+    vizConfig.effectDirection,
   ]);
 
   // For the legend, we need the counts of the data
@@ -492,6 +509,7 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
     independentAxisRange,
     dependentAxisRange,
     rawDataMinMaxValues,
+    effectDirection: vizConfig.effectDirection ?? 'up and down',
     /**
      * As sophisticated aesthetes, let's specify axis ranges for the empty viz placeholder
      */
@@ -737,6 +755,8 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
         .memberPlural
     ) || capitalize(options?.pointsDisplayNamePlural);
 
+  const effectDirection = vizConfig.effectDirection ?? 'up and down';
+
   const legendNode = finalData && countsData && (
     <PlotLegend
       type="list"
@@ -750,22 +770,30 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
           hasData: true,
           markerColor: significanceColors['inconclusive'],
         },
-        {
-          label: `Up in ${computationConfiguration?.comparator?.groupB
-            ?.map((entry: { label: string }) => entry.label)
-            .join(', ')} (${countsData[significanceColors['high']]})`,
-          marker: 'circle',
-          hasData: true,
-          markerColor: significanceColors['high'],
-        },
-        {
-          label: `Up in ${computationConfiguration?.comparator?.groupA
-            ?.map((entry: { label: string }) => entry.label)
-            .join(', ')} (${countsData[significanceColors['low']]})`,
-          marker: 'circle',
-          hasData: true,
-          markerColor: significanceColors['low'],
-        },
+        ...(effectDirection !== 'down only'
+          ? [
+              {
+                label: `Up in ${computationConfiguration?.comparator?.groupB
+                  ?.map((entry: { label: string }) => entry.label)
+                  .join(', ')} (${countsData[significanceColors['high']]})`,
+                marker: 'circle' as const,
+                hasData: true,
+                markerColor: significanceColors['high'],
+              },
+            ]
+          : []),
+        ...(effectDirection !== 'up only'
+          ? [
+              {
+                label: `Up in ${computationConfiguration?.comparator?.groupA
+                  ?.map((entry: { label: string }) => entry.label)
+                  .join(', ')} (${countsData[significanceColors['low']]})`,
+                marker: 'circle' as const,
+                hasData: true,
+                markerColor: significanceColors['low'],
+              },
+            ]
+          : []),
       ]}
       showCheckbox={false}
     />
@@ -779,24 +807,37 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       {!hideInputsAndControls && (
-        <LabelledGroup label="Threshold lines" alignChildrenHorizontally={true}>
-          <NumberInput
-            onValueChange={(newValue?: NumberOrDate) => {
-              updateVizConfig({ effectSizeThreshold: Number(newValue) });
-              options?.inputSnackbar &&
-                typeof newValue === 'number' &&
-                options.inputSnackbar(
-                  enqueueSnackbar,
-                  'effectSizeThreshold',
-                  newValue
-                );
-            }}
-            label={finalData?.effectSizeLabel ?? 'Effect Size'}
-            minValue={0}
-            value={vizConfig.effectSizeThreshold ?? DEFAULT_ES_THRESHOLD}
-            containerStyles={{ marginRight: 10 }}
-          />
-
+        <LabelledGroup label="Threshold lines">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+            <NumberInput
+              onValueChange={(newValue?: NumberOrDate) => {
+                updateVizConfig({ effectSizeThreshold: Number(newValue) });
+                options?.inputSnackbar &&
+                  typeof newValue === 'number' &&
+                  options.inputSnackbar(
+                    enqueueSnackbar,
+                    'effectSizeThreshold',
+                    newValue
+                  );
+              }}
+              label={finalData?.effectSizeLabel ?? 'Effect Size'}
+              minValue={0}
+              value={vizConfig.effectSizeThreshold ?? DEFAULT_ES_THRESHOLD}
+            />
+            <RadioButtonGroup
+              label="Effect direction"
+              selectedOption={vizConfig.effectDirection ?? 'up and down'}
+              options={['up and down', 'up only', 'down only']}
+              onOptionSelected={(newValue) =>
+                updateVizConfig({
+                  effectDirection:
+                    newValue as VolcanoPlotConfig['effectDirection'],
+                })
+              }
+              buttonColor="primary"
+              labelStyles={{ fontSize: '0.8125rem' }}
+            />
+          </div>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
             <NumberInput
               label="P-value"
@@ -812,10 +853,9 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
               }}
               minValue={0}
               value={vizConfig.significanceThreshold ?? DEFAULT_SIG_THRESHOLD}
-              containerStyles={{ marginLeft: 10 }}
               step={0.001}
             />
-            <div style={{ marginLeft: '10px' }}>
+            <div>
               <i>
                 Threshold uses raw p-value. Adjusted p-value shown in tooltips.
               </i>

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -828,6 +828,11 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
               label="Effect direction"
               selectedOption={vizConfig.effectDirection ?? 'up and down'}
               options={['up and down', 'up only', 'down only']}
+              optionLabels={[
+                'Up- or down-regulated',
+                'Up-regulated only',
+                'Down-regulated only',
+              ]}
               onOptionSelected={(newValue) =>
                 updateVizConfig({
                   effectDirection:

--- a/packages/libs/eda/src/lib/core/utils/filter-display.tsx
+++ b/packages/libs/eda/src/lib/core/utils/filter-display.tsx
@@ -1,0 +1,51 @@
+import { Fragment, ReactNode } from 'react';
+import { Filter } from '../types/filter';
+import { StudyEntity } from '../types/study';
+import { findEntityAndVariable } from './study-metadata';
+
+/**
+ * Formats a filter's value as a ReactNode, resolving variable display names
+ * from the provided entities array. Used in both FilterChipList tooltips and
+ * read-only review summaries.
+ */
+export function formatFilterValue(
+  filter: Filter,
+  entities: StudyEntity[]
+): ReactNode {
+  switch (filter.type) {
+    case 'stringSet':
+      return filter.stringSet.join(' | ');
+    case 'numberSet':
+      return filter.numberSet.join(' | ');
+    case 'dateSet':
+      return filter.dateSet.join(' | ');
+    case 'numberRange':
+      return `from ${filter.min} to ${filter.max}, inclusive`;
+    case 'dateRange':
+      return `from ${filter.min.split('T')[0]} to ${
+        filter.max.split('T')[0]
+      }, inclusive`;
+    case 'multiFilter':
+      return (
+        <>
+          {filter.subFilters.map((subFilter, index) => {
+            const entAndVar = findEntityAndVariable(entities, {
+              entityId: filter.entityId,
+              variableId: subFilter.variableId,
+            });
+            const label =
+              entAndVar?.variable.displayName ?? subFilter.variableId;
+            const value = subFilter.stringSet.join(' | ');
+            return (
+              <Fragment key={subFilter.variableId}>
+                {index > 0 && <br />}
+                {label} = {value}
+              </Fragment>
+            );
+          })}
+        </>
+      );
+    default:
+      return '';
+  }
+}

--- a/packages/libs/eda/src/lib/notebook/components/ReviewCard.tsx
+++ b/packages/libs/eda/src/lib/notebook/components/ReviewCard.tsx
@@ -66,7 +66,13 @@ export function ReviewCard({
   );
 }
 
-export function ReviewRow({ label, value }: { label: string; value: string }) {
+export function ReviewRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: ReactNode;
+}) {
   return (
     <div style={{ display: 'flex', gap: '0.5rem' }}>
       <span style={{ color: colors.grey[600], minWidth: '10rem' }}>

--- a/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
+++ b/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
@@ -1,7 +1,12 @@
 import { colors } from '@material-ui/core';
 import { plugins } from '../../core/components/computations/plugins';
 import { VolcanoPlotConfig } from '../../core/components/visualizations/implementations/VolcanoPlotVisualization';
-import { useFindEntityAndVariable } from '../../core/hooks/workspace';
+import {
+  useFindEntityAndVariable,
+  useStudyEntities,
+} from '../../core/hooks/workspace';
+import { findEntityAndVariable } from '../../core/utils/study-metadata';
+import { formatFilterValue } from '../../core/utils/filter-display';
 import { DifferentialExpressionConfig } from '../../core/types/apps';
 import { AnalysisState, Filter } from '../../core';
 import { TextCellContext } from '../Types';
@@ -56,16 +61,17 @@ export function DifferentialAnalysisReviewContent({
 
   const filters =
     (analysisState?.analysis?.descriptor?.subset?.descriptor as Filter[]) ?? [];
-  const findEntityAndVariable = useFindEntityAndVariable(filters);
+  const entities = useStudyEntities(filters);
+  const findEntityAndVariableByDescriptor = useFindEntityAndVariable(filters);
 
   const identifierVarInfo = deConfig?.identifierVariable
-    ? findEntityAndVariable(deConfig.identifierVariable)
+    ? findEntityAndVariableByDescriptor(deConfig.identifierVariable)
     : undefined;
   const valueVarInfo = deConfig?.valueVariable
-    ? findEntityAndVariable(deConfig.valueVariable)
+    ? findEntityAndVariableByDescriptor(deConfig.valueVariable)
     : undefined;
   const comparatorVarInfo = deConfig?.comparator?.variable
-    ? findEntityAndVariable(deConfig.comparator.variable)
+    ? findEntityAndVariableByDescriptor(deConfig.comparator.variable)
     : undefined;
 
   const hasExpressionData = identifierVarInfo != null && valueVarInfo != null;
@@ -136,6 +142,22 @@ export function DifferentialAnalysisReviewContent({
           }
         />
       </ReviewCard>
+
+      {filters.length > 0 && (
+        <ReviewCard title="Subset filters">
+          {filters.map((filter) => {
+            const ev = findEntityAndVariable(entities, filter);
+            if (!ev) return null;
+            return (
+              <ReviewRow
+                key={`${filter.entityId}/${filter.variableId}`}
+                label={`${ev.entity.displayName}: ${ev.variable.displayName}`}
+                value={formatFilterValue(filter, entities)}
+              />
+            );
+          })}
+        </ReviewCard>
+      )}
 
       <ReviewCard
         title="Group Comparison"

--- a/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
+++ b/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
@@ -30,6 +30,7 @@ interface DifferentialAnalysisReviewContentProps extends TextCellContext {
   sharedInputsCellId?: string;
   computeCellId?: string;
   volcanoCellId?: string;
+  dataEntityDisplayName?: string;
 }
 
 export function DifferentialAnalysisReviewContent({
@@ -42,6 +43,7 @@ export function DifferentialAnalysisReviewContent({
   sharedInputsCellId = 'de_shared_inputs',
   computeCellId = 'de_deseq2_compute',
   volcanoCellId = 'de_volcano',
+  dataEntityDisplayName = 'Sample',
 }: DifferentialAnalysisReviewContentProps) {
   const deComputation = analysisState?.analysis?.descriptor.computations.find(
     (c) => c.descriptor.type === 'differentialexpression'
@@ -144,7 +146,7 @@ export function DifferentialAnalysisReviewContent({
       </ReviewCard>
 
       {filters.length > 0 && (
-        <ReviewCard title="Subset filters">
+        <ReviewCard title={`${dataEntityDisplayName} Filters`}>
           {filters.map((filter) => {
             const ev = findEntityAndVariable(entities, filter);
             if (!ev) return null;

--- a/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
+++ b/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
@@ -208,7 +208,7 @@ export function DifferentialAnalysisReviewContent({
               ? 'Up-regulated only'
               : volcanoPlotConfig?.effectDirection === 'down only'
               ? 'Down-regulated only'
-              : 'Up- and down-regulated'
+              : 'Up- or down-regulated'
           }
         />
         {volcanoStep && (

--- a/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
+++ b/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
@@ -177,7 +177,16 @@ export function DifferentialAnalysisReviewContent({
           label="p-value ≤"
           value={String(volcanoPlotConfig?.significanceThreshold ?? '—')}
         />
-        <ReviewRow label="Direction" value="Up and down regulated" />
+        <ReviewRow
+          label="Direction"
+          value={
+            volcanoPlotConfig?.effectDirection === 'up only'
+              ? 'Up-regulated only'
+              : volcanoPlotConfig?.effectDirection === 'down only'
+              ? 'Down-regulated only'
+              : 'Up- and down-regulated'
+          }
+        />
         {volcanoStep && (
           <p
             style={{


### PR DESCRIPTION
Adds an "up only" / "down only" / "up and down" radio button to the volcano plot threshold controls, allowing users to restrict results to one direction of differential expression. The selected direction is reflected in the plot (threshold lines, point colouring, legend) and summarised in the review step.

**Note:** backend PR https://github.com/VEuPathDB/ApiCommonWebService/pull/18 

Also in this PR:
- **Sample Filters section** added to the DE review step, showing any active subset filters with human-readable values
- `formatFilterValue` extracted into a shared utility (`core/utils/filter-display.tsx`), removing duplicated switch logic from `FilterChipList`
- `ReviewRow` now accepts `ReactNode` values (needed for multi-filter display)
- `dataEntityDisplayName` prop on `DifferentialAnalysisReviewContent` (default: `"Sample"`) controls the filter section heading, avoiding the technical term "Subset"

## Screenshots

### Radio button and plot
<img width="1209" height="737" alt="image" src="https://github.com/user-attachments/assets/575a9183-d1e9-48a4-a16e-7056633312a7" />

### Review section
<img width="1274" height="630" alt="image" src="https://github.com/user-attachments/assets/745c734e-e312-4401-a8e1-d629b37145ed" />