### PR TITLE
Prevent `tabular` 500 for UD EDA download tab.

### DIFF
--- a/packages/libs/eda/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
+++ b/packages/libs/eda/src/lib/workspace/Subsetting/SubsetDownloadModal.tsx
@@ -166,6 +166,7 @@ export default function SubsetDownloadModal({
   // Required columns
   const requiredColumns = usePromise(
     useCallback(async () => {
+      if (!canLoadTablePreview) return null;
       const data = await subsettingClient.getTabularData(
         studyMetadata.id,
         currentEntity.id,
@@ -179,7 +180,14 @@ export default function SubsetDownloadModal({
         }
       );
       return processGridData(data, entities, currentEntity)[0];
-    }, [subsettingClient, studyMetadata.id, entities, currentEntity, mergeKeys])
+    }, [
+      subsettingClient,
+      studyMetadata.id,
+      entities,
+      currentEntity,
+      mergeKeys,
+      canLoadTablePreview,
+    ])
   );
 
   const requiredColumnAccessors = requiredColumns.value?.map(


### PR DESCRIPTION
There's a backend 500 on some `tabular` endpoint requests from the Downloads tab of the EDA for user datasets.

This change prevents that happening by not doing the `requiredColumns` request (the front end UI doesn't need it for single entity UDs anyway).