### PR TITLE
Fix `isInstalled` checks in user dataset detail components

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/Detail/EdaDatasetDetail.jsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/EdaDatasetDetail.jsx
@@ -16,13 +16,6 @@ class EdaDatasetDetail extends UserDatasetDetail {
       edaMapUrl,
     } = this.props;
 
-    const isInstalled =
-      status?.import.status === 'complete' &&
-      status?.install?.find((d) => d.installTarget === projectId)?.data.status ===
-        'complete';
-
-    if (!isInstalled) return null;
-
     if (edaWorkspaceUrl == null && edaMapUrl == null) return null;
 
     return (

--- a/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Detail/UserDatasetDetail.tsx
@@ -256,8 +256,12 @@ class UserDatasetDetail<S = {}> extends React.Component<DetailViewProps, S> {
     const { status } = this.props.userDataset;
     return (
       status?.import?.status === 'complete' &&
-      status?.install?.find((d) => d.installTarget === config.projectId)?.data
-        ?.status === 'complete'
+      status?.install?.some(
+        (d) =>
+          d.installTarget === config.projectId &&
+          d.data?.status === 'complete' &&
+          (d.meta == null || d.meta.status === 'complete')
+      )
     );
   }
 


### PR DESCRIPTION
Two small fixes to the `isInstalled` logic:

1. **DRY-up (`EdaDatasetDetail`)**: Removed a redundant local `isInstalled` check inside `renderEdaLinkout`. The method is only ever called from `getAttributes`, which already guards on `this.isInstalled()`, so the inner check was dead code.

2. **Meta status check (`UserDatasetDetail`)**: Extended `isInstalled` to also require `d.meta.status === 'complete'` when a `meta` install entry is present alongside `data`. If `meta` is absent the check is skipped. Also switched from `find(...)?. ...` to `some(...)` which better expresses the intent.
