### PR TITLE
bugs from team_dataExplorer zoom 2026-06-16

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Components/InputPair.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Components/InputPair.tsx
@@ -1,5 +1,5 @@
 import { Consumer } from '../../../../Utils';
-import { ChangeEvent, ReactElement, ReactNode } from 'react';
+import { ChangeEvent, ReactElement, ReactNode, RefObject } from 'react';
 import { FieldHelpText } from './FieldHelpText';
 
 interface BaseInputProps<T extends object = object> {
@@ -12,6 +12,7 @@ interface BaseInputProps<T extends object = object> {
   readonly helpText?: ReactNode;
   readonly disabled?: boolean;
   readonly required?: boolean;
+  readonly inputRef?: RefObject<HTMLInputElement>;
 }
 
 interface TextProps<T extends object = object> extends BaseInputProps<T> {
@@ -99,6 +100,7 @@ function Checkbox<T extends object>(props: CheckboxProps<T>): ReactElement {
     <span>
       <input
         type="checkbox"
+        ref={props.inputRef}
         id={props.idOverride ?? props.fieldName}
         name={props.nameOverride ?? props.fieldName}
         className={props.className}
@@ -115,6 +117,7 @@ function NumberInput<T extends object>(props: NumberProps<T>): ReactElement {
   return (
     <input
       type="number"
+      ref={props.inputRef}
       min={props.minimum}
       max={props.maximum}
       id={props.idOverride ?? props.fieldName}
@@ -133,6 +136,7 @@ function RadioInput<T extends object>(props: RadioProps<T>): ReactElement {
     <span>
       <input
         type="radio"
+        ref={props.inputRef}
         id={props.idOverride ?? props.fieldName}
         name={props.nameOverride ?? props.fieldName}
         value={props.value}
@@ -150,6 +154,7 @@ function TextInput<T extends object>(props: TextProps<T>): ReactElement {
   return (
     <input
       type={props.type ?? 'text'}
+      ref={props.inputRef}
       id={props.idOverride ?? props.fieldName}
       name={props.nameOverride ?? props.fieldName}
       className={props.className}

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/CharacteristicsSection.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/Sections/Core/CharacteristicsSection.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactElement, RefObject, useRef } from 'react';
 import { partialRight } from 'lodash';
 
 import {
@@ -240,37 +240,53 @@ function YearsInputs({
   const startField = jsonPath.appendToString<SampleYearRange>('start');
   const endField = jsonPath.appendToString<SampleYearRange>('end');
 
+  const startRef = useRef<HTMLInputElement>(null);
+  const endRef = useRef<HTMLInputElement>(null);
+
   const setYear = disabled
     ? () => {}
-    : (k: keyof SampleYearRange, v: number | undefined) => {
-        if (!v) return;
+    : (
+      k: keyof SampleYearRange,
+      v: string | undefined,
+      ref: RefObject<HTMLInputElement>,
+    ) => {
+      if (!v)
+        return;
 
-        if (isNaN(v)) return;
+      const parsed = parseInt(v);
 
-        setYears({ ...safeYears, [k]: v });
-      };
+      if (isNaN(parsed))
+        return;
+
+      if (parsed < 1500 || parsed > 9999)
+        ref.current?.classList?.add('invalid')
+      else
+        ref.current?.classList?.remove('invalid')
+
+      setYears({ ...safeYears, [k]: parsed });
+    };
 
   return (
     <>
       <InputPair
         label="Start Year"
-        type="number"
-        minimum={1500}
+        type="text"
+        inputRef={startRef}
         fieldName={startField}
         helpText="Year (YYYY) when data collection was initiated."
-        value={safeYears.start}
-        onChange={(v) => setYear('start', v)}
+        value={safeYears.start?.toString()}
+        onChange={(v) => setYear('start', v, startRef)}
         disabled={disabled}
       />
 
       <InputPair
         label="End Year"
-        type="number"
-        minimum={1500}
+        type="text"
+        inputRef={endRef}
         fieldName={endField}
         helpText="Year (YYYY) when data collection was concluded."
-        value={safeYears.end}
-        onChange={(v) => setYear('end', v)}
+        value={safeYears.end?.toString()}
+        onChange={(v) => setYear('end', v, endRef)}
         disabled={disabled}
       />
     </>

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.scss
@@ -125,7 +125,9 @@
     margin-top: $inputPadding;
   }
 
+  input[type='text']:not(:focus).invalid,
   input[type='text']:user-invalid,
+  textarea:not(:focus).invalid,
   textarea:user-invalid {
     border-color: var(--coreui-red-900);
     background-color: var(--coreui-mutedRed-300);

--- a/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Upload/UploadForm/UploadForm.tsx
@@ -178,8 +178,11 @@ function calcFormIsValid(
   const allInputsValid = uploadSection.current
     ?.querySelectorAll(':invalid').length === 0;
 
+  const noCustomErrors = uploadSection.current
+    ?.querySelectorAll('.invalid').length === 0;
+
   const missingDependencies = config.dependencies?.required === true
     && isEmpty(metadata.dependencies);
 
-  return allInputsValid && !missingDependencies;
+  return allInputsValid && noCustomErrors && !missingDependencies;
 }

--- a/packages/libs/web-common/src/user-dataset-upload-config.tsx
+++ b/packages/libs/web-common/src/user-dataset-upload-config.tsx
@@ -325,6 +325,34 @@ function phenotypeFormConfigurator(
     dataType,
     verbiage: {
       formTitle: `Upload a ${dataType.vdiConfig.category} Dataset`,
+      formInputs: {
+        datasetProperties: {
+          label: 'Variable Attributes File',
+          helpText: function HelpText() {
+            const { path } = useRouteMatch();
+            return (
+              <div className="formInfo">
+                <p>
+                  (Optional) Upload a variable attributes file describing the
+                  variables in the data file:
+                </p>
+                <ul>
+                  <li>in .csv, .tsv, or tab-delimited .txt format</li>
+                  <li>
+                    with columns labeled (i) variable; (ii) label; (iii)
+                    definition, and
+                  </li>
+                  <li>with one row for every variable in the data file</li>
+                </ul>
+                <p className="important-info-bold">
+                  A valid variable attributes file is required to make your
+                  dataset Public.
+                </p>
+              </div>
+            );
+          },
+        },
+      },
     },
     enableExperimentalOrganism: true,
     dataInputConfig: {


### PR DESCRIPTION
* changed the type of the year inputs from number to text and simulated browser validation we would have lost
* added missing verbiage for phenotype data properties input