### PR TITLE
DESeq2 expression floor filter: accurate sample counts for gene-subset analyses

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
@@ -2,32 +2,44 @@ import { useMemo } from 'react';
 import { Filter } from '../../types/filter';
 import { LabeledRange } from '../../api/DataClient/types';
 import { VariableDescriptor } from '../../types/variable';
+import { Variable } from '../../types/study';
 import { DifferentialExpressionMethod } from '../../types/apps';
 import { useStudyMetadata } from '../../hooks/workspace';
 import { useEntityCounts } from '../../hooks/entityCounts';
 
 function makeGroupFilter(
   variable: VariableDescriptor,
-  ranges: LabeledRange[]
+  ranges: LabeledRange[],
+  variableType?: Variable['type']
 ): Filter | undefined {
   if (!ranges.length) return undefined;
-  const isContinuous = ranges[0].min != null;
-  if (!isContinuous) {
+  if (variableType === 'date') {
+    const mins = ranges.map((r) => r.min!);
+    const maxes = ranges.map((r) => r.max!);
     return {
-      type: 'stringSet',
+      type: 'dateRange',
       entityId: variable.entityId,
       variableId: variable.variableId,
-      stringSet: ranges.map((r) => r.label),
+      min: mins.reduce((a, b) => (a < b ? a : b)),
+      max: maxes.reduce((a, b) => (a > b ? a : b)),
     };
   }
-  const mins = ranges.map((r) => parseFloat(r.min!));
-  const maxes = ranges.map((r) => parseFloat(r.max!));
+  if (variableType === 'number' || variableType === 'integer') {
+    const mins = ranges.map((r) => parseFloat(r.min!));
+    const maxes = ranges.map((r) => parseFloat(r.max!));
+    return {
+      type: 'numberRange',
+      entityId: variable.entityId,
+      variableId: variable.variableId,
+      min: Math.min(...mins),
+      max: Math.max(...maxes),
+    };
+  }
   return {
-    type: 'numberRange',
+    type: 'stringSet',
     entityId: variable.entityId,
     variableId: variable.variableId,
-    min: Math.min(...mins),
-    max: Math.max(...maxes),
+    stringSet: ranges.map((r) => r.label),
   };
 }
 
@@ -64,6 +76,16 @@ export function makeDeseqExpressionFloorFilter(
   };
 }
 
+export interface UseGroupCountsParams {
+  comparatorVariable: VariableDescriptor | undefined;
+  groupA: LabeledRange[] | undefined;
+  groupB: LabeledRange[] | undefined;
+  filters: Filter[] | undefined;
+  method?: DifferentialExpressionMethod;
+  valueVariable?: VariableDescriptor;
+  comparatorVariableType?: Variable['type'];
+}
+
 /**
  * Hook that computes per-group sample counts for a comparator variable
  * split into two groups (A and B). Each group's filter is independently
@@ -73,14 +95,15 @@ export function makeDeseqExpressionFloorFilter(
  * silently appended so that the displayed counts match what the R backend will
  * actually use after removeEmptyRecords strips all-zero-count samples.
  */
-export function useGroupCounts(
-  comparatorVariable: VariableDescriptor | undefined,
-  groupA: LabeledRange[] | undefined,
-  groupB: LabeledRange[] | undefined,
-  filters: Filter[] | undefined,
-  method?: DifferentialExpressionMethod,
-  valueVariable?: VariableDescriptor
-): GroupCounts {
+export function useGroupCounts({
+  comparatorVariable,
+  groupA,
+  groupB,
+  filters,
+  method,
+  valueVariable,
+  comparatorVariableType,
+}: UseGroupCountsParams): GroupCounts {
   const { rootEntity } = useStudyMetadata();
 
   const filtersWithFloor = useMemo(() => {
@@ -91,13 +114,13 @@ export function useGroupCounts(
 
   const groupAFilter = useMemo(() => {
     if (!comparatorVariable || !groupA?.length) return undefined;
-    return makeGroupFilter(comparatorVariable, groupA);
-  }, [comparatorVariable, groupA]);
+    return makeGroupFilter(comparatorVariable, groupA, comparatorVariableType);
+  }, [comparatorVariable, groupA, comparatorVariableType]);
 
   const groupBFilter = useMemo(() => {
     if (!comparatorVariable || !groupB?.length) return undefined;
-    return makeGroupFilter(comparatorVariable, groupB);
-  }, [comparatorVariable, groupB]);
+    return makeGroupFilter(comparatorVariable, groupB, comparatorVariableType);
+  }, [comparatorVariable, groupB, comparatorVariableType]);
 
   const groupAFilters = useMemo(
     () =>

--- a/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
-import { Filter } from '../types/filter';
-import { LabeledRange } from '../api/DataClient/types';
-import { VariableDescriptor } from '../types/variable';
-import { useStudyMetadata } from './workspace';
-import { useEntityCounts } from './entityCounts';
+import { Filter } from '../../types/filter';
+import { LabeledRange } from '../../api/DataClient/types';
+import { VariableDescriptor } from '../../types/variable';
+import { DifferentialExpressionMethod } from '../../types/apps';
+import { useStudyMetadata } from '../../hooks/workspace';
+import { useEntityCounts } from '../../hooks/entityCounts';
 
 function makeGroupFilter(
   variable: VariableDescriptor,
@@ -43,14 +44,34 @@ export interface GroupCounts {
  * Hook that computes per-group sample counts for a comparator variable
  * split into two groups (A and B). Each group's filter is independently
  * memoised so that changing one group doesn't trigger a recount for the other.
+ *
+ * When method is 'DESeq' and valueVariable is provided, a >=1 floor filter is
+ * silently appended so that the displayed counts match what the R backend will
+ * actually use after removeEmptyRecords strips all-zero-count samples.
+ * A !=0 equivalent for limma/ArrayDataCollection does not currently exist in
+ * the EDA filter repertoire — revisit if limma surfaces a similar edge case.
  */
 export function useGroupCounts(
   comparatorVariable: VariableDescriptor | undefined,
   groupA: LabeledRange[] | undefined,
   groupB: LabeledRange[] | undefined,
-  filters: Filter[] | undefined
+  filters: Filter[] | undefined,
+  method?: DifferentialExpressionMethod,
+  valueVariable?: VariableDescriptor
 ): GroupCounts {
   const { rootEntity } = useStudyMetadata();
+
+  const filtersWithFloor = useMemo(() => {
+    if (method !== 'DESeq' || valueVariable == null) return filters;
+    const floorFilter: Filter = {
+      type: 'numberRange',
+      entityId: valueVariable.entityId,
+      variableId: valueVariable.variableId,
+      min: 1,
+      max: Number.MAX_SAFE_INTEGER,
+    };
+    return [...(filters ?? []), floorFilter];
+  }, [method, valueVariable, filters]);
 
   const groupAFilter = useMemo(() => {
     if (!comparatorVariable || !groupA?.length) return undefined;
@@ -63,12 +84,14 @@ export function useGroupCounts(
   }, [comparatorVariable, groupB]);
 
   const groupAFilters = useMemo(
-    () => (groupAFilter ? [...(filters ?? []), groupAFilter] : undefined),
-    [filters, groupAFilter]
+    () =>
+      groupAFilter ? [...(filtersWithFloor ?? []), groupAFilter] : undefined,
+    [filtersWithFloor, groupAFilter]
   );
   const groupBFilters = useMemo(
-    () => (groupBFilter ? [...(filters ?? []), groupBFilter] : undefined),
-    [filters, groupBFilter]
+    () =>
+      groupBFilter ? [...(filtersWithFloor ?? []), groupBFilter] : undefined,
+    [filtersWithFloor, groupBFilter]
   );
 
   const groupACounts = useEntityCounts(groupAFilters);

--- a/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
@@ -53,25 +53,21 @@ export interface GroupCounts {
 }
 
 /**
- * Returns a >=1 NumberRangeFilter on valueVariable for DESeq analyses, or
- * undefined for all other methods. Append this to any filter array passed to
- * the subsetting API so that samples with all-zero counts for the selected
- * gene set are excluded consistently across the UI (counts display, comparator
- * variable distribution), matching the R backend's removeEmptyRecords behaviour.
- *
- * A !=0 equivalent for limma/ArrayDataCollection does not currently exist in
- * the EDA filter repertoire — revisit if limma surfaces a similar edge case.
+ * Returns a NumberRangeFilter on valueVariable to exclude samples with no
+ * measurement (NA). For DESeq the floor is 1 (matching removeEmptyRecords);
+ * for limma the range is [MIN_SAFE_INTEGER, MAX_SAFE_INTEGER] which admits all
+ * real expression values while still dropping NAs.
  */
-export function makeDeseqExpressionFloorFilter(
+export function makeExpressionValueRangeFilter(
   method: DifferentialExpressionMethod | undefined,
   valueVariable: VariableDescriptor | undefined
 ): Filter | undefined {
-  if (method !== 'DESeq' || valueVariable == null) return undefined;
+  if (method == null || valueVariable == null) return undefined;
   return {
     type: 'numberRange',
     entityId: valueVariable.entityId,
     variableId: valueVariable.variableId,
-    min: 1,
+    min: method === 'DESeq' ? 1 : Number.MIN_SAFE_INTEGER,
     max: Number.MAX_SAFE_INTEGER,
   };
 }
@@ -107,7 +103,7 @@ export function useGroupCounts({
   const { rootEntity } = useStudyMetadata();
 
   const filtersWithFloor = useMemo(() => {
-    const floorFilter = makeDeseqExpressionFloorFilter(method, valueVariable);
+    const floorFilter = makeExpressionValueRangeFilter(method, valueVariable);
     if (floorFilter == null) return filters;
     return [...(filters ?? []), floorFilter];
   }, [method, valueVariable, filters]);

--- a/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
@@ -41,6 +41,30 @@ export interface GroupCounts {
 }
 
 /**
+ * Returns a >=1 NumberRangeFilter on valueVariable for DESeq analyses, or
+ * undefined for all other methods. Append this to any filter array passed to
+ * the subsetting API so that samples with all-zero counts for the selected
+ * gene set are excluded consistently across the UI (counts display, comparator
+ * variable distribution), matching the R backend's removeEmptyRecords behaviour.
+ *
+ * A !=0 equivalent for limma/ArrayDataCollection does not currently exist in
+ * the EDA filter repertoire — revisit if limma surfaces a similar edge case.
+ */
+export function makeDeseqExpressionFloorFilter(
+  method: DifferentialExpressionMethod | undefined,
+  valueVariable: VariableDescriptor | undefined
+): Filter | undefined {
+  if (method !== 'DESeq' || valueVariable == null) return undefined;
+  return {
+    type: 'numberRange',
+    entityId: valueVariable.entityId,
+    variableId: valueVariable.variableId,
+    min: 1,
+    max: Number.MAX_SAFE_INTEGER,
+  };
+}
+
+/**
  * Hook that computes per-group sample counts for a comparator variable
  * split into two groups (A and B). Each group's filter is independently
  * memoised so that changing one group doesn't trigger a recount for the other.
@@ -48,8 +72,6 @@ export interface GroupCounts {
  * When method is 'DESeq' and valueVariable is provided, a >=1 floor filter is
  * silently appended so that the displayed counts match what the R backend will
  * actually use after removeEmptyRecords strips all-zero-count samples.
- * A !=0 equivalent for limma/ArrayDataCollection does not currently exist in
- * the EDA filter repertoire — revisit if limma surfaces a similar edge case.
  */
 export function useGroupCounts(
   comparatorVariable: VariableDescriptor | undefined,
@@ -62,14 +84,8 @@ export function useGroupCounts(
   const { rootEntity } = useStudyMetadata();
 
   const filtersWithFloor = useMemo(() => {
-    if (method !== 'DESeq' || valueVariable == null) return filters;
-    const floorFilter: Filter = {
-      type: 'numberRange',
-      entityId: valueVariable.entityId,
-      variableId: valueVariable.variableId,
-      min: 1,
-      max: Number.MAX_SAFE_INTEGER,
-    };
+    const floorFilter = makeDeseqExpressionFloorFilter(method, valueVariable);
+    if (floorFilter == null) return filters;
     return [...(filters ?? []), floorFilter];
   }, [method, valueVariable, filters]);
 

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
@@ -53,7 +53,7 @@ import {
   ancestorEntitiesForEntityId,
 } from '../../../utils/data-element-constraints';
 import { DifferentialExpressionConfig } from '../../../types/apps';
-import { useGroupCounts } from '../groupCounts';
+import { useGroupCounts, makeDeseqExpressionFloorFilter } from '../groupCounts';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
@@ -433,7 +433,15 @@ export function DifferentialExpressionConfiguration(
       configuration.comparator.variable.variableId,
       {
         valueSpec: 'count',
-        filters: otherFilters,
+        filters: [
+          ...(otherFilters ?? []),
+          ...[
+            makeDeseqExpressionFloorFilter(
+              configuration.differentialExpressionMethod,
+              configuration.valueVariable
+            ),
+          ].filter((f): f is Filter => f != null),
+        ],
       }
     );
 

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
@@ -53,7 +53,7 @@ import {
   ancestorEntitiesForEntityId,
 } from '../../../utils/data-element-constraints';
 import { DifferentialExpressionConfig } from '../../../types/apps';
-import { useGroupCounts, makeDeseqExpressionFloorFilter } from '../groupCounts';
+import { useGroupCounts, makeExpressionValueRangeFilter } from '../groupCounts';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
@@ -447,7 +447,7 @@ export function DifferentialExpressionConfiguration(
         filters: [
           ...(otherFilters ?? []),
           ...[
-            makeDeseqExpressionFloorFilter(
+            makeExpressionValueRangeFilter(
               configuration.differentialExpressionMethod,
               configuration.valueVariable
             ),

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
@@ -584,11 +584,7 @@ export function DifferentialExpressionConfiguration(
   const disabledVariableValues =
     selectedComparatorVariable?.variable.vocabulary?.filter((value) => {
       // Let all values pass if there was no filteredComparatorVariableDistribution
-      if (
-        filteredComparatorVariableDistribution.value == null ||
-        filteredComparatorVariableDistribution.value.histogram.length === 0
-      )
-        return false;
+      if (filteredComparatorVariableDistribution.value == null) return false;
 
       // Disable a variable if it does not appear in filteredComparatorVariableDistribution
       return !filteredComparatorVariableDistribution.value.histogram.some(

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
@@ -53,7 +53,7 @@ import {
   ancestorEntitiesForEntityId,
 } from '../../../utils/data-element-constraints';
 import { DifferentialExpressionConfig } from '../../../types/apps';
-import { useGroupCounts } from '../../../hooks/groupCounts';
+import { useGroupCounts } from '../groupCounts';
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
 
 const cx = makeClassNameHelper('AppStepConfigurationContainer');
@@ -480,7 +480,9 @@ export function DifferentialExpressionConfiguration(
     comparatorVariable,
     configuration.comparator?.groupA,
     configuration.comparator?.groupB,
-    filters
+    filters,
+    configuration.differentialExpressionMethod,
+    configuration.valueVariable
   );
 
   // Report per-group count gating to the parent (e.g. ComputeNotebookCell)

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
@@ -495,14 +495,15 @@ export function DifferentialExpressionConfiguration(
     groupBCountPending,
     groupAFilter,
     groupBFilter,
-  } = useGroupCounts(
+  } = useGroupCounts({
     comparatorVariable,
-    configuration.comparator?.groupA,
-    configuration.comparator?.groupB,
+    groupA: configuration.comparator?.groupA,
+    groupB: configuration.comparator?.groupB,
     filters,
-    configuration.differentialExpressionMethod,
-    configuration.valueVariable
-  );
+    method: configuration.differentialExpressionMethod,
+    valueVariable: configuration.valueVariable,
+    comparatorVariableType: selectedComparatorVariable?.variable.type,
+  });
 
   // Report per-group count gating to the parent (e.g. ComputeNotebookCell)
   useEffect(() => {

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/differentialExpression.tsx
@@ -176,6 +176,17 @@ export const plugin: ComputationPlugin = {
   isEnabledInPicker: isEnabledInPicker,
   studyRequirements:
     'These visualizations are only available for studies with compatible assay data.',
+  getCountWarning(counts) {
+    const root = counts['root'];
+    if (!root || root.pending || root.value == null) return { type: 'pending' };
+    if (root.value < 4)
+      return {
+        type: 'warning',
+        message:
+          'At least 4 samples (2 per group) are required to run differential expression. Please relax your filtering criteria.',
+      };
+    return { type: 'ok' };
+  },
 };
 
 function DifferentialExpressionConfigDescriptionComponent({

--- a/packages/libs/eda/src/lib/core/components/computations/plugins/dimensionalityReduction.tsx
+++ b/packages/libs/eda/src/lib/core/components/computations/plugins/dimensionalityReduction.tsx
@@ -110,7 +110,7 @@ export const plugin: ComputationPlugin = {
       return {
         type: 'warning',
         message:
-          'At least 2 samples are required to run dimensionality reduction.',
+          'At least 2 samples are required to run dimensionality reduction. Please relax your filtering criteria.',
       };
     return { type: 'ok' };
   },

--- a/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
+++ b/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
@@ -14,7 +14,7 @@ import { DifferentialExpressionConfig } from '../../core/types/apps';
 import { AnalysisState, Filter } from '../../core';
 import { TextCellContext } from '../Types';
 import { ReviewCard, ReviewRow } from '../components/ReviewCard';
-import { useGroupCounts } from '../../core/hooks/groupCounts';
+import { useGroupCounts } from '../../core/components/computations/groupCounts';
 
 export function isDEReadyToReviewAndSubmit(
   analysisState: AnalysisState | undefined
@@ -97,7 +97,9 @@ export function DifferentialAnalysisReviewContent({
       deConfig?.comparator?.variable,
       deConfig?.comparator?.groupA,
       deConfig?.comparator?.groupB,
-      filters
+      filters,
+      deConfig?.differentialExpressionMethod,
+      deConfig?.valueVariable
     );
 
   const formatCount = (count: number | undefined, pending: boolean): string => {

--- a/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
+++ b/packages/libs/eda/src/lib/notebook/notebooks/differentialAnalysisReview.tsx
@@ -93,14 +93,15 @@ export function DifferentialAnalysisReviewContent({
     .join(', ');
 
   const { groupACount, groupBCount, groupACountPending, groupBCountPending } =
-    useGroupCounts(
-      deConfig?.comparator?.variable,
-      deConfig?.comparator?.groupA,
-      deConfig?.comparator?.groupB,
+    useGroupCounts({
+      comparatorVariable: deConfig?.comparator?.variable,
+      groupA: deConfig?.comparator?.groupA,
+      groupB: deConfig?.comparator?.groupB,
       filters,
-      deConfig?.differentialExpressionMethod,
-      deConfig?.valueVariable
-    );
+      method: deConfig?.differentialExpressionMethod,
+      valueVariable: deConfig?.valueVariable,
+      comparatorVariableType: comparatorVarInfo?.variable.type,
+    });
 
   const formatCount = (count: number | undefined, pending: boolean): string => {
     if (pending) return ' (please wait...)';


### PR DESCRIPTION
### Background

When a user applies a subset filter on a small number of genes (e.g. all transmembrane genes), some samples end up with zero counts for every gene in that filtered set. The R backend's `removeEmptyRecords` logic (in `veupathUtils::getCollectionData`) silently drops those samples before running DESeq2, potentially leaving fewer than 2 samples per group and producing a cryptic RServe error with no useful message surfaced to the user.

The frontend already has a "< 2 samples per group" count-gating warning, but it was counting *all* samples — not the subset that the R backend would actually use — so the warning never fired for this edge case.

### What this PR does

Adds a silent `numberRange` filter (min=1, max=`Number.MAX_SAFE_INTEGER`) on the selected expression value variable whenever the differential expression method is DESeq2. This filter is appended to:

- **`useGroupCounts`** — so the per-group sample counts displayed in the configuration UI reflect what DESeq2 will actually see, allowing the existing gating warning to fire correctly before the computation runs.
- **`subsettingClient.getDistribution`** — so the comparator variable value picker also disables annotations whose samples would all be removed.

### Limma

Handled via `makeDeseqExpressionFloorFilter` being renamed to `makeExpressionValueRangeFilter` everywhere, with the limma path now producing a `[MIN_SAFE_INTEGER, MAX_SAFE_INTEGER]` range filter that drops NA samples while accepting the full range of normalised expression values.

### Changes

- `core/hooks/groupCounts.ts` → moved to `core/components/computations/groupCounts.ts` (only used by differential expression)
- `groupCounts.ts`: extended `useGroupCounts` with optional `method` and `valueVariable` params; extracted `makeDeseqExpressionFloorFilter` helper to share filter construction logic
- `differentialExpression.tsx`: passes method + valueVariable to `useGroupCounts`; applies the same floor filter to the comparator variable distribution call
- `differentialAnalysisReview.tsx`: passes method + valueVariable to `useGroupCounts` for consistent counts in the notebook review panel


Some additional tweaks and bug-fixes:

1. **`getDistribution` floor filter** (`differentialExpression.tsx`) — applied the same DESeq ≥1 expression filter to the comparator variable distribution call, so that value picker options for annotations whose samples all have zero counts are correctly greyed out (not just uncountable but unselectable).

2. **Empty histogram bug** (`differentialExpression.tsx`) — removed the `histogram.length === 0` short-circuit in `disabledVariableValues`, so that an aggressively filtered subset returning an empty distribution correctly disables *all* comparator variable values instead of leaving them all enabled.

3. **"Relax your filtering" banners** — added a `getCountWarning` to the differential expression plugin (threshold: 4 samples total / 2 per group) and updated the equivalent in dimensionality reduction, both with the message suffix *"Please relax your filtering criteria."* These surface as notebook cell banners before the user attempts to run the computation.


### Note also

This work highlighted some technical debt we should fix:
https://github.com/VEuPathDB/web-monorepo/issues/1682

Done it here:

**`groupCounts.ts` refactor**
- Added `Variable` import from `core/types/study`
- `makeGroupFilter` now takes `variableType?: Variable['type']` and branches explicitly: `'date'` → `dateRange` (lexicographic min/max), `'number'|'integer'` → `numberRange` (parseFloat), else → `stringSet`. The fragile `ranges[0].min != null` probe is gone.
- `useGroupCounts` switched to a named-params object (`UseGroupCountsParams` interface) with the new `comparatorVariableType` field threaded through to both filter memos.

**`differentialExpression.tsx`** — call site updated to named params; passes `selectedComparatorVariable?.variable.type` (already in scope).

**`differentialAnalysisReview.tsx`** — call site updated to named params; passes `comparatorVarInfo?.variable.type` (already computed on line 79).
