### PR TITLE
Show loading state while study metadata is pending

### DIFF
--- a/packages/libs/eda/src/lib/core/components/EDAWorkspaceContainer.tsx
+++ b/packages/libs/eda/src/lib/core/components/EDAWorkspaceContainer.tsx
@@ -57,7 +57,7 @@ export function EDAWorkspaceContainer(props: Props) {
       />
     );
 
-  if (wdkStudyRecordState == null || studyMetadata.value == null)
+  if (wdkStudyRecordState == null || studyMetadata.value == null || studyMetadata.pending)
     return <Loading />;
 
   return (


### PR DESCRIPTION
## Summary
Updated the loading condition in EDAWorkspaceContainer to properly handle the pending state of study metadata, ensuring the Loading component is displayed while metadata is being fetched.

## Key Changes
- Added `studyMetadata.pending` check to the loading condition in EDAWorkspaceContainer
- The component now displays the Loading state when study metadata is still being loaded, in addition to the existing null checks

## Implementation Details
The loading condition now checks three states before rendering the workspace:
1. `wdkStudyRecordState == null` - study record not yet loaded
2. `studyMetadata.value == null` - study metadata value not available
3. `studyMetadata.pending` - study metadata is currently being fetched

This prevents the workspace from rendering prematurely while asynchronous metadata requests are in flight.

https://claude.ai/code/session_01DEBNNmtzDxUdN9o8kfjLzF