### PR TITLE
dataset community promotion validation error modal

### DIFF
--- a/packages/libs/user-datasets/src/lib/Actions/UserDatasetsActions.ts
+++ b/packages/libs/user-datasets/src/lib/Actions/UserDatasetsActions.ts
@@ -1,4 +1,4 @@
-import { capitalize, get } from 'lodash';
+import { get } from 'lodash';
 
 import {
   transitionToInternalPage,
@@ -25,7 +25,10 @@ import {
 
 import { DatasetPatchRequest } from '../Service/Model';
 import { SharingModalContext } from '../Components/Sharing/UserDatasetSharingModal';
-import { CommunityPromotionError } from '../Components/Sharing/CommunityPromotionError';
+import {
+  CommunityPromotionError,
+  CommunityPromotionValidationError,
+} from '../Components/Sharing/CommunityPromotionError';
 
 export type Action =
   | DetailErrorAction
@@ -535,7 +538,7 @@ export function updateDatasetCommunityVisibility(
     validateVdiCompatibleThunk<UpdateCommunityVisibilityThunkAction>(
       async ({ wdkService }) => {
         try {
-          const validationErrors: { datasetId: string; messages: string[] }[] =
+          const validationErrors: CommunityPromotionValidationError[] =
             [];
           const serviceErrors: string[] = [];
 
@@ -554,13 +557,8 @@ export function updateDatasetCommunityVisibility(
                 ({ errors: msgs }) => {
                   validationErrors.push({
                     datasetId,
-                    messages: [
-                      ...msgs.general,
-                      ...Object.entries<string[]>(msgs.byKey).flatMap(
-                        ([key, values]) =>
-                          values.map((it) => `${capitalize(key)} - ${it}`)
-                      ),
-                    ],
+                    general: msgs.general,
+                    byField: msgs.byKey,
                   });
                 },
                 // on misc error

--- a/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/List/UserDatasetList.tsx
@@ -436,8 +436,7 @@ class UserDatasetList extends React.Component<DatasetListProps, State> {
 
   getTableActions() {
     const { isMyDataset } = this;
-    const { removeUserDataset, dataNoun, enablePublicUserDatasets } =
-      this.props;
+    const { removeUserDataset, dataNoun } = this.props;
     return [
       {
         callback: (_: DatasetListEntry[]) => {},
@@ -454,7 +453,9 @@ class UserDatasetList extends React.Component<DatasetListProps, State> {
                   break;
               }
             }}
-            enablePublicUserDatasets={enablePublicUserDatasets}
+            // FIXME: 2026-06-08 16:38 - Disabled for now due to complexity of
+            //   public dataset sharing requirements.
+            enablePublicUserDatasets={false}
           />
         ),
         selectionRequired: true,

--- a/packages/libs/user-datasets/src/lib/Components/Sharing/CommunityPromotionError.ts
+++ b/packages/libs/user-datasets/src/lib/Components/Sharing/CommunityPromotionError.ts
@@ -16,8 +16,11 @@ export interface CommunityPromotionError {
   /**
    * Validation error messages.
    */
-  readonly validationErrors?: readonly {
-    readonly datasetId: string;
-    readonly messages: readonly string[];
-  }[];
+  readonly validationErrors?: readonly CommunityPromotionValidationError[];
+}
+
+export interface CommunityPromotionValidationError {
+  readonly datasetId: string;
+  readonly general: readonly string[];
+  readonly byField: Record<string, readonly string[]>;
 }

--- a/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetCommunityModal.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetCommunityModal.tsx
@@ -10,7 +10,7 @@ import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 import { DatasetGetResponseBody, DatasetListEntry } from '../../Service';
 import { updateDatasetCommunityVisibility } from '../../Actions/UserDatasetsActions';
 import { DataNoun } from '../../Utils/types';
-import { CommunityPromotionError } from './CommunityPromotionError';
+import { CommunityPromotionError, CommunityPromotionValidationError } from './CommunityPromotionError';
 import { ReactElement, ReactNode } from 'react';
 import { CommunityAccess } from '../Misc/CommunityAccess';
 
@@ -190,14 +190,17 @@ function UpdateErrors({
     content = (
       <>
         <p>
-          {inList ? 'One or more datasets do' : 'Dataset does'} not contain
-          enough information to be made discoverable through <CommunityAccess />
+          {inList ? 'One or more datasets do' : 'Your dataset does'} not contain
+          enough information to be discoverable through <CommunityAccess />
           .
         </p>
         <p>
           Re-upload your {targetNounLower} and complete all sections on the
           upload form marked with a globe icon to enable <CommunityAccess />.
         </p>
+        {inList
+          ? undefined
+          : detailedValidationContent(errors)}
       </>
     );
   } else {
@@ -217,6 +220,95 @@ function UpdateErrors({
       <CloseButton />
     </div>
   );
+}
+
+function detailedValidationContent(errors: CommunityPromotionError): ReactElement {
+  const rows: ReactElement[] = [];
+
+  let hasDatasetCharacteristicsErrors = false;
+
+  for (const errorSet of errors.validationErrors!) {
+    for (const message of errorSet.general)
+      rows.push(<tr><td colSpan={2}>{message}</td></tr>);
+
+    for (const field of Object.keys(errorSet.byField).sort()) {
+      // multi-word fields
+      // what was the phrasing
+
+      // Special case, datasetCharacteristics
+      if (field.indexOf('datasetCharacteristics') > -1) {
+
+        if (!hasDatasetCharacteristicsErrors) {
+          rows.push(
+            <tr>
+              <th scope="row">Field Study or Clinical Trial Characteristics:</th>
+              <td>all fields required</td>
+            </tr>
+          );
+
+          hasDatasetCharacteristicsErrors = true;
+        }
+
+        continue;
+      }
+
+      let header: ReactNode = <th rowSpan={errorSet.byField[field].length}>
+        {parseKey(field)}:
+      </th>;
+
+      for (const message of errorSet.byField[field]) {
+        rows.push(
+          <tr>
+            {header}
+            <td>{message}</td>
+          </tr>
+        );
+      }
+    }
+  }
+
+  return <details>
+    <summary>Validation Details</summary>
+    <table id="community-error-list">{rows}</table>
+  </details>;
+}
+
+function parseKey(key: string): string {
+  if (key.startsWith("$."))
+    key = key.substring(2);
+
+  const split = key.split(/\.|\[|].?/);
+  const output = [];
+
+  for (let i = 0; i < split.length; i++) {
+    const maybeIndex = parseInt(split[i]);
+
+    if (isNaN(maybeIndex)) {
+      if (i > 0)
+        break;
+
+      output.push(capFirst(split[i]));
+      continue
+    }
+
+    if (i > 0) {
+      const prev: number = output.length - 1;
+      output[prev] = output[prev].substring(0, output[prev].length - 1);
+    }
+
+    output[i] = (maybeIndex + 1).toString();
+    break;
+  }
+
+  return output.join(' ');
+}
+
+// using this instead of other 'capitalize' functions because:
+// lodash capitalize lowercases the rest of the word ???
+// material-ui capitalize is removed in newer versions of mui
+// css text-transform will capitalize every word
+function capFirst(key: string): string {
+  return key.substring(0, 1).toUpperCase() + key.substring(1);
 }
 
 function isAre(total: number) {

--- a/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Sharing/UserDatasetSharingModal.scss
@@ -10,6 +10,25 @@
   font-size: 1.2em;
   padding: 1em;
 
+  #community-error-list {
+    width: inherit;
+    margin: 1.5em 0 1em 0;
+
+    *, th, td {
+      border: none;
+    }
+
+    th {
+      max-width: 45%;
+      text-align: right;
+      padding-right: 1ch;
+    }
+
+    td {
+      text-align: left;
+    }
+  }
+
   &-CloseBar {
     text-align: right;
   }
@@ -176,7 +195,6 @@
   }
   .wdk-Icon {
     font-size: 50px;
-    margin-bottom: 20px;
   }
 }
 


### PR DESCRIPTION
### Problem

> When the user attempts to promote a dataset to community, if there are any validation errors, they get a non-helpful 'something went wrong' modal. Replace this modal content with details about any validation errors that were encountered.

### Changes

1. disable the community sharing button in the dataset list view
2. render validation errors returned by VDI in the error modal on promotion failure
  a. any/all datasetCharacteristics issues are entirely replaced with a singular blanket 'required' message

### Screenshots

* Error List Open: <img width="810" height="475" alt="image" src="https://github.com/user-attachments/assets/2142af5f-cc22-4d29-913e-ba95ac6f555b" />
* Error List Closed: <img width="807" height="281" alt="image" src="https://github.com/user-attachments/assets/6af14c66-2ed4-47fd-a515-03107d830de2" />
