### PR TITLE
Fix My Datasets sorting and display "Shared With... Me"

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -175,12 +175,15 @@ class UserDatasetList extends React.Component<DatasetListProps, State> {
       );
   }
 
-  renderSharedWithCell(cellProps: MesaDataCellProps) {
-    const dataset = cellProps.row;
+  sharedWithValue(dataset: DatasetListEntry): string | null {
     if (!this.isMyDataset(dataset)) return 'Me';
     return !dataset.shares || !dataset.shares.length
       ? null
       : dataset.shares.map((share) => datasetUserFullName(share)).join(', ');
+  }
+
+  renderSharedWithCell(cellProps: MesaDataCellProps) {
+    return this.sharedWithValue(cellProps.row);
   }
 
   renderCommunityCell(cellProps: MesaDataCellProps) {
@@ -598,6 +601,12 @@ class UserDatasetList extends React.Component<DatasetListProps, State> {
       case 'type':
         return (data: DatasetListEntry, _: number): string =>
           data.type.category.toLowerCase();
+      case 'owner':
+        return (data: DatasetListEntry): string =>
+          datasetUserFullName(data.owner).toLowerCase();
+      case 'sharedWith':
+        return (data: DatasetListEntry): string | null =>
+          this.sharedWithValue(data)?.toLowerCase() ?? '\uFFFF';
       default:
         return (data: any, _: number) => {
           const val =

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -607,6 +607,8 @@ class UserDatasetList extends React.Component<DatasetListProps, State> {
       case 'sharedWith':
         return (data: DatasetListEntry): string | null =>
           this.sharedWithValue(data)?.toLowerCase() ?? '\uFFFF';
+      case 'size':
+        return (data: DatasetListEntry): number => data.fileSizeTotal ?? 0;
       default:
         return (data: any, _: number) => {
           const val =

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -140,6 +140,7 @@ class UserDatasetList extends React.Component<DatasetListProps, State> {
 
     this.renderOwnerCell = this.renderOwnerCell.bind(this);
     this.renderStatusCell = this.renderStatusCell.bind(this);
+    this.renderSharedWithCell = this.renderSharedWithCell.bind(this);
 
     this.openSharingModal = this.openSharingModal.bind(this);
     this.closeSharingModal = this.closeSharingModal.bind(this);
@@ -176,6 +177,7 @@ class UserDatasetList extends React.Component<DatasetListProps, State> {
 
   renderSharedWithCell(cellProps: MesaDataCellProps) {
     const dataset = cellProps.row;
+    if (!this.isMyDataset(dataset)) return 'Me';
     return !dataset.shares || !dataset.shares.length
       ? null
       : dataset.shares.map((share) => datasetUserFullName(share)).join(', ');

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -596,13 +596,11 @@ class UserDatasetList extends React.Component<DatasetListProps, State> {
       case 'type':
         return (data: DatasetListEntry, _: number): string =>
           data.type.category.toLowerCase();
-      case 'meta.name':
-        return (data: DatasetListEntry) => data.name.toLowerCase();
       default:
         return (data: any, _: number) => {
-          return typeof data[columnKey] !== 'undefined'
-            ? data[columnKey]
-            : null;
+          const val =
+            typeof data[columnKey] !== 'undefined' ? data[columnKey] : null;
+          return typeof val === 'string' ? val.toLowerCase() : val;
         };
     }
   }
@@ -613,9 +611,9 @@ class UserDatasetList extends React.Component<DatasetListProps, State> {
   ): DatasetListEntry[] {
     const direction: string = sort.direction;
     const columnKey: string = sort.columnKey;
-    const mappedValue = this.getColumnSortValueMapper(columnKey);
-    const sorted = [...rows].sort(MesaUtils.sortFactory(mappedValue));
-    return direction === 'asc' ? sorted : sorted.reverse();
+    const valueMapper = this.getColumnSortValueMapper(columnKey);
+    const sorted = [...rows].sort(MesaUtils.sortFactory(valueMapper));
+    return direction === 'asc' ? sorted.reverse() : sorted;
   }
 
   closeSharingModal() {


### PR DESCRIPTION
**My Datasets — Sorting Improvements**

We've made several improvements to the way datasets are sorted and displayed in the My Datasets table:

- **Alphabetical sorting now ignores case**, so "apple" and "Apple" are treated as the same for sorting purposes, rather than all uppercase names appearing before all lowercase ones.

- **Sorting by Name now works correctly.** Previously, the Name column was using an outdated internal label and wasn't being sorted properly.
  - Note: I did not trim leading/trailing whitespace - the VDI does this for all datasets going forwards so no need for legacy test datasets.

- **Ascending and descending sort order were the wrong way round.** Clicking a column header to sort A–Z would actually sort Z–A, and vice versa. This has been corrected.

- **Sorting by Owner now groups datasets by the same owner correctly.** Previously, datasets belonging to the same person could appear scattered throughout the list when sorting by Owner.

- **Sorting by Shared With now works.** This column was previously unsortable due to a mismatch between how the data is stored and how it's displayed.

- **Sorting by Size now sorts by actual file size** in bytes, rather than appearing in a seemingly random order.

- **Datasets shared with you now show "Me"** in the Shared With column, making it immediately clear that the dataset was shared with you personally.
