### PR TITLE
Filter only valid UDs in Datasets menu AND make failed community datasets request be more quiet

### DIFF
--- a/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
+++ b/packages/libs/eda/src/lib/workspace/AllAnalyses.tsx
@@ -190,7 +190,14 @@ export function AllAnalyses(props: Props) {
         const user = await wdkService.getCurrentUser();
         return Promise.all([
           user.isGuest ? [] : wdkService.vdi.getDatasetList(),
-          wdkService.vdi.getCommunityDatasetList(),
+          // Community datasets are supplementary and public; a failure to load
+          // them (e.g. a 401 from a stale guest session) should degrade to an
+          // empty list rather than reject the whole tuple and surface a global
+          // "something went wrong" modal.
+          wdkService.vdi.getCommunityDatasetList().catch((error) => {
+            console.error('Failed to load community datasets', error);
+            return [];
+          }),
         ]);
       }
       return [];

--- a/packages/libs/eda/src/lib/workspace/PublicAnalysesRoute.tsx
+++ b/packages/libs/eda/src/lib/workspace/PublicAnalysesRoute.tsx
@@ -31,7 +31,13 @@ export function PublicAnalysesRoute({
   const studyRecords = useWdkStudyRecords(subsettingClient);
   const communityDatasets = useWdkService(async (wdkService) => {
     if (isVdiCompatibleWdkService(wdkService))
-      return wdkService.vdi.getCommunityDatasetList();
+      // Community datasets are supplementary and public; a failure to load
+      // them (e.g. a 401 from a stale guest session) should degrade to an
+      // empty list rather than surface a global "something went wrong" modal.
+      return wdkService.vdi.getCommunityDatasetList().catch((error) => {
+        console.error('Failed to load community datasets', error);
+        return [];
+      });
     return [];
   }, []);
 

--- a/packages/libs/web-common/src/hooks/diyDatasets.ts
+++ b/packages/libs/web-common/src/hooks/diyDatasets.ts
@@ -24,7 +24,26 @@ export function useDiyDatasets() {
       const userDatasets = await wdkService.vdi.getDatasetList({
         install_target: projectId,
       });
-      const unsortedDiyEntries = userDatasets.map(userDatasetToMenuItem);
+      // potentially refactor the following filter as a utility function
+      // other similar uses: UserDatasetDetail.tsx and BigwigDatasetDetail.tsx
+      const validUserDatasets = userDatasets.filter(
+        ({
+          status: {
+            upload: { status: uploadStatus },
+            import: { status: importStatus } = {},
+            install: installations,
+          },
+        }) =>
+          uploadStatus === 'success' &&
+          importStatus === 'complete' &&
+          installations?.some(
+            ({ installTarget, meta, data }) =>
+              installTarget === projectId &&
+              data?.status === 'complete' &&
+              (meta == null || meta.status === 'complete')
+          )
+      );
+      const unsortedDiyEntries = validUserDatasets.map(userDatasetToMenuItem);
       return orderBy(unsortedDiyEntries, ({ name }) => name);
     },
     [requestTimestamp]
@@ -33,11 +52,21 @@ export function useDiyDatasets() {
   const communityDatasets = useWdkService(
     async (wdkService) => {
       assertIsVdiCompatibleWdkService(wdkService);
-      const userDatasets = await wdkService.vdi.getCommunityDatasetList();
-      const unsortedDiyEntries = userDatasets
-        .filter((userDataset) => userDataset.installTargets.includes(projectId))
-        .map(userDatasetToMenuItem);
-      return orderBy(unsortedDiyEntries, ({ name }) => name);
+      try {
+        const userDatasets = await wdkService.vdi.getCommunityDatasetList();
+        const unsortedDiyEntries = userDatasets
+          .filter((userDataset) =>
+            userDataset.installTargets.includes(projectId)
+          )
+          .map(userDatasetToMenuItem);
+        return orderBy(unsortedDiyEntries, ({ name }) => name);
+      } catch (error) {
+        // Community datasets are supplementary and public; a failure to load
+        // them (e.g. a 401 from a stale guest session) should degrade to an
+        // empty list rather than surface a global "something went wrong" modal.
+        console.error('Failed to load community datasets', error);
+        return [];
+      }
     },
     [requestTimestamp]
   );


### PR DESCRIPTION
Previously we showed datasets that had failed upload, import or install. Now that is fixed.

---

Fixes #1728 

Apologies - dual issue PR - both issues touched `packages/libs/web-common/src/hooks/diyDatasets.ts`

The `community` datasets response handling - quietly returning an empty array when the WDK guess user has expired due to restarted WDK service - should fix #1728 