### PR TITLE
filter out 'empty' contact objects before form submission

### DIFF
--- a/packages/libs/user-datasets/src/lib/Service/process/create-dataset.ts
+++ b/packages/libs/user-datasets/src/lib/Service/process/create-dataset.ts
@@ -1,5 +1,4 @@
 import {
-  DatasetContact,
   DatasetPostDetails,
   DatasetPostResponseBody,
   DatasetUploads,
@@ -79,12 +78,14 @@ function scrubDetails(details: DatasetPostDetails): DatasetPostDetails {
 function pruneSimpleRecords<T extends object>(
   records: T[] | undefined
 ): T[] | undefined {
-  if (!records) return undefined;
+  if (!records)
+    return undefined;
 
   const out: T[] = [];
 
   for (const record of records) {
-    if (record && !isEmptyObject(record)) out.push(record);
+    if (record && !isEmptyObject(record))
+      out.push(record);
   }
 
   return out.length > 0 ? out : undefined;
@@ -121,7 +122,9 @@ function scrubDatasetCharacteristics(
  * Tests if a given object contains truthy values.
  */
 function isEmptyObject(obj: Record<string, any>): boolean {
-  for (const key of Object.keys(obj)) if (obj[key]) return false;
+  for (const key of Object.keys(obj))
+    if (obj[key])
+      return false;
 
   return true;
 }

--- a/packages/libs/user-datasets/src/lib/Service/process/create-dataset.ts
+++ b/packages/libs/user-datasets/src/lib/Service/process/create-dataset.ts
@@ -55,8 +55,8 @@ function scrubDetails(details: DatasetPostDetails): DatasetPostDetails {
     ...details,
 
     installTargets: removeEmpties(details.installTargets),
-    contacts: pruneContacts(details.contacts),
-    datasetSources: removeEmpties(details.datasetSources),
+    contacts: pruneSimpleRecords(details.contacts),
+    datasetSources: pruneSimpleRecords(details.datasetSources),
     dependencies: removeEmpties(details.dependencies),
     funding: removeEmpties(details.funding),
     linkedDatasets: removeEmpties(details.linkedDatasets),
@@ -69,33 +69,25 @@ function scrubDetails(details: DatasetPostDetails): DatasetPostDetails {
   };
 }
 
-function pruneContacts(contacts: DatasetContact[] | undefined): DatasetContact[] | undefined  {
-  if (!contacts)
-    return undefined;
+/**
+ * Prunes arrays of simple key/value objects by removing objects that contain no
+ * truthy property values.
+ *
+ * If the resulting array is empty, the array itself is to be 'pruned', and
+ * undefined will be returned.
+ */
+function pruneSimpleRecords<T extends object>(
+  records: T[] | undefined
+): T[] | undefined {
+  if (!records) return undefined;
 
-  const out: DatasetContact[] = [];
+  const out: T[] = [];
 
-  for (const contact of contacts) {
-    const res = pruneContact(contact);
-
-    if (res)
-      out.push(res);
+  for (const record of records) {
+    if (record && !isEmptyObject(record)) out.push(record);
   }
 
-  return out.length > 0
-    ? out
-    : undefined;
-}
-
-function pruneContact(contact: DatasetContact | undefined): DatasetContact | undefined {
-  if (!contact)
-    return undefined;
-
-  return contact.firstName || contact.middleName || contact.lastName
-    || contact.country || contact.affiliation || contact.email
-    || contact.isPrimary
-    ? contact
-    : undefined;
+  return out.length > 0 ? out : undefined;
 }
 
 function scrubExternalIdentifiers(
@@ -123,6 +115,15 @@ function scrubDatasetCharacteristics(
     sampleTypes: removeEmpties(dChars?.sampleTypes),
     studySpecies: removeEmpties(dChars?.studySpecies),
   };
+}
+
+/**
+ * Tests if a given object contains truthy values.
+ */
+function isEmptyObject(obj: Record<string, any>): boolean {
+  for (const key of Object.keys(obj)) if (obj[key]) return false;
+
+  return true;
 }
 
 function removeEmpties<T>(values: T[] | undefined): T[] | undefined {

--- a/packages/libs/user-datasets/src/lib/Service/process/create-dataset.ts
+++ b/packages/libs/user-datasets/src/lib/Service/process/create-dataset.ts
@@ -1,4 +1,5 @@
 import {
+  DatasetContact,
   DatasetPostDetails,
   DatasetPostResponseBody,
   DatasetUploads,
@@ -54,7 +55,7 @@ function scrubDetails(details: DatasetPostDetails): DatasetPostDetails {
     ...details,
 
     installTargets: removeEmpties(details.installTargets),
-    contacts: removeEmpties(details.contacts),
+    contacts: pruneContacts(details.contacts),
     datasetSources: removeEmpties(details.datasetSources),
     dependencies: removeEmpties(details.dependencies),
     funding: removeEmpties(details.funding),
@@ -66,6 +67,35 @@ function scrubDetails(details: DatasetPostDetails): DatasetPostDetails {
       details.datasetCharacteristics
     ),
   };
+}
+
+function pruneContacts(contacts: DatasetContact[] | undefined): DatasetContact[] | undefined  {
+  if (!contacts)
+    return undefined;
+
+  const out: DatasetContact[] = [];
+
+  for (const contact of contacts) {
+    const res = pruneContact(contact);
+
+    if (res)
+      out.push(res);
+  }
+
+  return out.length > 0
+    ? out
+    : undefined;
+}
+
+function pruneContact(contact: DatasetContact | undefined): DatasetContact | undefined {
+  if (!contact)
+    return undefined;
+
+  return contact.firstName || contact.middleName || contact.lastName
+    || contact.country || contact.affiliation || contact.email
+    || contact.isPrimary
+    ? contact
+    : undefined;
 }
 
 function scrubExternalIdentifiers(


### PR DESCRIPTION
Presently, if a user creates a contact object, edits it, then blanks it out, we are submitting a contact object with empty values.

This filters out contact objects that contain no truthy values.