### PR TITLE
Conditionally render entire files section based on existence of files

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/UserDatasetFiles.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UserDatasetFiles.tsx
@@ -95,6 +95,11 @@ export function UserDatasetFiles(props: UserDatasetFilesProps) {
 
   const files = userDatasetFilesResult.data;
 
+  // No need for this section if there are no data files at all
+  // (e.g. upload failure)
+  const hasUpload = files.upload != null;
+  if (!hasUpload) return null;
+
   const getFileTableColumns = (
     fileType: DatasetFileType
   ): MesaColumn<ZipFileRow>[] => {


### PR DESCRIPTION
Before, we had broken file download link in the "Uploaded Files in Dataset" section. Now we just skip the entire "Data Files" section. See below:

<img width="2880" height="1568" alt="image" src="https://github.com/user-attachments/assets/e3b83328-6caa-4d0c-ad70-410a183ce800" />
