### PR TITLE
Require annotations file

### DIFF
--- a/packages/libs/user-datasets/src/lib/Common/Forms/Components/Sections/Definition/RootDetailsSection.tsx
+++ b/packages/libs/user-datasets/src/lib/Common/Forms/Components/Sections/Definition/RootDetailsSection.tsx
@@ -149,6 +149,7 @@ export function RootDetailsSection(
                   dataPropertiesFiles: files ?? undefined,
                 })
               }
+              required={datasetDetails.visibility === 'public'}
               helpText={
                 formConfig.verbiage.formInputs.datasetProperties.helpText
               }

--- a/packages/libs/user-datasets/src/lib/Components/Management/DatasetManagement.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Management/DatasetManagement.tsx
@@ -141,6 +141,13 @@ export interface DatasetManagementState {
   readonly isCommunityModalOpen: boolean;
 }
 
+enum CommunityPromotability {
+  CanPromote,
+  NotInstalled,
+  MissingDatasetProperties,
+  UnknownError,
+}
+
 class DatasetManagement<
   S extends DatasetManagementState = DatasetManagementState
 > extends React.Component<DatasetManagementProps, S> {
@@ -165,6 +172,30 @@ class DatasetManagement<
     this.closeSharingModal = this.closeSharingModal.bind(this);
     this.renderDetailsSection = this.renderDetailsSection.bind(this);
     this.renderAllDatasetsLink = this.renderAllDatasetsLink.bind(this);
+  }
+
+  private hasDatasetPropertiesFile(): boolean {
+    return !isEmpty(this.props.userDataset?.files?.datasetProperties);
+  }
+
+  private testCommunityPromotability(): CommunityPromotability {
+    if (!this.isInstalled()) return CommunityPromotability.NotInstalled;
+
+    const { userDataset, datasetTypes } = this.props;
+
+    const type = findDatasetTypeConfig(userDataset.type, datasetTypes!);
+
+    if (!type) {
+      return CommunityPromotability.UnknownError;
+    }
+
+    if (type.vdiConfig.usesDataProperties) {
+      return this.hasDatasetPropertiesFile()
+        ? CommunityPromotability.CanPromote
+        : CommunityPromotability.MissingDatasetProperties;
+    }
+
+    return CommunityPromotability.CanPromote;
   }
 
   openSharingModal() {
@@ -455,9 +486,18 @@ class DatasetManagement<
   renderDatasetActions() {
     const { isOwner } = this.props;
 
-    const notInstalledMessage = this.isInstalled()
-      ? undefined
-      : 'Datasets that have not been installed cannot be made public.';
+    const unpromotableMessage = (() => {
+      switch (this.testCommunityPromotability()) {
+        case CommunityPromotability.CanPromote:
+          return undefined;
+        case CommunityPromotability.NotInstalled:
+          return 'Datasets that have not been installed cannot be made public.';
+        case CommunityPromotability.MissingDatasetProperties:
+          return 'A variable annotations file is required to make this dataset public.';
+        default:
+          return 'Dataset cannot be made public at this time due to a site error.';
+      }
+    })();
 
     const editable =
       isOwner &&
@@ -493,7 +533,7 @@ class DatasetManagement<
                   break;
               }
             }}
-            disableCommunityReason={notInstalledMessage}
+            disableCommunityReason={unpromotableMessage}
             communityDatasetsEnabled={this.props.enablePublicUserDatasets}
           />
         )}

--- a/packages/libs/user-datasets/src/lib/Components/Update/UpdateForm.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/Update/UpdateForm.tsx
@@ -16,9 +16,10 @@ import { SubmittableState } from '../../Common/Forms/Components/UploadButton';
 import { useDatasetFormState } from '../../StoreModules/UserDatasetUploadStoreModule';
 import { isDatasetFormValid } from '../../Common/Forms/form-validation';
 import { DatasetFormProps } from '../../Common/Forms/DatasetFormProps';
-import { isEqual } from 'lodash';
-import { PartialDatasetDetails } from '../../Service';
+import { isEmpty, isEqual } from 'lodash';
+import { DatasetUploads, PartialDatasetDetails } from '../../Service';
 import { hasUploads } from '../../Service/Model/utility-types';
+import { DatasetTypeConfig } from '../../Common/Configuration';
 
 export interface UpdateFormProps extends DatasetFormProps {
   readonly originalDetails: PartialDatasetDetails;
@@ -57,7 +58,8 @@ export function UpdateForm(props: UpdateFormProps): ReactElement {
 
   useEffect(() => {
     setFormIsValid(
-      isDatasetFormValid(datasetDetails, props.formConfig, updateSection)
+      isDatasetFormValid(datasetDetails, props.formConfig, updateSection) &&
+        !isMissingDatasetProperties(props.formConfig.dataType, fileUploads)
     );
   }, [datasetDetails, fileUploads, props]);
 
@@ -93,5 +95,14 @@ export function UpdateForm(props: UpdateFormProps): ReactElement {
         />
       </form>
     </section>
+  );
+}
+
+function isMissingDatasetProperties(
+  type: DatasetTypeConfig,
+  files: DatasetUploads
+): boolean {
+  return (
+    type.vdiConfig.usesDataProperties && isEmpty(files.dataPropertiesFiles)
   );
 }


### PR DESCRIPTION
do not allow the user to promote a dataset to public without the presence of a variable annotations file.