### PR TITLE
Add plasmoFAST client-side tool for PlasmoDB

### DIFF
--- a/packages/sites/genomics-site/package.json
+++ b/packages/sites/genomics-site/package.json
@@ -100,5 +100,8 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "dependencies": {
+    "@veupathdb/plasmofast": "0.2.0"
+  }
 }

--- a/packages/sites/genomics-site/package.json
+++ b/packages/sites/genomics-site/package.json
@@ -102,6 +102,6 @@
     "dist"
   ],
   "dependencies": {
-    "@veupathdb/plasmofast": "0.2.0"
+    "@veupathdb/plasmofast": "0.2.2"
   }
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.scss
@@ -17,6 +17,7 @@
 
     background-color: #bdc0fa;
 
+    border-radius: 4px;
     margin-bottom: 1.5em;
     padding: 1em;
   }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.scss
@@ -1,0 +1,106 @@
+.api-PlasmoFast {
+  h2 {
+    font-size: 1.6em;
+  }
+
+  p {
+    font-size: 1.3em;
+  }
+
+  &--FormContainer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75em;
+
+    background-color: #bdc0fa;
+
+    margin-bottom: 1.5em;
+    padding: 1em;
+  }
+
+  &--FileLabel {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+
+    span {
+      font-weight: 600;
+    }
+  }
+
+  &--FileName {
+    font-size: 0.95em;
+    color: #333;
+  }
+
+  &--Controls {
+    margin-left: auto;
+  }
+
+  &--Progress {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75em;
+
+    margin-bottom: 1em;
+
+    progress {
+      flex: 1 1 240px;
+      height: 1.2rem;
+    }
+  }
+
+  &--ProgressLabel {
+    font-size: 0.95em;
+  }
+
+  &--Elapsed {
+    font-size: 0.95em;
+    font-style: italic;
+    color: #555;
+  }
+
+  &--Error {
+    color: #c00;
+    white-space: pre-wrap;
+    margin-bottom: 1em;
+  }
+
+  &--Call {
+    font-size: 1.3em;
+
+    &.no-call {
+      color: #555;
+      font-style: italic;
+    }
+  }
+
+  &--Results {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 2em;
+
+    th,
+    td {
+      border: 1px solid #ccc;
+      padding: 0.4rem 0.8rem;
+      text-align: right;
+    }
+
+    th:first-child,
+    td:first-child {
+      text-align: left;
+    }
+
+    thead {
+      background: #f0f0f0;
+    }
+  }
+
+  &--TopRow {
+    background: #fff6d6;
+    font-weight: 600;
+  }
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.scss
@@ -1,4 +1,6 @@
 .api-PlasmoFast {
+  max-width: 120ch;
+
   h2 {
     font-size: 1.6em;
   }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.tsx
@@ -92,7 +92,7 @@ export function PlasmoFast() {
       const totalSecs = ((Date.now() - startTime) / 1000).toFixed(1);
       setElapsed(`Completed in ${totalSecs}s`);
       setResult(finalResult);
-      setProgress({ pct: 100, reads: progress?.reads ?? 0 });
+      setProgress((prev) => ({ pct: 100, reads: prev?.reads ?? 0 }));
     } catch (err) {
       clearInterval(timer);
       setElapsed(undefined);
@@ -106,9 +106,6 @@ export function PlasmoFast() {
       setIsRunning(false);
       controllerRef.current = null;
     }
-    // `progress` intentionally excluded — it changes every tick and we only
-    // read it once at completion to preserve the final reads count.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.tsx
@@ -39,6 +39,9 @@ export function PlasmoFast() {
   const [result, setResult] = useState<AnalysisResult>();
   const [error, setError] = useState<string>();
   const [elapsed, setElapsed] = useState<string>();
+  // Bumping this remounts the FileInput, which is the only way to clear an
+  // uncontrolled <input type="file"> (its value can't be driven from state).
+  const [fileInputKey, setFileInputKey] = useState(0);
 
   const controllerRef = useRef<AbortController | null>(null);
 
@@ -49,6 +52,16 @@ export function PlasmoFast() {
 
   const onCancel = useCallback(() => {
     controllerRef.current?.abort();
+  }, []);
+
+  // Clear the selected file and reset the run state so the user can start fresh.
+  const clearFile = useCallback(() => {
+    setFileName(undefined);
+    setResult(undefined);
+    setProgress(undefined);
+    setError(undefined);
+    setElapsed(undefined);
+    setFileInputKey((k) => k + 1);
   }, []);
 
   const onFileSelected = useCallback(async (file: File | null) => {
@@ -121,16 +134,25 @@ export function PlasmoFast() {
         <label className={cx('--FileLabel')}>
           <span>FASTQ file</span>
           <FileInput
+            key={fileInputKey}
             accept=".fastq,.fastq.gz,.fq,.fq.gz"
             onChange={onFileSelected}
             disabled={isRunning}
           />
         </label>
         {fileName && <span className={cx('--FileName')}>{fileName}</span>}
+        {!isRunning && fileName && (
+          <OutlinedButton text="Clear" size="small" onPress={clearFile} />
+        )}
 
         {isRunning && (
           <div className={cx('--Controls')}>
-            <OutlinedButton text="Stop" themeRole="error" onPress={onCancel} />
+            <OutlinedButton
+              text="Stop"
+              size="small"
+              themeRole="error"
+              onPress={onCancel}
+            />
           </div>
         )}
       </div>

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/PlasmoFast.tsx
@@ -1,0 +1,216 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+
+import { analyze } from '@veupathdb/plasmofast';
+import { AnalysisResult, ProgressEvent } from '@veupathdb/plasmofast';
+
+import FileInput from '@veupathdb/wdk-client/lib/Components/InputControls/FileInput';
+import { makeClassNameHelper } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+import { OutlinedButton } from '@veupathdb/coreui/lib/components/buttons';
+
+import './PlasmoFast.scss';
+
+const cx = makeClassNameHelper('api-PlasmoFast');
+
+type Progress = {
+  pct: number;
+  reads: number;
+};
+
+/**
+ * Determine the most likely strain: the one with the highest `specific` count.
+ * Returns null if no strain has any specific hits (no confident call).
+ */
+function getTopStrain(result: AnalysisResult): string | null {
+  let topStrain: string | null = null;
+  let topCount = 0;
+  for (const [strain, counts] of Object.entries(result)) {
+    if (counts.specific > topCount) {
+      topCount = counts.specific;
+      topStrain = strain;
+    }
+  }
+  return topStrain;
+}
+
+export function PlasmoFast() {
+  const [fileName, setFileName] = useState<string>();
+  const [isRunning, setIsRunning] = useState(false);
+  const [progress, setProgress] = useState<Progress>();
+  const [result, setResult] = useState<AnalysisResult>();
+  const [error, setError] = useState<string>();
+  const [elapsed, setElapsed] = useState<string>();
+
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const topStrain = useMemo(
+    () => (result ? getTopStrain(result) : null),
+    [result]
+  );
+
+  const onCancel = useCallback(() => {
+    controllerRef.current?.abort();
+  }, []);
+
+  const onFileSelected = useCallback(async (file: File | null) => {
+    if (file == null) return;
+
+    // Reset state for a new run
+    setFileName(file.name);
+    setError(undefined);
+    setResult(undefined);
+    setProgress({ pct: 0, reads: 0 });
+    setElapsed(undefined);
+    setIsRunning(true);
+
+    const controller = new AbortController();
+    controllerRef.current = controller;
+
+    const startTime = Date.now();
+    const timer = setInterval(() => {
+      const secs = ((Date.now() - startTime) / 1000).toFixed(1);
+      setElapsed(`Elapsed: ${secs}s`);
+    }, 100);
+
+    try {
+      const finalResult = await analyze(file, {
+        signal: controller.signal,
+        onProgress: ({
+          bytesRead,
+          totalBytes,
+          readsProcessed,
+        }: ProgressEvent) => {
+          const pct =
+            totalBytes > 0 ? Math.round((bytesRead / totalBytes) * 100) : 0;
+          setProgress({ pct, reads: readsProcessed });
+        },
+        onPartialResult: (partial) => {
+          setResult(partial);
+        },
+      });
+
+      clearInterval(timer);
+      const totalSecs = ((Date.now() - startTime) / 1000).toFixed(1);
+      setElapsed(`Completed in ${totalSecs}s`);
+      setResult(finalResult);
+      setProgress({ pct: 100, reads: progress?.reads ?? 0 });
+    } catch (err) {
+      clearInterval(timer);
+      setElapsed(undefined);
+      if (controller.signal.aborted) {
+        // Cancellation is not a real error.
+        setError(undefined);
+      } else {
+        setError(String(err));
+      }
+    } finally {
+      setIsRunning(false);
+      controllerRef.current = null;
+    }
+    // `progress` intentionally excluded — it changes every tick and we only
+    // read it once at completion to preserve the final reads count.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className={cx('')}>
+      <h1>plasmoFAST &mdash; detect P. falciparum lab strains</h1>
+
+      <p>
+        Select a FASTQ file and plasmoFAST will detect which{' '}
+        <em>Plasmodium falciparum</em> lab strain it most closely matches.
+      </p>
+
+      <div className={cx('--FormContainer')}>
+        <label className={cx('--FileLabel')}>
+          <span>FASTQ file</span>
+          <FileInput
+            accept=".fastq,.fastq.gz,.fq,.fq.gz"
+            onChange={onFileSelected}
+            disabled={isRunning}
+          />
+        </label>
+        {fileName && <span className={cx('--FileName')}>{fileName}</span>}
+
+        {isRunning && (
+          <div className={cx('--Controls')}>
+            <OutlinedButton text="Stop" themeRole="error" onPress={onCancel} />
+          </div>
+        )}
+      </div>
+
+      {progress && (
+        <div className={cx('--Progress')}>
+          <progress max={100} value={progress.pct} />
+          <span className={cx('--ProgressLabel')}>
+            {progress.pct}% &middot; {progress.reads.toLocaleString()} reads
+          </span>
+          {elapsed && <span className={cx('--Elapsed')}>{elapsed}</span>}
+        </div>
+      )}
+
+      {error && <div className={cx('--Error')}>{error}</div>}
+
+      {topStrain != null ? (
+        <p className={cx('--Call')}>
+          Most likely strain: <strong>{topStrain}</strong>
+        </p>
+      ) : (
+        result && <p className={cx('--Call', 'no-call')}>No confident call</p>
+      )}
+
+      {result && (
+        <table className={cx('--Results')}>
+          <thead>
+            <tr>
+              <th>Strain</th>
+              <th>Specific</th>
+              <th>Nonspecific</th>
+              <th>Mixed</th>
+              <th>Low coverage</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(result).map(([strain, counts]) => (
+              <tr
+                key={strain}
+                className={strain === topStrain ? cx('--TopRow') : undefined}
+              >
+                <td>{strain}</td>
+                <td>{counts.specific}</td>
+                <td>{counts.nonspecific}</td>
+                <td>{counts.mixed}</td>
+                <td>{counts.lowCoverage}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <hr />
+
+      <h2>Explanation</h2>
+
+      <p>
+        plasmoFAST detects <em>Plasmodium falciparum</em> lab strains directly
+        from raw sequencing reads. Select a FASTQ file (or a gzip-compressed{' '}
+        <code>.fastq.gz</code>) and it counts strain-diagnostic 25-mers right in
+        your browser &mdash; <strong>your data is never uploaded</strong> to our
+        servers. Larger files take longer to process; you can stop a run at any
+        time.
+      </p>
+
+      <p>
+        For each candidate strain, the table reports how many diagnostic k-mers
+        were found that are <em>specific</em> to that strain,{' '}
+        <em>nonspecific</em> (shared with others), <em>mixed</em>, or seen at{' '}
+        <em>low coverage</em>. The strain with the most specific matches is
+        highlighted as the most likely call.
+      </p>
+
+      <p>
+        plasmoFAST was originally developed by Katie Ko (Kissinger Lab,
+        University of Georgia).
+      </p>
+    </div>
+  );
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/controllers/PlasmoFastController.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/controllers/PlasmoFastController.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { PlasmoFast } from '../PlasmoFast';
+
+import { useSetDocumentTitle } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
+
+export function PlasmoFastController() {
+  useSetDocumentTitle('plasmoFAST');
+
+  return <PlasmoFast />;
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/homepage/VEuPathDBHomePage.tsx
@@ -573,6 +573,17 @@ const useHeaderMenuItems = (
           url: 'https://www.ncbi.nlm.nih.gov/tools/primer-blast/',
         },
         {
+          key: 'plasmofast',
+          display: 'plasmoFAST',
+          tooltip:
+            'Detect P. falciparum lab strains from FASTQ sequencing files, entirely in your browser',
+          type: 'reactRoute',
+          url: '/plasmoFAST',
+          metadata: {
+            include: [PlasmoDB],
+          },
+        },
+        {
           key: 'plasmoap',
           display: 'PlasmoAP',
           type: 'reactRoute',
@@ -660,7 +671,7 @@ const useHeaderMenuItems = (
                 test: () => Boolean(useUserDatasetsWorkspace),
               },
             },
-          ]
+          ],
         },
         {
           key: 'favorites',

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/routes.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/routes.jsx
@@ -9,6 +9,7 @@ import FastaConfigController from './components/controllers/FastaConfigControlle
 import QueryGridController from './components/controllers/QueryGridController';
 import { JBrowseController } from './components/controllers/JBrowseController';
 import { PlasmoApController } from './components/controllers/PlasmoApController';
+import { PlasmoFastController } from './components/controllers/PlasmoFastController';
 
 import { useUserDatasetsWorkspace } from '@veupathdb/web-common/lib/config';
 
@@ -163,15 +164,17 @@ function DownloadsRouteComponent() {
  * Wrap Ebrc Routes
  */
 export const wrapRoutes = (ebrcRoutes) => [
-
-  // Allow guests to access dataset record pages for SEO and public visibility                                                                                             
-  {                                                                                                                                                                        
-    path: '/record/dataset/:primaryKey+',                                                                                                                                  
-    requiresLogin: false,                                                                                                                                                  
-    component: (props) => (                                                                                                                                                
-      <RecordController recordClass="dataset" primaryKey={props.match.params.primaryKey} />
-    ),                                                                                                                                                                     
-  },      
+  // Allow guests to access dataset record pages for SEO and public visibility
+  {
+    path: '/record/dataset/:primaryKey+',
+    requiresLogin: false,
+    component: (props) => (
+      <RecordController
+        recordClass="dataset"
+        primaryKey={props.match.params.primaryKey}
+      />
+    ),
+  },
 
   // Allow guests to access All Datasets and All Organisms for SEO and public visibility
   {
@@ -234,6 +237,11 @@ export const wrapRoutes = (ebrcRoutes) => [
         <SiteSearchRouteComponent />
       </Suspense>
     ),
+  },
+
+  {
+    path: '/plasmoFAST',
+    component: PlasmoFastController,
   },
 
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8905,6 +8905,7 @@ __metadata:
     "@veupathdb/eslint-config": "workspace:^"
     "@veupathdb/http-utils": "workspace:^"
     "@veupathdb/multi-blast": "workspace:^"
+    "@veupathdb/plasmofast": "npm:0.2.0"
     "@veupathdb/preferred-organisms": "workspace:^"
     "@veupathdb/react-scripts": "workspace:^"
     "@veupathdb/site-babel-config": "workspace:^"
@@ -9197,6 +9198,13 @@ __metadata:
     webpack-dev-server: "npm:^4.15.0"
   languageName: unknown
   linkType: soft
+
+"@veupathdb/plasmofast@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@veupathdb/plasmofast@npm:0.2.0"
+  checksum: 10/37a8a0d84a4a9b994c58094ac7b5aacd983672f68363fdeafa3fe1efac772cecfe919307f0ed664dda4776767cdecebc86e2f61946ce642aea6a6ee3c8c8d44c
+  languageName: node
+  linkType: hard
 
 "@veupathdb/preferred-organisms@workspace:^, @veupathdb/preferred-organisms@workspace:packages/libs/preferred-organisms":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -8905,7 +8905,7 @@ __metadata:
     "@veupathdb/eslint-config": "workspace:^"
     "@veupathdb/http-utils": "workspace:^"
     "@veupathdb/multi-blast": "workspace:^"
-    "@veupathdb/plasmofast": "npm:0.2.0"
+    "@veupathdb/plasmofast": "npm:0.2.2"
     "@veupathdb/preferred-organisms": "workspace:^"
     "@veupathdb/react-scripts": "workspace:^"
     "@veupathdb/site-babel-config": "workspace:^"
@@ -9199,10 +9199,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@veupathdb/plasmofast@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@veupathdb/plasmofast@npm:0.2.0"
-  checksum: 10/37a8a0d84a4a9b994c58094ac7b5aacd983672f68363fdeafa3fe1efac772cecfe919307f0ed664dda4776767cdecebc86e2f61946ce642aea6a6ee3c8c8d44c
+"@veupathdb/plasmofast@npm:0.2.2":
+  version: 0.2.2
+  resolution: "@veupathdb/plasmofast@npm:0.2.2"
+  checksum: 10/8d536c7865afd79a93da92909d0787308618fefcb9863a94a603ebfd48c3a74c95ec77008a692a04fb6f66f5d80e48b5481235c756ac05311156eb1ddd4b1cce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds a new `/plasmoFAST` tool that detects *Plasmodium falciparum* lab strains directly from FASTQ (or gzipped `.fastq.gz`) sequencing files. Analysis runs entirely in the browser via the `@veupathdb/plasmofast` library (k-mer counting in a Web Worker), so user data is never uploaded. The page shows a live progress bar with reads processed, a Stop button to cancel a run, and a per-strain results table that highlights the most likely strain. It's added to the Tools menu (PlasmoDB only) just above PlasmoAP.

- New route + `PlasmoFast` page/controller, modelled on the existing PlasmoAP tool
- Uses coreui buttons and wdk-client's `FileInput` for UI consistency
- Adds the `@veupathdb/plasmofast` dependency
