### PR TITLE
Add condition to creating gene PK values; no longer always has project_id (in UniDB)

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/records/AiExpressionSummary.tsx
@@ -505,11 +505,16 @@ function useAiExpressionSummary(
       if (!isGenomicsService(wdkService)) throw new Error('nasty');
       if (pollingCounter < 0) return undefined;
       const { projectId } = await wdkService.getConfig();
+      const recordClasses = await wdkService.getRecordClasses();
+      const geneRecordHasProjectId = recordClasses.find(
+        (rc) => rc.fullName === 'GeneRecordClasses.GeneRecordClass'
+      )?.primaryKeyColumnRefs.length === 2;
+      const genePkValues = geneRecordHasProjectId ? `${geneId},${projectId}` : geneId;
       const answerSpec = {
         searchName: 'single_record_question_GeneRecordClasses_GeneRecordClass',
         searchConfig: {
           parameters: {
-            primaryKeys: `${geneId},${projectId}`,
+            primaryKeys: genePkValues,
           },
         },
       };


### PR DESCRIPTION
Finds gene recordclass and inspects PK to determine if project_id is needed.  This is a little better than "if projectId === 'UniDB'.