### PR TITLE
Sanitize user/database-derived html properly before display

### DIFF
--- a/packages/libs/coreui/package.json
+++ b/packages/libs/coreui/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@react-hook/size": "^2.1.2",
     "core-js": "^3.25.3",
+    "dompurify": "^3.4.7",
     "lodash": "^4.17.21",
     "react-cool-dimensions": "^2.0.7",
     "react-draggable": "^4.4.5",

--- a/packages/libs/coreui/src/components/Mesa/Components/MesaTooltip.tsx
+++ b/packages/libs/coreui/src/components/Mesa/Components/MesaTooltip.tsx
@@ -1,4 +1,5 @@
 import React, { CSSProperties } from 'react';
+import DOMPurify from 'dompurify';
 
 import { Tooltip } from '../../info/Tooltip';
 
@@ -54,7 +55,11 @@ const MesaTooltip = ({
     <Tooltip
       title={
         renderHtml ? (
-          <div dangerouslySetInnerHTML={{ __html: content as string }} />
+          <div
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(content as string),
+            }}
+          />
         ) : (
           content ?? <></>
         )

--- a/packages/libs/coreui/src/components/Mesa/Templates.jsx
+++ b/packages/libs/coreui/src/components/Mesa/Templates.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 
 import { OptionsDefaults } from './Defaults';
 import OverScroll from './Components/OverScroll';
@@ -35,7 +36,9 @@ const Templates = {
     let { displayText, url } = value;
     let href = url ? url : '#';
     let text = displayText.length ? value.displayText : href;
-    text = <div dangerouslySetInnerHTML={{ __html: text }} />;
+    text = (
+      <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(text) }} />
+    );
     let target = '_blank';
 
     const props = { href, target, className };
@@ -59,7 +62,9 @@ const Templates = {
   htmlCell({ key, value, row, rowIndex, column }) {
     const { truncated } = column;
     const className = 'Cell HtmlCell Cell-' + key;
-    const content = <div dangerouslySetInnerHTML={{ __html: value }} />;
+    const content = (
+      <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(value) }} />
+    );
     const size = truncated === true ? '16em' : truncated;
 
     return truncated ? (

--- a/packages/libs/coreui/src/components/inputs/SelectTree/Utils.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/Utils.tsx
@@ -1,4 +1,5 @@
 import 'regenerator-runtime/runtime';
+import DOMPurify from 'dompurify';
 // Field types
 // -----------
 
@@ -384,13 +385,10 @@ export function safeHtml<P>(
   if (str.indexOf('<') === -1) {
     return <Component {...props}>{str}</Component>;
   }
-  // Use innerHTML to auto close tags
-  const container = document.createElement('div');
-  container.innerHTML = str;
   return (
     <Component
       {...props}
-      dangerouslySetInnerHTML={{ __html: container.innerHTML }}
+      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(str) }}
     />
   );
 }

--- a/packages/libs/preferred-organisms/package.json
+++ b/packages/libs/preferred-organisms/package.json
@@ -18,6 +18,7 @@
     "@veupathdb/coreui": "workspace:^",
     "@veupathdb/wdk-client": "workspace:^",
     "@veupathdb/web-common": "workspace:^",
+    "dompurify": "^3.4.7",
     "lodash": "^4.17.21",
     "recoil": "^0.7.7"
   },

--- a/packages/libs/preferred-organisms/src/lib/hooks/maxRecommendedGate.tsx
+++ b/packages/libs/preferred-organisms/src/lib/hooks/maxRecommendedGate.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import DOMPurify from 'dompurify';
 import { Dialog } from '@veupathdb/wdk-client/lib/Components';
 import {
   FilledButton,
@@ -99,7 +100,11 @@ export function useMaxRecommendedGate(
       <div className="MaxRecommendedGate">
         <div className="MaxRecommendedGate--Message">
           {customMessage ? (
-            <div dangerouslySetInnerHTML={{ __html: customMessage }} />
+            <div
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(customMessage),
+              }}
+            />
           ) : (
             defaultMessage
           )}

--- a/packages/libs/wdk-client/package.json
+++ b/packages/libs/wdk-client/package.json
@@ -25,6 +25,7 @@
     "@veupathdb/components": "workspace:^",
     "@veupathdb/coreui": "workspace:^",
     "classnames": "^2.2.0",
+    "dompurify": "^3.4.7",
     "history": "^4.10.1",
     "json-stable-stringify": "^1.0.0",
     "localforage": "^1.5.0",

--- a/packages/libs/wdk-client/src/Utils/ComponentUtils.tsx
+++ b/packages/libs/wdk-client/src/Utils/ComponentUtils.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import DOMPurify from 'dompurify';
 import { AttributeValue } from '../Utils/WdkModel';
 import { stripHTML } from './DomUtils';
 
@@ -267,13 +268,10 @@ export function safeHtml<P>(
   if (str.indexOf('<') === -1 && !isHtmlEntityFound) {
     return <Component {...props}>{str}</Component>;
   }
-  // Use innerHTML to auto close tags
-  let container = document.createElement('div');
-  container.innerHTML = str;
   return (
     <Component
       {...props}
-      dangerouslySetInnerHTML={{ __html: container.innerHTML }}
+      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(str) }}
     />
   );
 }

--- a/packages/libs/wdk-client/src/Views/ResultTableSummaryView/AttributeCell.tsx
+++ b/packages/libs/wdk-client/src/Views/ResultTableSummaryView/AttributeCell.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { isEqual, truncate } from 'lodash';
+import DOMPurify from 'dompurify';
 import { RecordInstance, AttributeField } from '../../Utils/WdkModel';
 import { safeHtml, wrappable } from '../../Utils/ComponentUtils';
 import { Tooltip } from '@veupathdb/coreui';
@@ -78,7 +79,7 @@ function AttributeCellInner({ attribute, recordInstance }: AttributeCellProps) {
       <a
         href={url}
         dangerouslySetInnerHTML={{
-          __html: truncatedDisplay,
+          __html: DOMPurify.sanitize(truncatedDisplay),
         }}
       />
     </div>

--- a/packages/libs/web-common/package.json
+++ b/packages/libs/web-common/package.json
@@ -37,6 +37,7 @@
     "@veupathdb/eda": "workspace:^",
     "@veupathdb/wdk-client": "workspace:^",
     "custom-event-polyfill": "^1.0.7",
+    "dompurify": "^3.4.7",
     "md5": "^2.3.0",
     "pluralize": "^8.0.0",
     "whatwg-fetch": "^3.5.0"

--- a/packages/libs/web-common/src/App/Header/HeaderNav.jsx
+++ b/packages/libs/web-common/src/App/Header/HeaderNav.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 import { siteSearchServiceUrl } from '../../config';
 import SiteMenu from '../../App/SiteMenu';
 import { UserMenu, UserMenuGuest } from '../../App/UserMenu';
@@ -213,7 +214,9 @@ class HeaderNav extends React.Component {
             <Branding {...this.props} />
           </div>
           <div style={{ alignSelf: 'center' }}>
-            <h3 dangerouslySetInnerHTML={{ __html: tagline }} />
+            <h3
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(tagline) }}
+            />
           </div>
           <a href="https://veupathdb.org" target="_blank">
             <img src={partofveupath} id="VEuPathLogo" />

--- a/packages/libs/web-common/src/App/ImageCard/ImageCard.jsx
+++ b/packages/libs/web-common/src/App/ImageCard/ImageCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 
 import './ImageCard.scss';
 
@@ -34,9 +35,15 @@ class ImageCard extends React.Component {
         />
         <div className="box ImageCard-Title">
           <a href={linkUrl}>
-            <h3 dangerouslySetInnerHTML={{ __html: title }} />
+            <h3
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(title) }}
+            />
           </a>
-          <p dangerouslySetInnerHTML={{ __html: description }} />
+          <p
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(description),
+            }}
+          />
         </div>
         <a className="ImageCard-Footer" href={linkUrl} target={linkTarget}>
           {linkText} <Icon fa={'chevron-circle-right'} />

--- a/packages/libs/web-common/src/App/Searches/SearchCard.jsx
+++ b/packages/libs/web-common/src/App/Searches/SearchCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 
 import './SearchCard.scss';
 
@@ -47,7 +48,7 @@ class SearchCard extends React.Component {
         <div className="box SearchCard-Body">
           <div
             dangerouslySetInnerHTML={{
-              __html: httpHtml({ description }),
+              __html: DOMPurify.sanitize(httpHtml({ description })),
             }}
           />
         </div>

--- a/packages/libs/web-common/src/App/Studies/StudyCard.jsx
+++ b/packages/libs/web-common/src/App/Studies/StudyCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 import { connect } from 'react-redux';
 import { useEda } from '../../config';
 import { CategoryIcon } from '../../App/Categories';
@@ -177,7 +178,10 @@ class StudyCard extends React.Component {
         <div className="box StudyCard-Body">
           <ul>
             {points.map((point, index) => (
-              <li key={index} dangerouslySetInnerHTML={{ __html: point }} />
+              <li
+                key={index}
+                dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(point) }}
+              />
             ))}
           </ul>
         </div>

--- a/packages/libs/web-common/src/components/SiteSearch/SiteSearch.tsx
+++ b/packages/libs/web-common/src/components/SiteSearch/SiteSearch.tsx
@@ -1586,7 +1586,10 @@ function makeGenericSummary(
 
 function HtmlString(props: { value: string }) {
   const { value } = props;
-  const sanitized = useMemo(() => DOMPurify.sanitize(value), [value]);
+  const sanitized = useMemo(
+    () => DOMPurify.sanitize(value, { FORBID_TAGS: ['img'] }),
+    [value]
+  );
   return <span dangerouslySetInnerHTML={{ __html: sanitized }} />;
 }
 

--- a/packages/libs/web-common/src/components/SiteSearch/SiteSearch.tsx
+++ b/packages/libs/web-common/src/components/SiteSearch/SiteSearch.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import { Tooltip } from '@veupathdb/coreui';
 import { DataGrid } from '@veupathdb/coreui';
 import {
@@ -1585,15 +1586,8 @@ function makeGenericSummary(
 
 function HtmlString(props: { value: string }) {
   const { value } = props;
-  const formattedValue = useMemo(() => {
-    const div = document.createElement('div');
-    div.innerHTML = value;
-    div
-      .querySelectorAll('img, object, iframe')
-      .forEach((el) => el.parentElement?.removeChild(el));
-    return div.innerHTML;
-  }, [value]);
-  return <span dangerouslySetInnerHTML={{ __html: formattedValue }} />;
+  const sanitized = useMemo(() => DOMPurify.sanitize(value), [value]);
+  return <span dangerouslySetInnerHTML={{ __html: sanitized }} />;
 }
 
 function formatSummaryFieldValue(value?: string | string[]) {

--- a/packages/libs/web-common/src/components/homepage/FeaturedTools.tsx
+++ b/packages/libs/web-common/src/components/homepage/FeaturedTools.tsx
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import React, {
   useCallback,
   useEffect,
@@ -393,7 +394,7 @@ const SelectionBody = ({ entry }: SelectionBodyProps) => {
         ref={ref}
         className={cx('SelectionBodyContent', isExpanded && 'expanded')}
         dangerouslySetInnerHTML={{
-          __html: entry?.output || '...',
+          __html: DOMPurify.sanitize(entry?.output || '...'),
         }}
       ></div>
       {isOverflowing && (

--- a/packages/libs/web-common/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
+++ b/packages/libs/web-common/src/components/records/DatasetRecordClasses.DatasetRecordClass.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 import { connect } from 'react-redux';
 import { HelpIcon, Link } from '@veupathdb/wdk-client/lib/Components';
 import { pure } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
@@ -117,7 +118,11 @@ export function RecordHeading(props) {
           {organism_prefix ? (
             <>
               <dt>Organism (source or reference)</dt>
-              <dd dangerouslySetInnerHTML={{ __html: organism_prefix }} />
+              <dd
+                dangerouslySetInnerHTML={{
+                  __html: DOMPurify.sanitize(organism_prefix),
+                }}
+              />
             </>
           ) : null}
 
@@ -161,7 +166,7 @@ export function RecordHeading(props) {
           <dt>Summary</dt>
           <dd
             style={{ whiteSpace: 'normal' }}
-            dangerouslySetInnerHTML={{ __html: summary }}
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(summary) }}
           />
 
           {megabase_pairs ? (

--- a/packages/libs/web-common/src/components/records/UserDatasetRecordClasses.UserDatasetRecordClass.jsx
+++ b/packages/libs/web-common/src/components/records/UserDatasetRecordClasses.UserDatasetRecordClass.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 import { connect } from 'react-redux';
 import { HelpIcon, Link } from '@veupathdb/wdk-client/lib/Components';
 import { projectId } from '../../config';
@@ -88,7 +89,7 @@ export function RecordHeading(props) {
           <dt>Summary:</dt>
           <dd
             style={{ whiteSpace: 'normal' }}
-            dangerouslySetInnerHTML={{ __html: summary }}
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(summary) }}
           />
 
           <dt>Data Accessibility:</dt>

--- a/packages/sites/clinepi-site/package.json
+++ b/packages/sites/clinepi-site/package.json
@@ -88,6 +88,7 @@
     "dist"
   ],
   "dependencies": {
-    "@veupathdb/preferred-organisms": "workspace:^"
+    "@veupathdb/preferred-organisms": "workspace:^",
+    "dompurify": "^3.4.7"
   }
 }

--- a/packages/sites/clinepi-site/webapp/js/client/component-wrappers/QuestionWizard.jsx
+++ b/packages/sites/clinepi-site/webapp/js/client/component-wrappers/QuestionWizard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 import { connect } from 'react-redux';
 import { IconAlt, Link } from '@veupathdb/wdk-client/lib/Components';
 import { getStudyByQuestionName } from '../selectors/siteData';
@@ -34,7 +35,7 @@ export default (QuestionWizard) =>
               <span id="prompt">Summary: </span>
               <span
                 dangerouslySetInnerHTML={{
-                  __html: wizardState.question.summary,
+                  __html: DOMPurify.sanitize(wizardState.question.summary),
                 }}
               />
             </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7908,6 +7908,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10/8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
+  languageName: node
+  linkType: hard
+
 "@types/uglify-js@npm:*":
   version: 3.17.1
   resolution: "@types/uglify-js@npm:3.17.1"
@@ -8459,6 +8466,7 @@ __metadata:
     bubleify: "npm:^2.0.0"
     core-js: "npm:^3.25.3"
     css-loader: "npm:^6.7.4"
+    dompurify: "npm:^3.4.7"
     file-loader: "npm:^3.0.1"
     html-webpack-plugin: "npm:^4.5.2"
     ify-loader: "npm:^1.1.0"
@@ -8624,6 +8632,7 @@ __metadata:
     chromatic: "npm:^6.2.0"
     core-js: "npm:^3.25.3"
     css-loader: "npm:^6.7.4"
+    dompurify: "npm:^3.4.7"
     eslint: "npm:^8.9.0"
     eslint-plugin-react: "npm:^7.28.0"
     eslint-plugin-react-hooks: "npm:^4.3.0"
@@ -9114,6 +9123,7 @@ __metadata:
     "@veupathdb/wdk-client": "workspace:^"
     "@veupathdb/web-common": "workspace:^"
     babel-eslint: "npm:^10.0.0"
+    dompurify: "npm:^3.4.7"
     eslint: "npm:^7.5.0"
     eslint-config-react-app: "npm:^6.0.0"
     eslint-plugin-flowtype: "npm:^5.2.0"
@@ -9346,6 +9356,7 @@ __metadata:
     babel-eslint: "npm:^8.0.1"
     babel-jest: "npm:^23.1.2"
     classnames: "npm:^2.2.0"
+    dompurify: "npm:^3.4.7"
     eslint: "npm:^7.12.1"
     eslint-plugin-import: "npm:^2.8.0"
     eslint-plugin-react: "npm:^7.4.0"
@@ -9413,6 +9424,7 @@ __metadata:
     "@veupathdb/wdk-client": "workspace:^"
     bubleify: "npm:^2.0.0"
     custom-event-polyfill: "npm:^1.0.7"
+    dompurify: "npm:^3.4.7"
     icon-font-generator: "npm:^2.1.11"
     ify-loader: "npm:^1.1.0"
     md5: "npm:^2.3.0"
@@ -17393,6 +17405,18 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: 10/809b805a50a9c6884a29f38aec0a4e1b4537f40e1c861950ed47d10b049febe6b79ab72adaeeebb3cc8fc1cd33f34e97048a72a9265103426d93efafa78d3e96
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.4.7":
+  version: 3.4.7
+  resolution: "dompurify@npm:3.4.7"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10/7432e2a2fe1f4235e09e54d40c285eb76812afab46605fb52449891ca922e474fd5cab2cc297ae9ae1e235d1186e9e9924c32178903359d18e4587cd5119471b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**DOMPurify** is a battle-tested HTML sanitizer. You give it an HTML string, it gives you back an HTML string that's safe to inject into the DOM.

It works by parsing the input into a real DOM tree, then walking every node and attribute against an allowlist. Anything not on the list — `<script>` tags, inline event handlers like `onerror="..."`, `javascript:` URLs, `<iframe>`, `<object>` — is stripped. Safe markup (formatting tags, links, search-result `<em>` highlights) passes through untouched, so it's transparent to legitimate content.

This is the correct approach for sanitizing server-delivered HTML before rendering it with React's `dangerouslySetInnerHTML`. The React prop exists to make injection *explicit*, not to make it *safe* — that's DOMPurify's job.

Prior to this PR, the codebase had a mix of no sanitization, hand-rolled regex transforms that didn't sanitize (only linkified), and one partial attempt that removed a few specific tags but missed `<script>` and inline event handlers. DOMPurify replaces all of that with a single consistent call at each injection site.

Will it keep us safe? The `3.x.y` branch is regularly patched and we should be good if we keep an eye on updates.

---

Every `dangerouslySetInnerHTML` is now either:
- Wrapped in `DOMPurify.sanitize()` (13 sites)
- Using `sanitaryTextReformat()` — the pre-existing safe escaper in `SaveableTextEditor` (untouched)
- Injecting locally-generated SVG in the map markers (untouched, no external data)

**Summary of what changed:**

| File | Change |
|------|--------|
| `wdk-client/Utils/ComponentUtils.tsx` | Added DOMPurify; removed intermediate `container` div in `safeHtml` |
| `wdk-client/Views/ResultTableSummaryView/AttributeCell.tsx` | Sanitize link `displayText` |
| `coreui/inputs/SelectTree/Utils.tsx` | Same fix as `ComponentUtils.safeHtml` |
| `coreui/Mesa/Components/MesaTooltip.tsx` | Sanitize `content` |
| `coreui/Mesa/Templates.jsx` | Sanitize `text` and `value` |
| `web-common/SiteSearch/SiteSearch.tsx` | Replaced manual DOM stripping with `DOMPurify.sanitize` — restore original behaviour with `{ FORBID_TAGS: ['img'] }` (adds to block list) |
| `web-common/Header/HeaderNav.jsx` | Sanitize `tagline` |
| `web-common/Searches/SearchCard.jsx` | Sanitize result of `httpHtml()` |
| `web-common/records/DatasetRecordClasses…` | Sanitize `organism_prefix` + `summary` |
| `web-common/records/UserDatasetRecordClasses…` | Sanitize `summary` |
| `web-common/Studies/StudyCard.jsx` | Sanitize `point` |
| `web-common/homepage/FeaturedTools.tsx` | Sanitize `entry?.output` |
| `web-common/ImageCard/ImageCard.jsx` | Sanitize `title` + `description` |
| `preferred-organisms/maxRecommendedGate.tsx` | Sanitize `customMessage` |
| `clinepi-site/QuestionWizard.jsx` | Sanitize `question.summary` |
