### PR TITLE
effectDirection enum values now look like enum values

### DIFF
--- a/packages/libs/components/src/plots/VolcanoPlot.tsx
+++ b/packages/libs/components/src/plots/VolcanoPlot.tsx
@@ -104,9 +104,9 @@ export interface VolcanoPlotProps {
    * at which points can be plotted. This information will also be shown in tooltips for floored points.
    */
   statisticsFloors?: StatisticsFloors;
-  /** Controls which directions of effect are highlighted. 'up only' hides the negative threshold line;
-   * 'down only' hides the positive threshold line. Defaults to 'up and down'. */
-  effectDirection?: 'up and down' | 'up only' | 'down only';
+  /** Controls which directions of effect are highlighted. 'upOnly' hides the negative threshold line;
+   * 'downOnly' hides the positive threshold line. Defaults to 'upAndDown'. */
+  effectDirection?: 'upAndDown' | 'upOnly' | 'downOnly';
 }
 
 const EmptyVolcanoPlotStats: VolcanoPlotStats = [];
@@ -227,7 +227,7 @@ function VolcanoPlot(props: VolcanoPlotProps, ref: Ref<PlotRef>) {
     showSpinner = false,
     rawDataMinMaxValues,
     statisticsFloors = DefaultStatisticsFloors,
-    effectDirection = 'up and down',
+    effectDirection = 'upAndDown',
   } = props;
 
   // Use ref forwarding to enable screenshotting of the plot for thumbnail versions.
@@ -341,9 +341,9 @@ function VolcanoPlot(props: VolcanoPlotProps, ref: Ref<PlotRef>) {
    * prevent the line from rendering outside the graph.
    */
   const showNegativeFoldChangeThresholdLine =
-    effectDirection !== 'up only' && -effectSizeThreshold > xAxisMin;
+    effectDirection !== 'upOnly' && -effectSizeThreshold > xAxisMin;
   const showPositiveFoldChangeThresholdLine =
-    effectDirection !== 'down only' && effectSizeThreshold < xAxisMax;
+    effectDirection !== 'downOnly' && effectSizeThreshold < xAxisMax;
   const showSignificanceThresholdLine =
     -Math.log10(Number(significanceThreshold)) > yAxisMin &&
     -Math.log10(Number(significanceThreshold)) < yAxisMax;

--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/VolcanoPlotVisualization.tsx
@@ -125,11 +125,26 @@ export const VolcanoPlotConfig = t.partial({
   /** Label for the effect size axis/threshold, sourced from the backend response. */
   effectSizeLabel: t.string,
   effectDirection: t.union([
-    t.literal('up and down'),
-    t.literal('up only'),
-    t.literal('down only'),
+    t.literal('upAndDown'),
+    t.literal('upOnly'),
+    t.literal('downOnly'),
   ]),
 });
+
+export const effectDirectionOptions = [
+  'upAndDown',
+  'upOnly',
+  'downOnly',
+] as const;
+
+export const effectDirectionLabels: Record<
+  NonNullable<VolcanoPlotConfig['effectDirection']>,
+  string
+> = {
+  upAndDown: 'Up- or down-regulated',
+  upOnly: 'Up-regulated only',
+  downOnly: 'Down-regulated only',
+};
 
 export interface VolcanoPlotOptions
   extends LayoutOptions,
@@ -213,27 +228,24 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
           computationType: computation.descriptor.type,
         };
 
-  const data = useCachedPromise(
-    async (): Promise<VolcanoPlotResponse> => {
-      if (!dataRequestDeps) throw new Error('dataRequestDeps is not defined');
-      // There are _no_ viz request params for the volcano plot (config: {}).
-      // The data service streams the volcano data directly from the compute service.
-      const params = {
-        studyId: dataRequestDeps.studyId,
-        filters: dataRequestDeps.filters,
-        config: {},
-        computeConfig: dataRequestDeps.computationConfiguration,
-      };
+  const data = useCachedPromise(async (): Promise<VolcanoPlotResponse> => {
+    if (!dataRequestDeps) throw new Error('dataRequestDeps is not defined');
+    // There are _no_ viz request params for the volcano plot (config: {}).
+    // The data service streams the volcano data directly from the compute service.
+    const params = {
+      studyId: dataRequestDeps.studyId,
+      filters: dataRequestDeps.filters,
+      config: {},
+      computeConfig: dataRequestDeps.computationConfiguration,
+    };
 
-      return dataClient.getVisualizationData(
-        dataRequestDeps.computationType,
-        visualization.descriptor.type,
-        params,
-        VolcanoPlotResponse
-      );
-    },
-    [visualization.descriptor.type, dataRequestDeps]
-  );
+    return dataClient.getVisualizationData(
+      dataRequestDeps.computationType,
+      visualization.descriptor.type,
+      params,
+      VolcanoPlotResponse
+    );
+  }, [visualization.descriptor.type, dataRequestDeps]);
 
   /**
    * Find mins and maxes of the data and for the plot.
@@ -349,11 +361,11 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
             effectSizeThreshold,
             significanceColors
           );
-          const effectDirection = vizConfig.effectDirection ?? 'up and down';
-          if (effectDirection === 'up only' && Number(d.effectSize) < 0) {
+          const effectDirection = vizConfig.effectDirection ?? 'upAndDown';
+          if (effectDirection === 'upOnly' && Number(d.effectSize) < 0) {
             sigColor = significanceColors['inconclusive'];
           } else if (
-            effectDirection === 'down only' &&
+            effectDirection === 'downOnly' &&
             Number(d.effectSize) > 0
           ) {
             sigColor = significanceColors['inconclusive'];
@@ -510,7 +522,7 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
     independentAxisRange,
     dependentAxisRange,
     rawDataMinMaxValues,
-    effectDirection: vizConfig.effectDirection ?? 'up and down',
+    effectDirection: vizConfig.effectDirection ?? 'upAndDown',
     /**
      * As sophisticated aesthetes, let's specify axis ranges for the empty viz placeholder
      */
@@ -767,7 +779,7 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
         .memberPlural
     ) || capitalize(options?.pointsDisplayNamePlural);
 
-  const effectDirection = vizConfig.effectDirection ?? 'up and down';
+  const effectDirection = vizConfig.effectDirection ?? 'upAndDown';
 
   const legendNode = finalData && countsData && (
     <PlotLegend
@@ -782,7 +794,7 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
           hasData: true,
           markerColor: significanceColors['inconclusive'],
         },
-        ...(effectDirection !== 'down only'
+        ...(effectDirection !== 'downOnly'
           ? [
               {
                 label: `Up in ${computationConfiguration?.comparator?.groupB
@@ -794,7 +806,7 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
               },
             ]
           : []),
-        ...(effectDirection !== 'up only'
+        ...(effectDirection !== 'upOnly'
           ? [
               {
                 label: `Up in ${computationConfiguration?.comparator?.groupA
@@ -838,13 +850,11 @@ function VolcanoPlotViz(props: VisualizationProps<VolcanoPlotOptions>) {
             />
             <RadioButtonGroup
               label="Effect direction"
-              selectedOption={vizConfig.effectDirection ?? 'up and down'}
-              options={['up and down', 'up only', 'down only']}
-              optionLabels={[
-                'Up- or down-regulated',
-                'Up-regulated only',
-                'Down-regulated only',
-              ]}
+              selectedOption={vizConfig.effectDirection ?? 'upAndDown'}
+              options={[...effectDirectionOptions]}
+              optionLabels={effectDirectionOptions.map(
+                (k) => effectDirectionLabels[k]
+              )}
               onOptionSelected={(newValue) =>
                 updateVizConfig({
                   effectDirection:

--- a/packages/libs/eda/src/lib/notebook/Utils.tsx
+++ b/packages/libs/eda/src/lib/notebook/Utils.tsx
@@ -8,7 +8,10 @@ import { Analysis, NewAnalysis } from '../core';
 import { AnalysisDescriptor } from '../core/types/analysis';
 import { Computation } from '../core/types/visualization';
 import { DifferentialExpressionConfig } from '../core/types/apps';
-import { VolcanoPlotConfig } from '../core/components/visualizations/implementations/VolcanoPlotVisualization';
+import {
+  VolcanoPlotConfig,
+  effectDirectionLabels,
+} from '../core/components/visualizations/implementations/VolcanoPlotVisualization';
 import {
   entityTreeToArray,
   findEntityAndVariable,
@@ -165,11 +168,7 @@ function ComputationSummary({
         <ReviewRow
           label="Direction"
           value={
-            volcanoConfig?.effectDirection === 'up only'
-              ? 'Up-regulated only'
-              : volcanoConfig?.effectDirection === 'down only'
-              ? 'Down-regulated only'
-              : 'Up- or down-regulated'
+            effectDirectionLabels[volcanoConfig?.effectDirection ?? 'upAndDown']
           }
         />
       </ReviewCard>

--- a/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
+++ b/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
@@ -1,6 +1,9 @@
 import { colors } from '@material-ui/core';
 import { plugins } from '../../core/components/computations/plugins';
-import { VolcanoPlotConfig } from '../../core/components/visualizations/implementations/VolcanoPlotVisualization';
+import {
+  VolcanoPlotConfig,
+  effectDirectionLabels,
+} from '../../core/components/visualizations/implementations/VolcanoPlotVisualization';
 import {
   useFindEntityAndVariable,
   useStudyEntities,
@@ -204,11 +207,9 @@ export function DifferentialAnalysisReviewContent({
         <ReviewRow
           label="Direction"
           value={
-            volcanoPlotConfig?.effectDirection === 'up only'
-              ? 'Up-regulated only'
-              : volcanoPlotConfig?.effectDirection === 'down only'
-              ? 'Down-regulated only'
-              : 'Up- or down-regulated'
+            effectDirectionLabels[
+              volcanoPlotConfig?.effectDirection ?? 'upAndDown'
+            ]
           }
         />
         {volcanoStep && (


### PR DESCRIPTION
`effectDirection` type and internal comparisons updated to `'upAndDown' | 'upOnly' | 'downOnly'`

There has to be a bit of repetition because of the run-time declaration of the `io-ts` codec. It's a one-way street.

will make the corresponding change now in https://github.com/VEuPathDB/ApiCommonWebService/pull/18