### PR TITLE
Fix compound record runtime bugs

### DIFF
--- a/packages/libs/web-common/src/components/DatasetGraph.tsx
+++ b/packages/libs/web-common/src/components/DatasetGraph.tsx
@@ -35,7 +35,7 @@ interface RecordTableProps {
 interface RowData {
   source_id: string;
   assay_type: string;
-  module: string;
+  module: string | null;
   paralog_number: number;
   graph_ids: string;
   dataset_id: string;
@@ -340,7 +340,7 @@ const DatasetGraph: React.FC<DatasetGraphProps> = ({
   const specialImgUrl =
     dataTable && dataTable.record.attributes.specialJbrowseUrl;
 
-  const isUserDataset = module.startsWith('UserDatasets');
+  const isUserDataset = module?.startsWith('UserDatasets') ?? false;
 
   const dataset_link = makeDatasetUrl(rowData, isUserDataset);
   const tutorial_link = makeTutorialUrl();

--- a/packages/sites/genomics-site/package.json
+++ b/packages/sites/genomics-site/package.json
@@ -69,6 +69,7 @@
     "file-loader": "^3.0.1",
     "html-webpack-plugin": "^4.5.2",
     "ify-loader": "^1.1.0",
+    "imports-loader": "^1.1.1",
     "jquery": "1.9.1",
     "js-cookie": "^2.2.0",
     "mini-css-extract-plugin": "^2.7.6",

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/common/Compound.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/common/Compound.jsx
@@ -14,7 +14,12 @@ export function loadChemDoodleWeb() {
   return new Promise(function (resolve, reject) {
     try {
       require.ensure([], function (require) {
-        require('!!script-loader!site/js/ChemDoodleWeb');
+        // ChemDoodleWeb.js is a UMD module. When loaded via script-loader,
+        // webpack's module-scope `exports` leaks into the eval scope and
+        // the UMD wrapper picks the CommonJS branch, then throws on the
+        // undefined `module`. Shadow both so the UMD falls through to the
+        // browser-global branch that actually registers readMOL et al.
+        require('!!script-loader!imports-loader?additionalCode=var%20exports%3Dundefined%3Bvar%20module%3Dundefined%3B!site/js/ChemDoodleWeb');
         resolve(ChemDoodle);
       });
     } catch (err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8805,6 +8805,7 @@ __metadata:
     file-loader: "npm:^3.0.1"
     html-webpack-plugin: "npm:^4.5.2"
     ify-loader: "npm:^1.1.0"
+    imports-loader: "npm:^1.1.1"
     jquery: "npm:1.9.1"
     js-cookie: "npm:^2.2.0"
     mini-css-extract-plugin: "npm:^2.7.6"


### PR DESCRIPTION
Runtime errors here:
https://beta.plasmodb.org/plasmo.beta/app/record/compound/CHEBI:15608

Claude and I tracked down and resolved two issues:

1. vendored ChemDoodle import had broken at some point recently-ish (Node 24 upgrade?)
2. `module.startsWith()` runtime error is made safe but is really a backend issue - the `MassSpecGraphs` section has a non-informative placeholder-ish entry.