### PR TITLE
Fix too many bins protection for histogram `distribution` back end calls

### DIFF
--- a/packages/libs/eda/config-overrides.js
+++ b/packages/libs/eda/config-overrides.js
@@ -58,3 +58,25 @@ module.exports = function override(config, env) {
     },
   };
 };
+
+/*
+ * Jest (test runner) config overrides, applied by react-app-rewired.
+ *
+ * Several modules in this package transitively import the d3 family of
+ * packages (e.g. d3, d3-scale), which ship as untransformed ES modules.
+ * CRA's default `transformIgnorePatterns` skips everything in node_modules,
+ * so Jest chokes on the `export` syntax with "Unexpected token 'export'".
+ *
+ * react-app-rewired *concatenates* array overrides from package.json onto
+ * CRA's defaults, so we can't relax the pattern there - the broad default
+ * still matches. Instead we replace `transformIgnorePatterns` outright here,
+ * using a negative lookahead so the d3 packages (and their deps) ARE
+ * transformed while everything else in node_modules is still skipped.
+ */
+module.exports.jest = function (config) {
+  config.transformIgnorePatterns = [
+    '[/\\\\]node_modules[/\\\\](?!(?:d3|d3-[\\w-]+|internmap|delaunator|robust-predicates)[/\\\\]).+\\.(js|jsx|mjs|cjs|ts|tsx)$',
+    '^.+\\.module\\.(css|sass|scss)$',
+  ];
+  return config;
+};

--- a/packages/libs/eda/package.json
+++ b/packages/libs/eda/package.json
@@ -19,6 +19,7 @@
     "react-cool-dimensions": "^2.0.7",
     "react-draggable": "^4.4.3",
     "react-resizable": "^3.0.4",
+    "react-test-renderer": "^18.0.0",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
@@ -65,7 +66,7 @@
     "@tanstack/react-query-devtools": "^4.35.3",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^11.1.0",
-    "@testing-library/react-hooks": "^5.0.3",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^12.1.10",
     "@types/date-arithmetic": "^4.1.1",
     "@types/debounce-promise": "^3.1.3",
@@ -79,6 +80,7 @@
     "@types/react-resizable": "^1.7.2",
     "@types/react-router-dom": "^5.3.3",
     "@types/react-table": "^7.7.12",
+    "@types/react-test-renderer": "^18",
     "@types/uuid": "^8.3.4",
     "@veupathdb/browserslist-config": "workspace:^",
     "@veupathdb/eslint-config": "workspace:^",
@@ -90,6 +92,7 @@
     "buffer": "^6.0.3",
     "http-proxy-middleware": "^2.0.6",
     "ify-loader": "^1.1.0",
+    "jest-watch-typeahead": "^3.0.1",
     "notistack": "^3.0.1",
     "path-browserify": "^1.0.1",
     "postcss-normalize": "^10.0.1",
@@ -109,5 +112,11 @@
     "stream-browserify": "^3.0.0",
     "typescript": "^4.3.4",
     "web-vitals": "^0.2.4"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "useAnalysis\\.test\\.tsx"
+    ]
   }
 }

--- a/packages/libs/eda/src/lib/core/constants.ts
+++ b/packages/libs/eda/src/lib/core/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * The maximum number of bins the backend will produce for a single
+ * `distribution` request. Exceeding it yields a bad-request response:
+ * "Variable ... Maximum number of allowed bins (2000) exceeded."
+ *
+ * Front-end code that computes histogram ranges/bin widths must keep
+ * `(rangeMax - rangeMin) / binWidth` at or below this limit.
+ */
+export const MAX_DISTRIBUTION_BINS = 2000;

--- a/packages/libs/eda/src/lib/core/utils/default-axis-range.test.ts
+++ b/packages/libs/eda/src/lib/core/utils/default-axis-range.test.ts
@@ -1,0 +1,75 @@
+import { numberDateDefaultAxisRange } from './default-axis-range';
+import { NumberVariable } from '../types/study';
+import { NumberRange } from '../types/general';
+
+// The backend rejects `distribution` requests whose bin count exceeds this.
+// See "Maximum number of allowed bins (2000) exceeded" bad-request errors.
+const MAX_ALLOWED_BINS = 2000;
+
+function makeIntegerVariable(
+  distributionDefaults: NumberVariable['distributionDefaults']
+): NumberVariable {
+  return {
+    id: 'VAR_TEST',
+    providerLabel: 'test',
+    displayName: 'Test integer variable',
+    hideFrom: [],
+    type: 'integer',
+    units: '',
+    dataShape: 'continuous',
+    distinctValuesCount: 5,
+    isTemporal: false,
+    isFeatured: false,
+    isMergeKey: false,
+    isMultiValued: false,
+    distributionDefaults,
+  };
+}
+
+describe('numberDateDefaultAxisRange - max bins protection', () => {
+  // Real-life bug: a year-like integer variable with values 2000..2004,
+  // continuous, binWidth 1. Because rangeMin (2000) !== rangeMax (2004),
+  // the histogram's lower bound was set to 0, producing 2004 bins for a
+  // displayRangeMin..displayRangeMax of 0..2004, exceeding the backend's
+  // 2000-bin limit. https://github.com/VEuPathDB/web-monorepo (year integers)
+  it('does not produce more than the max allowed bins for a large-valued integer variable', () => {
+    const binWidth = 1;
+    const variable = makeIntegerVariable({
+      rangeMin: 2000,
+      rangeMax: 2004,
+      binWidth,
+    });
+
+    const range = numberDateDefaultAxisRange(
+      variable,
+      undefined,
+      undefined,
+      undefined
+    ) as NumberRange;
+
+    const binCount = (range.max - range.min) / binWidth;
+    expect(binCount).toBeLessThanOrEqual(MAX_ALLOWED_BINS);
+
+    // and the range must still cover the data
+    expect(range.min).toBeLessThanOrEqual(2000);
+    expect(range.max).toBeGreaterThanOrEqual(2004);
+  });
+
+  it('still starts ordinary positive integer variables at zero', () => {
+    const variable = makeIntegerVariable({
+      rangeMin: 5,
+      rangeMax: 100,
+      binWidth: 1,
+    });
+
+    const range = numberDateDefaultAxisRange(
+      variable,
+      undefined,
+      undefined,
+      undefined
+    ) as NumberRange;
+
+    expect(range.min).toBe(0);
+    expect(range.max).toBe(100);
+  });
+});

--- a/packages/libs/eda/src/lib/core/utils/default-axis-range.test.ts
+++ b/packages/libs/eda/src/lib/core/utils/default-axis-range.test.ts
@@ -1,10 +1,7 @@
 import { numberDateDefaultAxisRange } from './default-axis-range';
 import { NumberVariable } from '../types/study';
 import { NumberRange } from '../types/general';
-
-// The backend rejects `distribution` requests whose bin count exceeds this.
-// See "Maximum number of allowed bins (2000) exceeded" bad-request errors.
-const MAX_ALLOWED_BINS = 2000;
+import { MAX_DISTRIBUTION_BINS } from '../constants';
 
 function makeIntegerVariable(
   distributionDefaults: NumberVariable['distributionDefaults']
@@ -48,7 +45,7 @@ describe('numberDateDefaultAxisRange - max bins protection', () => {
     ) as NumberRange;
 
     const binCount = (range.max - range.min) / binWidth;
-    expect(binCount).toBeLessThanOrEqual(MAX_ALLOWED_BINS);
+    expect(binCount).toBeLessThanOrEqual(MAX_DISTRIBUTION_BINS);
 
     // and the range must still cover the data
     expect(range.min).toBeLessThanOrEqual(2000);

--- a/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
+++ b/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
@@ -144,13 +144,15 @@ const MAX_EDGE_CASE_BINS = 2000;
  * The basic functionality is to return `min([ displayRangeMin ?? 0, rangeMin, observedMin ])`
  * The zero is targeted at histograms which should start at zero even if rangeMin > 0.
  *
- * However, there is an edge case when rangeMin === rangeMax. (When the default binWidth defaults to 1.)
+ * However, there is an edge case for variables whose values are clustered far from zero
+ * (e.g. a year-like integer with values 2000..2004 and a default `binWidth` of 1).
  * If we are making a `distribution` histogram request in this scenario, we do NOT want
- * to request `{ min: 0, max: rangeMax, binWidth: 1 }`
- * because this will cause an OOM error on the backend if `rangeMax` is large.
+ * to anchor the lower bound at zero and request `{ min: 0, max: rangeMax, binWidth: 1 }`
+ * because the bin count (`rangeMax / binWidth`) would exceed the backend's limit and
+ * produce a "Maximum number of allowed bins exceeded" error.
  *
- * The solution is to check for the edge case and return
- * `rangeMin - binWidth` for the lower bound if the number of bins would be excessive.
+ * The solution is to detect when anchoring at zero would create an excessive number of
+ * bins and instead use `rangeMin - binWidth` for the lower bound.
  */
 function getSafeLowerBound(
   { displayRangeMin, rangeMin, rangeMax, binWidth }: NumberDistributionDefaults,
@@ -162,9 +164,9 @@ function getSafeLowerBound(
   if (displayRangeMin != null) {
     lowerBound = displayRangeMin;
   } else if (
-    // check for the edge-case
-    rangeMin === rangeMax &&
-    rangeMax / (binWidth ?? 1) > MAX_EDGE_CASE_BINS
+    // would anchoring the lower bound at zero create too many bins?
+    rangeMax / (binWidth ?? 1) >
+    MAX_EDGE_CASE_BINS
   ) {
     lowerBound = rangeMin - (binWidth ?? 1);
   }

--- a/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
+++ b/packages/libs/eda/src/lib/core/utils/default-axis-range.ts
@@ -2,6 +2,7 @@ import { NumberDistributionDefaults, Variable } from '../types/study';
 import { NumberOrDateRange } from '@veupathdb/components/lib/types/general';
 // type of computedVariableMetadata for computation apps such as alphadiv and abundance
 import { VariableMapping } from '../api/DataClient/types';
+import { MAX_DISTRIBUTION_BINS } from '../constants';
 import { min, max } from 'lodash';
 
 export function numberDateDefaultAxisRange(
@@ -138,8 +139,6 @@ export function numberDateDefaultAxisRange(
   } else return undefined;
 }
 
-const MAX_EDGE_CASE_BINS = 2000;
-
 /**
  * The basic functionality is to return `min([ displayRangeMin ?? 0, rangeMin, observedMin ])`
  * The zero is targeted at histograms which should start at zero even if rangeMin > 0.
@@ -166,7 +165,7 @@ function getSafeLowerBound(
   } else if (
     // would anchoring the lower bound at zero create too many bins?
     rangeMax / (binWidth ?? 1) >
-    MAX_EDGE_CASE_BINS
+    MAX_DISTRIBUTION_BINS
   ) {
     lowerBound = rangeMin - (binWidth ?? 1);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2855,6 +2855,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/console@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/console@npm:30.4.1"
+  dependencies:
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.1.2"
+    jest-message-util: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+    slash: "npm:^3.0.0"
+  checksum: 10/4eb463d29654c20716f5f9cde43e5d958cb3b9234477df57da5b3814c3f1a4a0ab611a8eaf4b5abc146190a012584d7025f445f3560ed62acd843fc95c0a0e65
+  languageName: node
+  linkType: hard
+
 "@jest/console@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/console@npm:26.6.2"
@@ -3057,6 +3071,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/pattern@npm:30.4.0":
+  version: 30.4.0
+  resolution: "@jest/pattern@npm:30.4.0"
+  dependencies:
+    "@types/node": "npm:*"
+    jest-regex-util: "npm:30.4.0"
+  checksum: 10/4fb1db0e586713708d2fcd79059315600978608483ef2d80e04a0a59b20b0d8de0d3f47cad950ff90bfb9ea3cb788709ee3d1eb225734e4dbf1c4b743c93d204
+  languageName: node
+  linkType: hard
+
 "@jest/reporters@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/reporters@npm:26.6.2"
@@ -3131,6 +3155,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/schemas@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/schemas@npm:30.4.1"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.34.0"
+  checksum: 10/86e62c8fd8fc77535085f1ede3a416430a3740f78b8f88ec7d0ee4516b22daf3326ffc1ade9d5f7839bbde923aaf1b5ac430a42ed4bb1a38edc3de5005a58f51
+  languageName: node
+  linkType: hard
+
 "@jest/schemas@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/schemas@npm:28.1.3"
@@ -3168,6 +3201,18 @@ __metadata:
     graceful-fs: "npm:^4.2.9"
     source-map: "npm:^0.6.0"
   checksum: 10/90b1f4212b7191d594275c9b9aae18319b944e4ed018af74a1661fd9b783983074d00369a111274697b87193aa2b084f0f022a265d070f4a66d39d06d14a0336
+  languageName: node
+  linkType: hard
+
+"@jest/test-result@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/test-result@npm:30.4.1"
+  dependencies:
+    "@jest/console": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    "@types/istanbul-lib-coverage": "npm:^2.0.6"
+    collect-v8-coverage: "npm:^1.0.2"
+  checksum: 10/c420182d72cef64827981230b4c84b2de3f4312067e7baf1e3e13c501dc57f73faa09fed1a5ed1a6e96bc29f6c67ac2c14de5f973945f14853010729678cb44a
   languageName: node
   linkType: hard
 
@@ -3275,6 +3320,21 @@ __metadata:
     source-map: "npm:^0.6.1"
     write-file-atomic: "npm:^3.0.0"
   checksum: 10/9e0bec99971d28fc205e5e282be384a0269760b8452aa94e3d400465819b6c790c862ec5597d8c9439f2da97e68c0c4cec071340ff3e4c4414a34e5b2a19074a
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/types@npm:30.4.1"
+  dependencies:
+    "@jest/pattern": "npm:30.4.0"
+    "@jest/schemas": "npm:30.4.1"
+    "@types/istanbul-lib-coverage": "npm:^2.0.6"
+    "@types/istanbul-reports": "npm:^3.0.4"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.33"
+    chalk: "npm:^4.1.2"
+  checksum: 10/cc0999508613487c6d0f55661cd342ebe7cfe579fa9917534b94310204358f03f94524f70f00b4fe3c6dd2ccd0fd44657615a1b9f420ab310d68b43964bff87c
   languageName: node
   linkType: hard
 
@@ -4359,6 +4419,13 @@ __metadata:
   version: 0.25.24
   resolution: "@sinclair/typebox@npm:0.25.24"
   checksum: 10/d415546153478befa3c8386a4723e3061ac065867c7e22fe0374d36091991676d231e5381e66daa0ed21639217c6c80e0d6224a9c89aaac269e58b82b2f4a2f4
+  languageName: node
+  linkType: hard
+
+"@sinclair/typebox@npm:^0.34.0":
+  version: 0.34.49
+  resolution: "@sinclair/typebox@npm:0.34.49"
+  checksum: 10/5eb77de66c9deff83d43aa1f667832e2468f4dbd0ba91b80684f741a2e1e4120ffedb779be1578ae5b848250c3fbeffc032dc726947c5e42f3393903c1358cb9
   languageName: node
   linkType: hard
 
@@ -6214,26 +6281,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react-hooks@npm:^5.0.3":
-  version: 5.1.3
-  resolution: "@testing-library/react-hooks@npm:5.1.3"
+"@testing-library/react-hooks@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "@testing-library/react-hooks@npm:8.0.1"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
-    "@types/react": "npm:>=16.9.0"
-    "@types/react-dom": "npm:>=16.9.0"
-    "@types/react-test-renderer": "npm:>=16.9.0"
-    filter-console: "npm:^0.1.1"
     react-error-boundary: "npm:^3.1.0"
   peerDependencies:
-    react: ">=16.9.0"
-    react-dom: ">=16.9.0"
-    react-test-renderer: ">=16.9.0"
+    "@types/react": ^16.9.0 || ^17.0.0
+    react: ^16.9.0 || ^17.0.0
+    react-dom: ^16.9.0 || ^17.0.0
+    react-test-renderer: ^16.9.0 || ^17.0.0
   peerDependenciesMeta:
+    "@types/react":
+      optional: true
     react-dom:
       optional: true
     react-test-renderer:
       optional: true
-  checksum: 10/4b3a2cd203e6d0445faf27f6ac6ebde97f3b97ef01781dfd91b7dc2be8adee39901665dba1a7d202a40e5fe983c5901037bfe73f7ac385e3521f51cd4bf28110
+  checksum: 10/f7b69373feebe99bc7d60595822cc5c00a1a5a4801bc4f99b597256a5c1d23c45a51f359051dd8a7bdffcc23b26f324c582e9433c25804934fd351a886812790
   languageName: node
   linkType: hard
 
@@ -7312,6 +7378,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/istanbul-lib-coverage@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
+  checksum: 10/3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
+  languageName: node
+  linkType: hard
+
 "@types/istanbul-lib-report@npm:*":
   version: 3.0.0
   resolution: "@types/istanbul-lib-report@npm:3.0.0"
@@ -7327,6 +7400,15 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "npm:*"
   checksum: 10/f1ad54bc68f37f60b30c7915886b92f86b847033e597f9b34f2415acdbe5ed742fa559a0a40050d74cdba3b6a63c342cac1f3a64dba5b68b66a6941f4abd7903
+  languageName: node
+  linkType: hard
+
+"@types/istanbul-reports@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/istanbul-reports@npm:3.0.4"
+  dependencies:
+    "@types/istanbul-lib-report": "npm:*"
+  checksum: 10/93eb18835770b3431f68ae9ac1ca91741ab85f7606f310a34b3586b5a34450ec038c3eed7ab19266635499594de52ff73723a54a72a75b9f7d6a956f01edee95
   languageName: node
   linkType: hard
 
@@ -7725,12 +7807,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-test-renderer@npm:*, @types/react-test-renderer@npm:>=16.9.0":
+"@types/react-test-renderer@npm:*":
   version: 18.0.0
   resolution: "@types/react-test-renderer@npm:18.0.0"
   dependencies:
     "@types/react": "npm:*"
   checksum: 10/6afc938a1d7618d88ab8793e251f0bd5981bf3f08c1b600f74df3f8800b92589ea534dc6dcb7c8d683893fcc740bf8d7843a42bf2dae59785cfe88f004bd7b0b
+  languageName: node
+  linkType: hard
+
+"@types/react-test-renderer@npm:^18":
+  version: 18.3.1
+  resolution: "@types/react-test-renderer@npm:18.3.1"
+  dependencies:
+    "@types/react": "npm:^18"
+  checksum: 10/f8cc23cc8decdb6068cdc8f8c306e189eab8e569443ce97b216e757ee42eb20b18d2280ef41e2955668413f14be92765a3ba86cfcfeeae6b20c965acd9674786
   languageName: node
   linkType: hard
 
@@ -7859,6 +7950,13 @@ __metadata:
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
   checksum: 10/205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  languageName: node
+  linkType: hard
+
+"@types/stack-utils@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@types/stack-utils@npm:2.0.3"
+  checksum: 10/72576cc1522090fe497337c2b99d9838e320659ac57fa5560fcbdcbafcf5d0216c6b3a0a8a4ee4fdb3b1f5e3420aa4f6223ab57b82fef3578bec3206425c6cf5
   languageName: node
   linkType: hard
 
@@ -8008,6 +8106,15 @@ __metadata:
   dependencies:
     "@types/yargs-parser": "npm:*"
   checksum: 10/9673a69487768dad14e805777bca262f7a5774d3a0964981105ffc04ff95e754f1109fa2c8210a0fe863f263c580ddf667e1345f22e018036513245b3dc3c71c
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^17.0.33":
+  version: 17.0.35
+  resolution: "@types/yargs@npm:17.0.35"
+  dependencies:
+    "@types/yargs-parser": "npm:*"
+  checksum: 10/47bcd4476a4194ea11617ea71cba8a1eddf5505fc39c44336c1a08d452a0de4486aedbc13f47a017c8efbcb5a8aa358d976880663732ebcbc6dbcbbecadb0581
   languageName: node
   linkType: hard
 
@@ -8682,7 +8789,7 @@ __metadata:
     "@tanstack/react-query-devtools": "npm:^4.35.3"
     "@testing-library/jest-dom": "npm:^5.16.5"
     "@testing-library/react": "npm:^11.1.0"
-    "@testing-library/react-hooks": "npm:^5.0.3"
+    "@testing-library/react-hooks": "npm:^8.0.1"
     "@testing-library/user-event": "npm:^12.1.10"
     "@types/date-arithmetic": "npm:^4.1.1"
     "@types/debounce-promise": "npm:^3.1.3"
@@ -8696,6 +8803,7 @@ __metadata:
     "@types/react-resizable": "npm:^1.7.2"
     "@types/react-router-dom": "npm:^5.3.3"
     "@types/react-table": "npm:^7.7.12"
+    "@types/react-test-renderer": "npm:^18"
     "@types/uuid": "npm:^8.3.4"
     "@veupathdb/browserslist-config": "workspace:^"
     "@veupathdb/components": "workspace:^"
@@ -8717,6 +8825,7 @@ __metadata:
     http-proxy-middleware: "npm:^2.0.6"
     ify-loader: "npm:^1.1.0"
     io-ts: "npm:^2.2.16"
+    jest-watch-typeahead: "npm:^3.0.1"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.1.1"
     monocle-ts: "npm:^2.3.11"
@@ -8734,6 +8843,7 @@ __metadata:
     react-router: "npm:^5.2.1"
     react-router-dom: "npm:^5.3.0"
     react-scripts: "npm:5.0.1"
+    react-test-renderer: "npm:^18.0.0"
     read: "npm:^1.0.7"
     sass: "npm:^1.54.4"
     script-loader: "npm:^0.7.2"
@@ -11244,12 +11354,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.0, ansi-escapes@npm:^4.3.1":
+"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.0, ansi-escapes@npm:^4.3.1, ansi-escapes@npm:^4.3.2":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
     type-fest: "npm:^0.21.3"
   checksum: 10/8661034456193ffeda0c15c8c564a9636b0c04094b7f78bd01517929c17c504090a60f7a75f949f5af91289c264d3e1001d91492c1bd58efc8e100500ce04de2
+  languageName: node
+  linkType: hard
+
+"ansi-escapes@npm:^7.0.0":
+  version: 7.3.0
+  resolution: "ansi-escapes@npm:7.3.0"
+  dependencies:
+    environment: "npm:^1.0.0"
+  checksum: 10/189e23e75aacf00ee647ba0545687456cc4bc62547dd0cf6c7728f91fce88854c8e885d5819a278b39981bb846d9427693d2380c562aecdb0cf91d3342141e93
   languageName: node
   linkType: hard
 
@@ -11378,6 +11497,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "ansi-regex@npm:6.2.2"
+  checksum: 10/9b17ce2c6daecc75bcd5966b9ad672c23b184dc3ed9bf3c98a0702f0d2f736c15c10d461913568f2cf527a5e64291c7473358885dd493305c84a1cfed66ba94f
+  languageName: node
+  linkType: hard
+
 "ansi-reset@npm:^0.1.1":
   version: 0.1.1
   resolution: "ansi-reset@npm:0.1.1"
@@ -11421,7 +11547,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^5.0.0":
+"ansi-styles@npm:^5.0.0, ansi-styles@npm:^5.2.0":
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: 10/d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
@@ -13784,6 +13910,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^5.2.0":
+  version: 5.6.2
+  resolution: "chalk@npm:5.6.2"
+  checksum: 10/1b2f48f6fba1370670d5610f9cd54c391d6ede28f4b7062dd38244ea5768777af72e5be6b74fb6c6d54cb84c4a2dff3f3afa9b7cb5948f7f022cfd3d087989e0
+  languageName: node
+  linkType: hard
+
 "char-regex@npm:^1.0.2":
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
@@ -13967,6 +14100,13 @@ __metadata:
   version: 3.8.0
   resolution: "ci-info@npm:3.8.0"
   checksum: 10/b00e9313c1f7042ca8b1297c157c920d6d69f0fbad7b867910235676df228c4b4f4df33d06cacae37f9efba7a160b0a167c6be85492b419ef71d85660e60606b
+  languageName: node
+  linkType: hard
+
+"ci-info@npm:^4.2.0":
+  version: 4.4.0
+  resolution: "ci-info@npm:4.4.0"
+  checksum: 10/dfded0c630267d89660c8abb988ac8395a382bdfefedcc03e3e2858523312c5207db777c239c34774e3fcff11f015477c19d2ac8a58ea58aa476614a2e64f434
   languageName: node
   linkType: hard
 
@@ -14266,6 +14406,13 @@ __metadata:
   version: 1.0.1
   resolution: "collect-v8-coverage@npm:1.0.1"
   checksum: 10/85b26945ab9b8e15077f877a4a5bc91d836480c600bac4cd0a0e8be8515583fdfc393ccff049ff3e9f46cac39e5295af049209f3c484f30a028056cc5dd1fe8a
+  languageName: node
+  linkType: hard
+
+"collect-v8-coverage@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "collect-v8-coverage@npm:1.0.3"
+  checksum: 10/656443261fb7b79cf79e89cba4b55622b07c1d4976c630829d7c5c585c73cda1c2ff101f316bfb19bb9e2c58d724c7db1f70a21e213dcd14099227c5e6019860
   languageName: node
   linkType: hard
 
@@ -17672,6 +17819,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emittery@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "emittery@npm:0.13.1"
+  checksum: 10/fbe214171d878b924eedf1757badf58a5dce071cd1fa7f620fa841a0901a80d6da47ff05929d53163105e621ce11a71b9d8acb1148ffe1745e045145f6e69521
+  languageName: node
+  linkType: hard
+
 "emittery@npm:^0.7.1":
   version: 0.7.2
   resolution: "emittery@npm:0.7.2"
@@ -17842,6 +17996,13 @@ __metadata:
   bin:
     envinfo: dist/cli.js
   checksum: 10/e7a2d71c7dfe398a4ffda0e844e242d2183ef2627f98e74e4cd71edd2af691c8707a2b34aacef92538c27b3daf9a360d32202f33c0a9f27f767c4e1c6ba8b522
+  languageName: node
+  linkType: hard
+
+"environment@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "environment@npm:1.1.0"
+  checksum: 10/dd3c1b9825e7f71f1e72b03c2344799ac73f2e9ef81b78ea8b373e55db021786c6b9f3858ea43a436a2c4611052670ec0afe85bc029c384cc71165feee2f4ba6
   languageName: node
   linkType: hard
 
@@ -19411,13 +19572,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"filter-console@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "filter-console@npm:0.1.1"
-  checksum: 10/0560e2bf52e5275da82034c2628ef3455e5e23add52c6959b8bd6e0ec46b1bac244f0a352f998789fdff8b95af1aa82599a1fe106048c6e2ae6575d2ab3ab39f
-  languageName: node
-  linkType: hard
-
 "finalhandler@npm:1.2.0":
   version: 1.2.0
   resolution: "finalhandler@npm:1.2.0"
@@ -20713,7 +20867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
@@ -23934,6 +24088,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-message-util@npm:30.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.27.1"
+    "@jest/types": "npm:30.4.1"
+    "@types/stack-utils": "npm:^2.0.3"
+    chalk: "npm:^4.1.2"
+    graceful-fs: "npm:^4.2.11"
+    jest-util: "npm:30.4.1"
+    picomatch: "npm:^4.0.3"
+    pretty-format: "npm:30.4.1"
+    slash: "npm:^3.0.0"
+    stack-utils: "npm:^2.0.6"
+  checksum: 10/f83894efa37aa9c61c0a559b1027ecdb0d0cd8afd3e8ea74e797c707d58daea814e72f04b6db0bb6a148c12ae203e9c6e6c5544832ca5fae286c4f80c18ddc3f
+  languageName: node
+  linkType: hard
+
 "jest-message-util@npm:^23.4.0":
   version: 23.4.0
   resolution: "jest-message-util@npm:23.4.0"
@@ -24051,6 +24223,13 @@ __metadata:
     jest-resolve:
       optional: true
   checksum: 10/db1a8ab2cb97ca19c01b1cfa9a9c8c69a143fde833c14df1fab0766f411b1148ff0df878adea09007ac6a2085ec116ba9a996a6ad104b1e58c20adbf88eed9b2
+  languageName: node
+  linkType: hard
+
+"jest-regex-util@npm:30.4.0, jest-regex-util@npm:^30.0.0":
+  version: 30.4.0
+  resolution: "jest-regex-util@npm:30.4.0"
+  checksum: 10/8664fcc1d07c8236a3bd012c0f06ae9d14d96e758b32ee340a3a7c4c326d0b5052d8c4ae4f4c4184f08bf78723d905352f22923647df9658ace3604f03bf074f
   languageName: node
   linkType: hard
 
@@ -24464,6 +24643,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-util@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-util@npm:30.4.1"
+  dependencies:
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.1.2"
+    ci-info: "npm:^4.2.0"
+    graceful-fs: "npm:^4.2.11"
+    picomatch: "npm:^4.0.3"
+  checksum: 10/603093e12076906afcf28be514d5b7ac4e3c0e26997b0047614cf2a308b65d773137304a1fb011d747517e881aeed067f6606b9937f5b838d67f6e5734b49ebe
+  languageName: node
+  linkType: hard
+
 "jest-util@npm:^23.4.0":
   version: 23.4.0
   resolution: "jest-util@npm:23.4.0"
@@ -24610,6 +24803,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-watch-typeahead@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "jest-watch-typeahead@npm:3.0.1"
+  dependencies:
+    ansi-escapes: "npm:^7.0.0"
+    chalk: "npm:^5.2.0"
+    jest-regex-util: "npm:^30.0.0"
+    jest-watcher: "npm:^30.0.0"
+    slash: "npm:^5.0.0"
+    string-length: "npm:^6.0.0"
+    strip-ansi: "npm:^7.0.1"
+  peerDependencies:
+    jest: ^30.0.0
+  checksum: 10/dbaaa6d9929079482655c05af9f9c8491fa04aa5a24460b540b8383e78bb6bc6580cddbf8e2b15cfc34d68e610c19f5ccb8f0b0a5aea7f00affb3d976ec152ed
+  languageName: node
+  linkType: hard
+
 "jest-watcher@npm:^23.4.0":
   version: 23.4.0
   resolution: "jest-watcher@npm:23.4.0"
@@ -24664,6 +24874,22 @@ __metadata:
     jest-util: "npm:^28.1.3"
     string-length: "npm:^4.0.1"
   checksum: 10/e6d2c099d461408a992d144c230112fb282b2d8f54c49227bdb0c3efcfa5ecab70a019fc57d8ad6360000459087bb942c4f72670b52fc5b97ac0d9834f87d24e
+  languageName: node
+  linkType: hard
+
+"jest-watcher@npm:^30.0.0":
+  version: 30.4.1
+  resolution: "jest-watcher@npm:30.4.1"
+  dependencies:
+    "@jest/test-result": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    ansi-escapes: "npm:^4.3.2"
+    chalk: "npm:^4.1.2"
+    emittery: "npm:^0.13.1"
+    jest-util: "npm:30.4.1"
+    string-length: "npm:^4.0.2"
+  checksum: 10/05350ed3d5643e87e22cc5faee14f912dfc06ba63d56944006d9837f2070ed509a1d124c7e7be3e3a9a6a382bd31d491146da6fda4483acd4b8292091888e9bd
   languageName: node
   linkType: hard
 
@@ -28790,6 +29016,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
+  languageName: node
+  linkType: hard
+
 "pidtree@npm:^0.3.0":
   version: 0.3.1
   resolution: "pidtree@npm:0.3.1"
@@ -30835,6 +31068,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:30.4.1":
+  version: 30.4.1
+  resolution: "pretty-format@npm:30.4.1"
+  dependencies:
+    "@jest/schemas": "npm:30.4.1"
+    ansi-styles: "npm:^5.2.0"
+    react-is-18: "npm:react-is@^18.3.1"
+    react-is-19: "npm:react-is@^19.2.5"
+  checksum: 10/60311ef47a646eeaec0432efe66290cb6f0d2eccb123a28ad4ab6d7e53087bc62db91cfd54c3cc00c89d6875aefb2bf6264381b6c9411ce6bff3d6aa8280abad
+  languageName: node
+  linkType: hard
+
 "pretty-format@npm:^23.6.0":
   version: 23.6.0
   resolution: "pretty-format@npm:23.6.0"
@@ -31816,6 +32061,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-is-18@npm:react-is@^18.3.1, react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0, react-is@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
+  languageName: node
+  linkType: hard
+
+"react-is-19@npm:react-is@^19.2.5":
+  version: 19.2.6
+  resolution: "react-is@npm:19.2.6"
+  checksum: 10/5248eb5cfc135794c110f97fc0716a9439dc641d6bccbb8c00487c6c492644592ce4dd959fd23790bf05c1f26e0b62f11322b1e51372715a96a4bc4565a17d74
+  languageName: node
+  linkType: hard
+
 "react-is@npm:17.0.2, react-is@npm:^16.8.0 || ^17.0.0, react-is@npm:^17.0.1, react-is@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
@@ -32344,6 +32603,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-shallow-renderer@npm:^16.15.0":
+  version: 16.15.0
+  resolution: "react-shallow-renderer@npm:16.15.0"
+  dependencies:
+    object-assign: "npm:^4.1.1"
+    react-is: "npm:^16.12.0 || ^17.0.0 || ^18.0.0"
+  peerDependencies:
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 10/06457fe5bcaa44aeca998905b6849304742ea1cc2d3841e4a0964c745ff392bc4dec07f8c779f317faacce3a0bf6f84e15020ac0fa81adb931067dbb0baf707b
+  languageName: node
+  linkType: hard
+
 "react-spring@npm:^8.0.27":
   version: 8.0.27
   resolution: "react-spring@npm:8.0.27"
@@ -32394,6 +32665,19 @@ __metadata:
   peerDependencies:
     react: ^16.14.0
   checksum: 10/1a064a65c6073bb72376e8539e979836c52cd6629207163594078005e7bf68a4b35d9397a0ac04aa2a534a9f8f9eb2c2c3a5ff9d2dc8b67bafd6be7451dd1527
+  languageName: node
+  linkType: hard
+
+"react-test-renderer@npm:^18.0.0":
+  version: 18.3.1
+  resolution: "react-test-renderer@npm:18.3.1"
+  dependencies:
+    react-is: "npm:^18.3.1"
+    react-shallow-renderer: "npm:^16.15.0"
+    scheduler: "npm:^0.23.2"
+  peerDependencies:
+    react: ^18.3.1
+  checksum: 10/d53137315c677bdfba702a7179a69828233fc7635ae1e0c03b203923d643400ace72b343cb3dd3dafba8911c20bef53f55bff7aa2e4ddff3ccc423fdd9deeee2
   languageName: node
   linkType: hard
 
@@ -34661,6 +34945,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slash@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "slash@npm:5.1.0"
+  checksum: 10/2c41ec6fb1414cd9bba0fa6b1dd00e8be739e3fe85d079c69d4b09ca5f2f86eafd18d9ce611c0c0f686428638a36c272a6ac14799146a8295f259c10cc45cde4
+  languageName: node
+  linkType: hard
+
 "slice-ansi@npm:^3.0.0":
   version: 3.0.0
   resolution: "slice-ansi@npm:3.0.0"
@@ -35167,7 +35458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-utils@npm:^2.0.2, stack-utils@npm:^2.0.3":
+"stack-utils@npm:^2.0.2, stack-utils@npm:^2.0.3, stack-utils@npm:^2.0.6":
   version: 2.0.6
   resolution: "stack-utils@npm:2.0.6"
   dependencies:
@@ -35389,7 +35680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-length@npm:^4.0.1":
+"string-length@npm:^4.0.1, string-length@npm:^4.0.2":
   version: 4.0.2
   resolution: "string-length@npm:4.0.2"
   dependencies:
@@ -35406,6 +35697,15 @@ __metadata:
     char-regex: "npm:^2.0.0"
     strip-ansi: "npm:^7.0.1"
   checksum: 10/71f73b8c8a743e01dcd001bcf1b197db78d5e5e53b12bd898cddaf0961be09f947dfd8c429783db3694b55b05cb5a51de6406c5085ff1aaa10c4771440c8396d
+  languageName: node
+  linkType: hard
+
+"string-length@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "string-length@npm:6.0.0"
+  dependencies:
+    strip-ansi: "npm:^7.1.0"
+  checksum: 10/b171e9e193ec292ad71f8b2a36e20478bf1bac8cd5beec062fb126942d627dfd9311959e271e9ab7b0a383d16b85b9e25a183d15786e30f22104d152e7627f99
   languageName: node
   linkType: hard
 
@@ -35661,6 +35961,15 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10/07b3142f515d673e05d2da1ae07bba1eb2ba3b588135a38dea598ca11913b6e9487a9f2c9bed4c74cd31e554012b4503d9fb7e6034c7324973854feea2319110
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "strip-ansi@npm:7.2.0"
+  dependencies:
+    ansi-regex: "npm:^6.2.2"
+  checksum: 10/96da3bc6d73cfba1218625a3d66cf7d37a69bf0920d8735b28f9eeaafcdb6c1fe8440e1ae9eb1ba0ca355dbe8702da872e105e2e939fa93e7851b3cb5dd7d316
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## The bug
In `getSafeLowerBound` (`default-axis-range.ts`), the "max bins" protection only triggered when `rangeMin === rangeMax`. The real-world year variable has `rangeMin: 2000, rangeMax: 2004` — **not equal** — so the guard was skipped, the lower bound defaulted to `0`, and a `distribution` request for `0..2004` with `binWidth: 1` produced 2004 bins, exceeding the backend's 2000-bin limit.

The equality check was a red herring: the actual danger is purely *"would anchoring the lower bound at 0 produce too many bins?"* — which is `rangeMax / binWidth > 2000`, regardless of whether `rangeMin` equals `rangeMax`.

## The fix
Dropped the `rangeMin === rangeMax &&` condition. Now whenever anchoring at 0 would blow the bin budget, the lower bound falls back to `rangeMin - binWidth` (giving `1999..2004` → 5 bins for the year case). The ordinary case (small positive variable) still starts at 0.

## No tests
Complex spaghetti logic can easily break (this bug being an example). The bin range code desperately needs refactoring but the only safe way to do this is build a wall of tests and make sure the refactor has no regressions. This is a big TODO but I thought it would be a good idea to start  now. It turns out the test machinery had been neglected for some time, so we fixed that here (though the `useAnalysis` test has been ignored for now because there are `jest` transform problems with a transitive dependency to `jquery` - we already fixed one for `d3`)

## The test
`packages/libs/eda/src/lib/core/utils/default-axis-range.test.ts` — two cases against `numberDateDefaultAxisRange` directly:
1. The year variable (2000–2004) must not exceed 2000 bins **and** must still cover the data. (This is the one that reproduced the bug.)
2. An ordinary positive integer (5–100) still starts at 0 — regression guard.
