### PR TITLE
Beta review spreadsheet fixes.

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Components/InputPair.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Components/InputPair.tsx
@@ -57,11 +57,14 @@ export function InputPair<T extends object = object>(
     <FieldHelpText className={props.className}>{props.helpText}</FieldHelpText>
   ) : undefined;
 
-  let labelClass = '';
+  let labelClass = "";
 
-  if (props.className) labelClass += ' ' + props.className;
-  if (props.labelClass) labelClass += ' ' + props.labelClass;
-  if (props.required) labelClass += ' required';
+  if (props.className)
+    labelClass += " " + props.className;
+  if (props.labelClass)
+    labelClass += " " + props.labelClass;
+  if (props.required)
+    labelClass += " required";
 
   let input: ReactElement;
 

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Components/InputPair.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Components/InputPair.tsx
@@ -57,11 +57,11 @@ export function InputPair<T extends object = object>(
     <FieldHelpText className={props.className}>{props.helpText}</FieldHelpText>
   ) : undefined;
 
-  const labelClass = props.className
-    ? props.labelClass
-      ? `${props.className} ${props.labelClass}`
-      : props.className
-    : props.labelClass;
+  let labelClass = '';
+
+  if (props.className) labelClass += ' ' + props.className;
+  if (props.labelClass) labelClass += ' ' + props.labelClass;
+  if (props.required) labelClass += ' required';
 
   let input: ReactElement;
 

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/CharacteristicsSection.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/CharacteristicsSection.tsx
@@ -73,9 +73,9 @@ export function CharacteristicsSection({
           fieldName="enable-characteristics"
           className="not-disabled"
           helpText={
-            'Whether the dataset is from a human, vector, animal, or plant' +
-            ' population study; an epidemiological study (including' +
-            ' surveillance); or a clinical trial'
+            'Whether the dataset or underlying samples originated from a' +
+            ' human, vector, animal, or plant population study; an' +
+            ' epidemiological or surveillance study; or a clinical trial.'
           }
         />
 

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/DatasetSources.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/DatasetSources.tsx
@@ -109,6 +109,8 @@ function DataSource({
   source,
   setSource,
 }: DataSourceProps): ReactElement {
+  const required = index === 0 && enabled;
+
   return (
     <li className="field-grid">
       <InputPair
@@ -117,6 +119,7 @@ function DataSource({
         value={source.url}
         onChange={(v) => setSource({ ...source, url: v }, index)}
         disabled={!enabled}
+        required={required}
         helpText="The URL where the dataset is hosted or was obtained."
       />
 
@@ -126,6 +129,7 @@ function DataSource({
         value={source.version}
         onChange={(v) => setSource({ ...source, version: v }, index)}
         disabled={!enabled}
+        required={required}
         helpText={
           'The version number or publication date from the site where the' +
           ' data was obtained. If neither is available, the data download' +

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/DatasetUsage.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/DatasetUsage.tsx
@@ -24,7 +24,9 @@ export function DatasetUsage({
   const fieldName =
     jsonPath.appendToString<DatasetPostDetails>('dataDisclaimer');
 
-  const disabledClass = clientSideState.hasDisclaimer ? '' : ' disabled-fields';
+  const { hasDisclaimer } = clientSideState;
+
+  const disabledClass = hasDisclaimer ? '' : ' disabled-fields';
 
   const setEnabled = (enabled: boolean) =>
     setClientSideState({ ...clientSideState, hasDisclaimer: enabled });
@@ -36,7 +38,7 @@ export function DatasetUsage({
           Important Reuse Considerations
         </label>
         <YesNoToggle
-          value={clientSideState.hasDisclaimer}
+          value={hasDisclaimer}
           setValue={setEnabled}
           fieldName="enable-disclaimer"
           className="not-disabled"
@@ -47,12 +49,18 @@ export function DatasetUsage({
           }
         />
 
-        <label htmlFor={fieldName}>Disclaimers</label>
+        <label
+          htmlFor={fieldName}
+          className={hasDisclaimer ? 'required' : undefined}
+        >
+          Disclaimers
+        </label>
         <textarea
           name={fieldName}
           id={fieldName}
           value={datasetMeta.dataDisclaimer}
-          disabled={!clientSideState.hasDisclaimer}
+          disabled={!hasDisclaimer}
+          required={hasDisclaimer}
           onChange={(e) =>
             changeHandler(
               'dataDisclaimer',

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/DatasetUsage.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/DatasetUsage.tsx
@@ -51,10 +51,8 @@ export function DatasetUsage({
 
         <label
           htmlFor={fieldName}
-          className={hasDisclaimer ? 'required' : undefined}
-        >
-          Disclaimers
-        </label>
+          className={hasDisclaimer ? "required" : undefined}
+        >Disclaimers</label>
         <textarea
           name={fieldName}
           id={fieldName}

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/DatasetPropertiesInput.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/DatasetPropertiesInput.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import { Consumer } from '../../../../../Utils';
+import { GlobeIcon } from '../../Components';
 
 export interface DatasetPropertiesInputProps {
   readonly label: string;
@@ -24,7 +25,7 @@ export function DatasetPropertiesInput(
   return (
     <>
       <label htmlFor={props.fieldName} className={labelClass}>
-        {props.label}
+        <GlobeIcon /> {props.label}
       </label>
       <input
         type="file"

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/RootDetailsSection.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/RootDetailsSection.tsx
@@ -67,7 +67,7 @@ export function RootDetailsSection(
 
       <div className="field-grid">
         <InputPair
-          label="Name"
+          label="Dataset Name"
           fieldName={nameKey}
           value={datasetDetails.name}
           onChange={(v) => setMetadata({ ...datasetDetails, name: v })}

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/RootDetailsSection.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/RootDetailsSection.tsx
@@ -103,6 +103,7 @@ export function RootDetailsSection(
             <DatasetPropertiesInput
               label={formProps.verbiage.formInputs.datasetProperties.label}
               fieldName="dataPropertiesFile"
+              allowedExtensions={['.txt', '.csv', '.tsv']}
               setFiles={(files) =>
                 setUploads({
                   ...fileUploads,

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.tsx
@@ -115,7 +115,7 @@ export function UploadForm(props: UploadFormProps): ReactElement {
         />
       </header>
 
-      <form className={props.formClassName} onChange={onFormChange}>
+      <form className={props.formClassName} onInput={onFormChange}>
         <RootDetailsSection
           formProps={props}
           detailsJsonPath={metaPath}

--- a/packages/libs/web-common/src/user-dataset-upload-config.tsx
+++ b/packages/libs/web-common/src/user-dataset-upload-config.tsx
@@ -18,6 +18,7 @@ import {
   DatasetTypeConfig,
   DatasetUploadConfig,
 } from '@veupathdb/user-datasets/lib/Components/Upload';
+import { formatFileSize } from '@veupathdb/user-datasets/lib/Utils/formatting';
 
 /**
  * Type identifiers for dataset types that have client handling.
@@ -301,8 +302,16 @@ function isasimpleFormConfigurator(
       file: {
         enabled: true,
         helpText: (
-          <div style={{ marginTop: '0.25em' }}>
-            File must be a .csv, .tsv, or tab-delimited .txt file
+          <div>
+            <p>
+              Upload a single <strong>data file</strong> (maximum{' '}
+              {formatFileSize(dataType.vdiConfig.maxFileSize, 'binary')}):
+            </p>
+            <ul>
+              <li>in .csv, .tsv, or tab-delimited .txt format; compressed (.zip)
+                files are also supported</li>
+              <li>with variables as columns, records as rows</li>
+            </ul>
           </div>
         ),
       },


### PR DESCRIPTION
* Yes/No section toggles set required fields
  * disclaimer becomes required when section is enabled
  * at least one data source is required when section is enabled
* corrected inconsistent behavior regarding form validation when toggling sections
* limit VAF extensions to txt, csv, tsv
* changed "Name" label to "Dataset Name"
* replaced isasimple upload verbiage
* added globe icon to VAF input
* updated dataset characteristics yes/no toggle help text.