### PR TITLE
Left-align subtitle for dexp and mbio, tweak logo animation

### DIFF
--- a/packages/libs/web-common/src/App/Header/HeaderNav.jsx
+++ b/packages/libs/web-common/src/App/Header/HeaderNav.jsx
@@ -133,7 +133,7 @@ class HeaderNav extends React.Component {
               <i>{titleSecPart}</i>
             </Link>
           </h1>
-          <p>
+          <p className="HeaderNav-subTitle">
             {subTitle} <br />
           </p>
         </div>

--- a/packages/libs/web-common/src/App/Header/HeaderNav.scss
+++ b/packages/libs/web-common/src/App/Header/HeaderNav.scss
@@ -85,12 +85,12 @@ $red: #dd314e;
       width: 40px;
     }
 
-    p {
+    p.HeaderNav-subTitle {
       margin: 0;
-      padding: 0;
+      padding: 0px 0px 0px 3px;
       opacity: 0.5;
       font-size: 16px;
-      font-weight: 200;
+      font-weight: 250;
       line-height: 1.3em;
       letter-spacing: 0.2px;
       code {
@@ -143,9 +143,9 @@ $red: #dd314e;
   &:hover {
     color: $red;
     text-decoration: none;
-    transition: all 0.5s;
+    transition: transform 200ms ease;
     &:hover {
-      transform: scale(0.95);
+      transform: scale(1.02);
     }
     mark {
       color: white;

--- a/packages/libs/web-common/src/App/Hero/Hero.scss
+++ b/packages/libs/web-common/src/App/Hero/Hero.scss
@@ -1,14 +1,10 @@
 .wdk-Hero {
-  magrin: 0;
   width: 100%;
   padding: 10px;
-  text-align: center;
   box-sizing: border-box;
   background-size: cover;
 
   .stack {
     height: 100%;
-    align-items: center;
-    justify-content: center;
   }
 }


### PR DESCRIPTION

<img width="734" height="154" alt="image" src="https://github.com/user-attachments/assets/96a562ae-d963-406a-8da1-845d629d3688" />


Header animation is a slightly more canonical (and subtle) grow.

Affects MBio too