### PR TITLE
add reference genome input to dataset upload form

### DIFF
--- a/packages/libs/coreui/src/components/buttons/index.ts
+++ b/packages/libs/coreui/src/components/buttons/index.ts
@@ -26,7 +26,7 @@ export type ButtonStyleSpec = {
   };
 };
 
-type ButtonStateStyleSpec = {
+export type ButtonStateStyleSpec = {
   /** Color to use for outline/fill. Will accept any
    * valid CSS color definition. */
   color: CSSProperties['color'];

--- a/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
+++ b/packages/libs/coreui/src/components/inputs/SelectTree/SelectTree.tsx
@@ -1,9 +1,10 @@
-import { ReactNode, useEffect, useState } from 'react';
+import { CSSProperties, ReactNode, useEffect, useState } from 'react';
 import PopoverButton from '../../buttons/PopoverButton/PopoverButton';
 import CheckboxTree, {
-  CheckboxTreeProps,
+  CheckboxTreeProps, CheckboxTreeStyleSpec,
   LinksPosition,
 } from '../checkboxes/CheckboxTree/CheckboxTree';
+import { PartialButtonStyleSpec } from '../../buttons';
 
 export interface SelectTreeProps<T> extends CheckboxTreeProps<T> {
   buttonDisplayContent: ReactNode;
@@ -15,6 +16,30 @@ export interface SelectTreeProps<T> extends CheckboxTreeProps<T> {
   instantUpdate?: boolean;
   /** Optional. When true, popover (if using) closing will be deferred until this becomes false */
   deferPopoverClosing?: boolean;
+  styleOverrides?: SelectTreeStyleSpec;
+}
+
+export interface SelectTreeStyleSpec extends CheckboxTreeStyleSpec {
+  /**
+   * Style spec passed through to the PopoverButton component if
+   * `hasPopoverButton` is `true`.
+   */
+  readonly popoverButton?: PartialButtonStyleSpec;
+
+  /**
+   * Whether selection text should be truncated at a max width.
+   *
+   * Default: `true`
+   */
+  readonly truncateSelection?: boolean;
+
+  /**
+   * Width the selection content should be truncated to when `truncateSelection`
+   * is `true`.
+   *
+   * Default: `300px`
+   */
+  readonly truncateSelectionWidth?: string;
 }
 
 function SelectTree<T>(props: SelectTreeProps<T>) {
@@ -31,6 +56,7 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
     instantUpdate = true,
     wrapPopover,
     deferPopoverClosing = false,
+    styleOverrides,
   } = props;
 
   // This local state is updated whenever a checkbox is clicked in the species tree.
@@ -54,16 +80,18 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
   }, [onSelectionChange, localSelectedList]);
 
   function truncatedButtonContent(selectedList: string[]) {
+    const styling: CSSProperties = (styleOverrides?.truncateSelection ?? true)
+      ? {
+        // this styling is copied from SelectList!
+        maxWidth: styleOverrides?.truncateSelectionWidth ?? '300px',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }
+      : {};
+
     return (
-      <span
-        style={{
-          // this styling is copied from SelectList!
-          maxWidth: '300px',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-      >
+      <span style={styling}>
         {selectedList.join(', ')}
       </span>
     );
@@ -115,7 +143,7 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
       additionalFilters={props.additionalFilters}
       isAdditionalFilterApplied={props.isAdditionalFilterApplied}
       wrapTreeSection={props.wrapTreeSection}
-      styleOverrides={props.styleOverrides}
+      styleOverrides={styleOverrides}
       customTreeNodeCssSelectors={props.customTreeNodeCssSelectors}
     />
   );
@@ -127,6 +155,7 @@ function SelectTree<T>(props: SelectTreeProps<T>) {
       onClose={onClose}
       isDisabled={props.isDisabled}
       deferClosing={deferPopoverClosing}
+      styleOverrides={styleOverrides?.popoverButton}
     >
       <div
         style={{

--- a/packages/libs/user-datasets/src/lib/Components/Upload/Configuration/DatasetUploadConfig.ts
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/Configuration/DatasetUploadConfig.ts
@@ -34,7 +34,7 @@ export interface DatasetCharacteristicsFormSectionConfig {
 
 export interface DependencyInputProps {
   readonly dependencies: readonly DatasetDependency[];
-  readonly setDependencies: Consumer<readonly DatasetDependency[]>;
+  readonly setDependencies: Consumer<DatasetDependency[]>;
 }
 
 export interface DependenciesConfig {

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/CollaboratorsSection.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/CollaboratorsSection.tsx
@@ -120,7 +120,7 @@ function ContactBlock({ path, ...props }: ContactBlockProps): ReactElement {
         />
 
         <TextField
-          label="Middle Name"
+          label="Middle Name (optional)"
           field="middleName"
           pathBuilder={path}
           value={props.contact.middleName}

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/DatasetDependencies.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/DatasetDependencies.tsx
@@ -1,0 +1,25 @@
+import { ReactElement } from 'react';
+import { DatasetDependency, DatasetPostDetails } from '../../../../../Service';
+import { Consumer } from '../../../../../Utils';
+import { DependenciesConfig } from '../../../Configuration';
+
+export interface DatasetDependenciesProps {
+  readonly datasetDetails: DatasetPostDetails;
+  readonly setDatasetDetails: Consumer<DatasetPostDetails>;
+  readonly config: DependenciesConfig;
+}
+
+export function DatasetDependencies(props: DatasetDependenciesProps): ReactElement {
+  const setDependencies = (deps: DatasetDependency[]) =>
+    props.setDatasetDetails({ ...props.datasetDetails, dependencies: deps })
+
+  return <>
+    <label
+      className={props.config.required ? 'required' : ''}
+    >Reference Genome</label>
+    {props.config.renderInput({
+      dependencies: props.datasetDetails.dependencies ?? [],
+      setDependencies,
+    })}
+  </>;
+}

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/RootDetailsSection.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Definition/RootDetailsSection.tsx
@@ -15,6 +15,7 @@ import { useDispatch } from 'react-redux';
 import { useUploadFormState } from '../../../../../StoreModules/UserDatasetUploadStoreModule';
 import { updateFormState } from '../../../../../Actions/UserDatasetUploadActions';
 import { SubmittableState } from '../../Components/UploadButton';
+import { DatasetDependencies } from './DatasetDependencies';
 
 export interface RootDetailsSectionProps {
   readonly formProps: UploadFormProps;
@@ -60,6 +61,13 @@ export function RootDetailsSection(
   const fileUpload = buildFileProps(formProps, fileUploads, setUploads);
   const urlUpload = buildUrlProps(formProps, fileUploads, setUploads);
 
+  const referenceGenome = formProps.dependencies
+    ?  <DatasetDependencies
+      config={formProps.dependencies}
+      datasetDetails={datasetDetails}
+      setDatasetDetails={setMetadata} />
+    : null;
+
   return (
     <section>
       <h3>
@@ -72,7 +80,6 @@ export function RootDetailsSection(
           fieldName={nameKey}
           value={datasetDetails.name}
           onChange={(v) => setMetadata({ ...datasetDetails, name: v })}
-          labelClass="required"
           minLength={3}
           maxLength={1024}
           required={true}
@@ -83,11 +90,12 @@ export function RootDetailsSection(
           fieldName={summaryKey}
           value={datasetDetails.summary}
           onChange={(v) => setMetadata({ ...datasetDetails, summary: v })}
-          labelClass="required"
           minLength={3}
           maxLength={4000}
           required={true}
         />
+
+        {referenceGenome}
 
         <RootDataInput
           pathBuilder={props.contentJsonPath}

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.scss
@@ -1,5 +1,5 @@
 #dataset-upload {
-  $inputPadding: 5px;
+  $inputPadding: 8px;
   $commonRadius: 8px;
 
   max-width: 1024px;
@@ -104,10 +104,15 @@
     margin-bottom: 1em;
   }
 
-  input:not([type='radio']):not([type='checkbox']),
+  input:not([type='radio']):not([type='checkbox']):not([type='file']),
   textarea {
     border-radius: 5px;
     padding: $inputPadding;
+  }
+
+  ::file-selector-button {
+    padding: $inputPadding;
+    margin: 0 1ch 0 0;
   }
 
   input[type='checkbox'],
@@ -166,7 +171,7 @@
 
     .field-grid {
       margin: 0;
-      grid-template-columns: 1fr 5fr;
+      grid-template-columns: 3fr 10fr;
     }
 
     &.narrow-labels {
@@ -220,6 +225,10 @@
     font-weight: bold;
     text-decoration: none;
     padding: 0;
+  }
+
+  .non-bold-labels label {
+    font-weight: normal;
   }
 
   .multi-input {

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.tsx
@@ -1,4 +1,10 @@
-import { ReactElement, useEffect, useState } from 'react';
+import {
+  ReactElement,
+  RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { Link } from 'react-router-dom';
 
 import Banner from '@veupathdb/coreui/lib/components/banners/Banner';
@@ -11,18 +17,16 @@ import {
 } from './Components';
 import { MetadataSection, RootDetailsSection } from './Sections';
 import { DatasetUploadConfig } from '../Configuration';
-import { VdiServiceMetadata } from '../../../Service';
+import { DatasetPostDetails, VdiServiceMetadata } from '../../../Service';
 import { JsonPathBuilder, Runnable } from '../../../Utils';
 import { BadUpload } from '../../../StoreModules';
 import { UploadUrlParams } from './DataModel';
 
 import './UploadForm.scss';
 import { UploadWarningModal } from './UploadWarningModal';
-import { CommunityAccess } from '../../Misc/CommunityAccess';
 import { SubmittableState } from './Components/UploadButton';
 import { useUploadFormState } from '../../../StoreModules/UserDatasetUploadStoreModule';
-
-const DatasetUploadSectionID = 'dataset-upload';
+import { isEmpty } from 'lodash';
 
 export interface UploadFormProps extends DatasetUploadConfig {
   readonly baseUrl: string;
@@ -70,14 +74,16 @@ export function UploadForm(props: UploadFormProps): ReactElement {
 
   const { datasetDetails, fileUploads } = useUploadFormState();
 
+  const uploadSection = useRef<HTMLElement>(null);
+
   useEffect(() => {
     setFormIsValid(
-      calcFormIsValid(document.getElementById(DatasetUploadSectionID)!)
+      calcFormIsValid(datasetDetails, props, uploadSection)
     );
-  }, [setFormIsValid, datasetDetails, fileUploads]);
+  }, [setFormIsValid, datasetDetails, fileUploads, props]);
 
   return (
-    <section id={DatasetUploadSectionID}>
+    <section id="dataset-upload" ref={uploadSection}>
       <header>
         <UploadErrorBanner errors={props.badUploadState} />
 
@@ -164,6 +170,16 @@ export function UploadForm(props: UploadFormProps): ReactElement {
   );
 }
 
-function calcFormIsValid(e: Element): boolean {
-  return e.querySelectorAll(':invalid').length === 0;
+function calcFormIsValid(
+  metadata: DatasetPostDetails,
+  config: DatasetUploadConfig,
+  uploadSection: RefObject<HTMLElement>,
+): boolean {
+  const allInputsValid = uploadSection.current
+    ?.querySelectorAll(':invalid').length === 0;
+
+  const missingDependencies = config.dependencies?.required === true
+    && isEmpty(metadata.dependencies);
+
+  return allInputsValid && !missingDependencies;
 }

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadFormController.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadFormController.tsx
@@ -71,7 +71,7 @@ export function UploadFormController({
     dispatch(clearBadUpload());
 
     {
-      const validationErrors = validateFormState(formState);
+      const validationErrors = validateFormState(formState, formConfig);
 
       if (!isEmpty(validationErrors)) {
         dispatch(
@@ -157,10 +157,16 @@ export function UploadFormController({
  * performed all required client-side-only form steps before attempting an
  * upload.
  */
-function validateFormState({
-  formMetaState: clientSide,
-}: UploadFormState): Record<string, string[]> {
+function validateFormState(
+  { datasetDetails }: UploadFormState,
+  formConfig: DatasetUploadConfig,
+): Record<string, string[]> {
   const keyedErrors: Record<string, string[]> = {};
+
+  if (formConfig.dependencies?.required === true && isEmpty(datasetDetails.dependencies)) {
+    keyedErrors["$.details.dependencies"] = ["selection is required"];
+  }
+
   /* TODO: to be re-enabled for the update form
   const errorMessage = ['selection is required'];
 

--- a/packages/libs/web-common/src/user-dataset-upload-config.tsx
+++ b/packages/libs/web-common/src/user-dataset-upload-config.tsx
@@ -12,13 +12,17 @@ import {
   DependencyInputProps,
   UploadFormConfigurators,
 } from '@veupathdb/user-datasets/lib';
-import { Link } from 'react-router-dom';
 import { useRouteMatch } from 'react-router-dom';
 import {
   DatasetTypeConfig,
   DatasetUploadConfig,
 } from '@veupathdb/user-datasets/lib/Components/Upload';
 import { formatFileSize } from '@veupathdb/user-datasets/lib/Utils/formatting';
+import { SelectTreeStyleSpec } from '@veupathdb/coreui/lib/components/inputs/SelectTree/SelectTree';
+import {
+  ButtonStateStyleSpec,
+  PartialButtonStyleSpec,
+} from '@veupathdb/coreui/lib/components/buttons';
 
 /**
  * Type identifiers for dataset types that have client handling.
@@ -68,7 +72,12 @@ export const userDatasetTypeConfigs: readonly ClientDatasetTypeConfig[] = [
 /**
  * Dataset type specific upload form configuration constructors.
  *
- * One should exist for every dataset type that users can upload.
+ * Each entry in the following array should be a tuple of dataset type
+ * identifier and type-specific form config constructor.
+ *
+ * One should exist for every dataset type that users can upload on any site,
+ * the entries will be filtered by site at a later point based on the VDI
+ * service configuration.
  */
 export const uploadFormConfigurators: UploadFormConfigurators = [
   // bigwig
@@ -441,12 +450,38 @@ function ReferenceGenomeDependency({
   dependencies,
   setDependencies,
 }: DependencyInputProps): ReactElement | null {
-  const styleOverrides = {
+  const popoverStyle: Partial<ButtonStateStyleSpec> = {
+    dropShadow: {
+      offsetX: 'none',
+      offsetY: '',
+      blurRadius: '',
+      color: '',
+    },
+    border: {
+      color: '#afafaf',
+      width: 1,
+      style: 'solid',
+    },
+  };
+
+  const styleOverrides: SelectTreeStyleSpec = {
     treeNode: {
       labelTextWrapper: {
         fontSize: '1.1em',
       },
     },
+
+    truncateSelectionWidth: '500px',
+
+    popoverButton: {
+      container: {
+        marginBottom: '1em',
+      },
+      default: popoverStyle,
+      disabled: popoverStyle,
+      hover: popoverStyle,
+      pressed: popoverStyle,
+    }
   };
 
   const selectedList = dependencies?.map((entry) => entry.resourceDisplayName);


### PR DESCRIPTION
touches some stuff outside of the user datasets workspace to adjust the ref genome input styling.  without style adjustment it looked absurdly out of place as the largest element on the form, and only element with a box shadow.

<img width="991" height="483" alt="image" src="https://github.com/user-attachments/assets/fc39defb-21e1-4445-96b2-03807b58d893" />
