### PR TITLE
use permissions response to determine if user dataset or curated (to determine wdk record to use)

### DIFF
--- a/packages/libs/eda/src/lib/core/hooks/study.ts
+++ b/packages/libs/eda/src/lib/core/hooks/study.ts
@@ -31,8 +31,6 @@ import { usePermissions } from '@veupathdb/study-data-access/lib/data-restrictio
 import { FetchClientError } from '@veupathdb/http-utils';
 import { useCachedPromise } from './cachedPromise';
 
-const STUDY_RECORD_CLASS_NAME = 'dataset';
-
 interface StudyState {
   studyRecordClass: StudyRecordClass;
   studyRecord: StudyRecord;
@@ -46,8 +44,22 @@ export interface HookValue {
   studyRecord: StudyRecord;
 }
 export function useWdkStudyRecord(datasetId: string): HookValue | undefined {
+  const permissionsResponse = usePermissions();
+
+  // Determine record class name based on isUserStudy from permissions
+  // undefined while permissions are loading → will return undefined from the hook
+  const STUDY_RECORD_CLASS_NAME = permissionsResponse.loading
+    ? undefined
+    : permissionsResponse.permissions.perDataset[datasetId]?.isUserStudy
+    ? 'userdataset'
+    : 'dataset';
+
   return useWdkServiceWithRefresh(
     async (wdkService) => {
+      if (STUDY_RECORD_CLASS_NAME === undefined) {
+        return undefined;
+      }
+
       const studyRecordClass = await wdkService.findRecordClass(
         STUDY_RECORD_CLASS_NAME
       );
@@ -105,7 +117,7 @@ export function useWdkStudyRecord(datasetId: string): HookValue | undefined {
         studyRecordClass,
       };
     },
-    [datasetId]
+    [datasetId, STUDY_RECORD_CLASS_NAME]
   );
 }
 
@@ -148,13 +160,24 @@ export function useWdkStudyRecords(
  * */
 export function useWdkStudyReleases(): Array<WdkStudyRelease> {
   const studyRecord = useStudyRecord();
+  const permissionsResponse = usePermissions();
+
+  // Extract datasetId from studyRecord.id
+  const datasetId = studyRecord.id[0]?.value;
+
+  // Determine record class name based on isUserStudy from permissions
+  const STUDY_RECORD_CLASS_NAME = permissionsResponse.loading
+    ? 'dataset'
+    : permissionsResponse.permissions.perDataset[datasetId]?.isUserStudy
+    ? 'userdataset'
+    : 'dataset';
 
   return (
     useWdkService((wdkService) => {
       return wdkService.getRecord(STUDY_RECORD_CLASS_NAME, studyRecord.id, {
         tables: ['DownloadVersion'],
       });
-    })?.tables['DownloadVersion'].map(
+    }, [studyRecord.id, STUDY_RECORD_CLASS_NAME])?.tables['DownloadVersion'].map(
       (release) => ({
         // DAVE/JAMIE: I was sure if I could tell TS that these values
         // would always be present.


### PR DESCRIPTION
(this file offers hooks to use by many components; one reason is to know which wdk record to use.
a couple of recent commits undid  wdkrecord hardcoding, in 2 components, instead set to use hooks in this file:
- 40710a7
- 2eb48da
)

claude helped with this file update,  the prompt was to use the permissions response;
updates are:

  1. useWdkStudyRecord (line 46):                                                                                                                                     
                                                                                                                                                                      
  - Now calls usePermissions() to get permissions data                                                                                                                
  - Dynamically sets STUDY_RECORD_CLASS_NAME based on permissionsResponse.permissions.perDataset[datasetId]?.isUserStudy                                              
  - Returns 'userdataset' if isUserStudy is true, otherwise 'dataset'                                                                                                 
  - Returns undefined while permissions are loading (which causes the hook to wait)                                                                                   
  - Added STUDY_RECORD_CLASS_NAME to the dependency array                                                                                                             
                                                                                                                                                                      
  2. useWdkStudyReleases (line 161):                                                                                                                                  
                                                                                                                                                                      
  - Now calls usePermissions() to get permissions data                                                                                                                
  - Extracts datasetId from studyRecord.id[0]?.value                                                                                                                  
  - Dynamically sets STUDY_RECORD_CLASS_NAME using the same logic as above                                                                                            
  - Added STUDY_RECORD_CLASS_NAME to the dependency array  
