### PR TITLE
Fix file size formatting.

### DIFF
--- a/packages/libs/user-datasets/src/lib/Utils/formatting.ts
+++ b/packages/libs/user-datasets/src/lib/Utils/formatting.ts
@@ -21,7 +21,7 @@ export function formatFileSize(
   let mag = 0;
   let quo = bytes;
 
-  while (quo > div && mag < 4) {
+  while (quo >= div && mag < 4) {
     quo /= div;
     mag++;
   }


### PR DESCRIPTION
Currently it incorrectly shows `1024MiB` instead of `1GiB`.

Problem: 
<img width="482" height="83" alt="image" src="https://github.com/user-attachments/assets/a7d0a414-1686-4dce-bc8e-8141e443f7b4" />

With fix: 
<img width="469" height="64" alt="image" src="https://github.com/user-attachments/assets/990d7700-4e18-4dfd-a7a6-37309ecaa6e7" />
