### PR TITLE
adjust conflicting styles with the status sublist in the dataset management page

### DIFF
--- a/packages/libs/user-datasets/src/lib/Components/Management/DatasetManagement.scss
+++ b/packages/libs/user-datasets/src/lib/Components/Management/DatasetManagement.scss
@@ -120,17 +120,19 @@
         margin-left: 1em;
       }
 
-      // .DatasetManagement-NestedField {
-      //   margin-left: 2em;
-      // }
-
       .DatasetManagement-AttributeName {
         flex: 0 0 auto;
         padding-right: 10px;
       }
       .DatasetManagement-AttributeValue {
         flex: 1 1 auto;
-        ul {
+
+        ul.status-messages {
+          margin: 0.5em 0;
+          padding-left: 1.5em;
+        }
+
+        ul:not(.status-messages) {
           display: flex;
           list-style: none;
           margin: 0;

--- a/packages/libs/user-datasets/src/lib/Components/UserDatasetStatus.tsx
+++ b/packages/libs/user-datasets/src/lib/Components/UserDatasetStatus.tsx
@@ -273,7 +273,7 @@ function renderErrorMessages(messages: string[]): React.ReactNode {
 
   // Always render as bulleted list with newlines as <br>
   return (
-    <ul style={{ margin: '0.5em 0', paddingLeft: '1.5em', listStyle: 'disc' }}>
+    <ul className="status-messages">
       {messages.map((message, index) => (
         <li key={index}>
           {message.split('\n').map((line, i, arr) => (


### PR DESCRIPTION
### Before
<img width="1375" height="115" alt="image" src="https://github.com/user-attachments/assets/3c376d32-26c3-45c3-8419-2c1abcac3243" />

### After
<img width="542" height="160" alt="image" src="https://github.com/user-attachments/assets/5ea0c2a4-6c0d-4e7d-882c-b0ff1cbdb1d4" />
