### PR TITLE
add input validation to dataset source url

### DIFF
--- a/packages/libs/user-datasets/src/lib/Common/Forms/Components/InputPair.tsx
+++ b/packages/libs/user-datasets/src/lib/Common/Forms/Components/InputPair.tsx
@@ -31,6 +31,7 @@ interface TextProps<T extends object = object> extends BaseInputProps<T> {
   readonly value?: string;
   readonly minLength?: number;
   readonly maxLength?: number;
+  readonly placeholder?: string;
 }
 
 interface CheckboxProps<T extends object = object> extends BaseInputProps<T> {
@@ -158,6 +159,7 @@ function TextInput<T extends object>(props: TextProps<T>): ReactElement {
       value={props.value ?? ''}
       minLength={props.minLength}
       maxLength={props.maxLength}
+      placeholder={props.placeholder}
     />
   );
 }

--- a/packages/libs/user-datasets/src/lib/Common/Forms/Components/Sections/Core/DatasetSources.tsx
+++ b/packages/libs/user-datasets/src/lib/Common/Forms/Components/Sections/Core/DatasetSources.tsx
@@ -144,7 +144,11 @@ function DataSource({
         onChange={(v) => setSource({ ...source, url: v }, index)}
         disabled={!enabled}
         required={required}
-        helpText="The URL where the dataset is hosted or was obtained."
+        placeholder="https://data.source.org/path"
+        helpText={
+          'The full URL where the dataset is hosted or was obtained. URLs must'
+          + ' include a protocol prefix such as "https://", "ftp://", etc..'
+        }
       />
 
       <InputPair

--- a/packages/libs/user-datasets/src/lib/Common/Forms/Components/Sections/Core/DatasetSources.tsx
+++ b/packages/libs/user-datasets/src/lib/Common/Forms/Components/Sections/Core/DatasetSources.tsx
@@ -138,6 +138,7 @@ function DataSource({
     <li className="field-grid">
       <InputPair
         label="Source URL"
+        type="url"
         fieldName={jsonPath.appendToString<PostDatasetSource>('url')}
         value={source.url}
         onChange={(v) => setSource({ ...source, url: v }, index)}

--- a/packages/libs/user-datasets/src/lib/Common/Forms/DatasetForm.scss
+++ b/packages/libs/user-datasets/src/lib/Common/Forms/DatasetForm.scss
@@ -154,12 +154,19 @@
     margin-top: $inputPadding;
   }
 
-  input[type='text']:not(:focus).invalid,
-  input[type='text']:user-invalid,
-  textarea:not(:focus).invalid,
-  textarea:user-invalid {
-    border-color: var(--coreui-red-900);
-    background-color: var(--coreui-mutedRed-300);
+  input[type='email'],
+  input[type='number'],
+  input[type='url'],
+  input[type='text'],
+  textarea {
+    &:not(:focus) {
+      &.invalid,
+      &:invalid,
+      &:user-invalid {
+        border-color: var(--coreui-red-900);
+        background-color: var(--coreui-mutedRed-300);
+      }
+    }
   }
 
   label {


### PR DESCRIPTION
use build-in browser validation for the url input and apply validation styling to it.

As with all inputs, the update/upload button is disabled if the content is invalid.

<img width="567" height="94" alt="image" src="https://github.com/user-attachments/assets/006a47ec-102f-4a0f-961f-bf1c27beb49e" />

(the following screenshots predate the description text update pictured above)

<img width="579" height="83" alt="image" src="https://github.com/user-attachments/assets/bd6e765f-d652-42a6-9082-306332aa7f20" />

<img width="584" height="90" alt="2026-07-09T11:37:53-0400" src="https://github.com/user-attachments/assets/e4d886d2-8300-4f0c-9b83-e6af37f035c3" />
