### PR TITLE
add user datasets to internal search pages

### DIFF
--- a/USERDATASET_INTEGRATION_PLAN.md
+++ b/USERDATASET_INTEGRATION_PLAN.md
@@ -1,461 +1,154 @@
 # UserDataset Integration Plan for InternalGeneDataset.tsx
 
-## Context
+## Status
 
-### What is InternalGeneDataset.tsx?
+**Phase 1 Implementation** - Backend structure fully confirmed, ready to implement
 
-The `InternalGeneDataset.tsx` component implements a two-level question architecture:
-
-- **Internal Questions** (stub/catalog layer): Don't execute queries themselves, but show available datasets
-- **Real Questions** (execution layer): Actual parameterized searches pre-configured with specific dataset IDs
-
-### Current State
-
-- Component displays a catalog of **DataSource records** (recently upgraded from Dataset records)
-- DataSources come from backend/workflow system
-- Backend provides:
-  - Dataset metadata (name, organism, publications, etc.)
-  - References table linking to real questions
-  - Structured data populating `DatasourceRecord` and `InternalQuestionRecord`
-
-### New Requirement: UserDatasets
-
-- **UserDatasets** are user-provided data (not from workflow)
-- Conceptually similar to DataSource/Dataset but with differences
-- Need to support querying UserDatasets alongside DataSources
+**Date**: 2026-07-19
 
 ---
 
-## Key Architecture Components (Current Implementation)
+## Overview
 
-### Data Flow
+Integrate UserDatasets (user-uploaded data) alongside DataSources (curated data) in the InternalGeneDataset component. Display both in a unified table with source type filtering and appropriate visual distinctions.
 
-1. Internal question identified by `datasetCategory` and `datasetSubtype` properties
-2. Queries **"DatasourcesByCategory"** to get available datasets
-3. Each dataset has a `References` table listing valid real questions
-4. Ontology tree provides category metadata (Differential Expression, Fold Change, etc.)
-5. Buttons generated dynamically for each valid dataset-category-question combination
+**Component**: `packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx`
 
-### Key Data Structures
+---
 
-**InternalQuestionRecord** (lines 64-70):
+## Phase 1 Scope
 
-```typescript
-{
-  target_name: string,    // Real question name
-  dataset_id: string,
-  target_type: string,
-  dataset_name: string,
-  record_type: string
-}
+**Includes:**
+
+- Display UserDatasets and DataSources in same table
+- Source type icons (Internal/Public UD/Private UD) and filtering
+- Button generation with parameterized URLs
+- Basic metadata display
+
+**Excludes (Phase 2):**
+
+- Publications table for UserDatasets
+
+---
+
+## Architecture Decisions
+
+### Separate Processing Functions
+
+UserDatasets and DataSources use **separate processing functions** for maintainability and flexibility:
+
+- `getDatasourceRecords()` - Processes DataSource responses (References table)
+- `getUserDatasetRecords()` - Processes UserDataset responses (ExploreWebsiteSearches table)
+- Both return normalized `DatasourceRecord[]` shape
+- Merge results client-side
+
+### Key Differences: DataSources vs UserDatasets
+
+| Aspect            | DataSources                                              | UserDatasets                                                    |
+| ----------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
+| **Backend Table** | `References`                                             | `ExploreWebsiteSearches`                                        |
+| **Questions**     | Dataset-specific (e.g., `GenesByRnaSeq_RSRC123_DiffExp`) | Generic (e.g., `GenesByRNASeqUserDataset`)                      |
+| **URL Pattern**   | `#GenesByRnaSeq_RSRC123_DiffExp`                         | `#GenesByRNASeqUserDataset?param.rna_seq_dataset=5BM5MtFs0l0YZ` |
+| **Parameters**    | None (baked into question name)                          | Dataset ID passed as parameter                                  |
+| **Primary Key**   | `dataset_name` + `dataset_id`                            | Only `dataset_id` (used for both)                               |
+
+---
+
+## Backend Structure (CONFIRMED)
+
+### WDK Endpoint
+
+```
+POST /service/record-types/userdataset/searches/UserDatasetsByCategory/reports/standard
 ```
 
-**Note**: Name is confusing - this represents the _real_ questions that can be used with a dataset, not the internal question itself. Extracted from dataset's References table.
-
-**DatasourceRecord** (lines 72-82):
+### Request Configuration
 
 ```typescript
-{
-  dataset_name: string,
-  display_name: string,
-  organism_prefix: string,
-  dataset_id: string,
-  summary: string,
-  build_number_introduced: string,
-  publications: LinkAttributeValue[],
-  searches: string,        // Computed: space-separated category abbreviations
-  isPreferred: boolean     // Based on organism preferences
-}
-```
-
-This is the UI representation of a dataset row in the table.
-
-### Backend Query
-
-Currently queries: **"DatasourcesByCategory"** question with `dataset_category` parameter (lines 570-598)
-
----
-
-## Critical Questions to Answer Before Implementation
-
-### 1. UserDataset Backend Integration
-
-- Does a UserDataset have a similar References table structure?
-- Is there a parallel question like "UserDatasetsByCategory"?
-- Or do UserDatasets need to be fetched via a different WDK mechanism entirely?
-
-### 2. UserDataset Metadata Differences
-
-- What fields will UserDatasets have vs. DataSources?
-  - Will publications field apply?
-  - Will build_number_introduced apply?
-  - Any UserDataset-specific fields needed?
-- Will UserDatasets have the same category-based organization?
-
-### 3. Question Associations
-
-- Will UserDatasets link to _existing_ real questions, or new UserDataset-specific questions?
-- How will the References/question mapping work?
-- Will the naming pattern be similar: `GenesBy_{DataType}_{DatasetName}_{SearchCategory}`?
-
-### 4. Display Requirements
-
-- Should UserDatasets appear in the same table as DataSources, or separately?
-- Any visual distinction needed (badge, icon, different styling)?
-- Should there be a toggle to show/hide UserDatasets?
-
-### 5. Filtering/Preferences
-
-- Should organism preferences apply to UserDatasets?
-- Any UserDataset-specific filtering needed?
-- Should the "NEW" badge logic apply to UserDatasets?
-
-### 6. Permissions/Ownership
-
-- Are UserDatasets user-specific or shared?
-- Any access control considerations?
-- Should the UI show ownership information?
-
----
-
-## Component File Location
-
-`packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx`
-
----
-
-## Next Steps
-
-1. Answer the critical questions above
-2. Explore UserDataset backend API/WDK structure
-3. Design data structure changes needed
-4. Plan UI changes (table columns, visual distinctions)
-5. Implement backend integration
-6. Test with real UserDataset data
-
----
-
-## Detailed Architecture Analysis
-
-### Complete Data Flow (Current)
-
-**Phase 1: Initialization** (lines 103-138)
-
-- Extract Redux state: questions, ontology, recordClasses, preferredOrganisms
-- Get internal question metadata via `getTableQuestionMetadata()`
-
-**Phase 2: Data Loading** (lines 140-182)
-
-```typescript
-useWdkService(async (wdkService) => {
-  1. getAnswerJson() → Queries "DatasourcesByCategory"
-  2. getInternalQuestions() → Extracts question references
-  3. getDisplayCategoryMetadata() → Processes ontology tree
-  4. getDatasourceRecords() → Transforms into UI-ready records
-})
-```
-
-**Phase 3: Processing Internal Questions** (lines 599-641)
-
-- Function: `getInternalQuestions()`
-- Extracts question references from References table
-- Filters by `target_type === 'question'` and matching `record_type`
-
-**Phase 4: Category Metadata from Ontology** (lines 724-799)
-
-- Function: `getDisplayCategoryMetadata()`
-- Traverses ontology tree to find category nodes
-- Builds mapping: `questionNamesByDatasetAndCategory`
-- Extracts display metadata: `displayCategoriesByName`
-
-**Phase 5: Transform to UI Records** (lines 643-722)
-
-- Function: `getDatasourceRecords()`
-- Converts dataset records to table rows
-- Computes `searches` field (available category abbreviations)
-- Adds `isPreferred` based on organism preferences
-
-### Button Generation (lines 382-426)
-
-```typescript
-renderCell: (cellProps) => {
-  displayCategoryOrder.map((categoryName) => {
-    const categorySearchName = getCategorySearchName(
-      questionNamesByDatasetAndCategory,
-      datasetName,
-      categoryName
-    );
-
-    if (categorySearchName) {
-      return (
-        <Link to={`${internalSearchName}#${categorySearchName}`}>
-          {displayCategoriesByName[categoryName].shortDisplayName}
-        </Link>
-      );
-    }
-  });
+const USERDATASET_REPORT_CONFIG = {
+  attributes: [
+    'name', // Maps to displayName in response
+    'ref_organism_formatted', // HTML formatted organism
+    'dataset_id', // Primary key with EDAUD_ prefix
+    'summary',
+    'is_public', // STRING: "Private" or "Public"
+    'primary_contact_name',
+    'ref_organism', // Clean string for filtering
+  ],
+  tables: ['ExploreWebsiteSearches'],
+  pagination: { offset: 0, numRecords: -1 },
 };
 ```
 
-### Key Integration Points
+### Response Structure
 
-- **WDK Service**: `useWdkService` hook for async data fetching
-- **Plugin System**: Component registered via `pluginConfig.tsx`
-- **Preferred Organisms**: `@veupathdb/preferred-organisms` package
-- **Ontology Tree**: Category metadata and question organization
-
----
-
-## Design Patterns Used
-
-1. **Two-Level Question Architecture**: Separation of catalog vs. execution
-2. **Ontology-Driven UI**: Categories from tree structure, not hardcoded
-3. **Dataset-Question References via Database**: Dynamic associations
-4. **URL Hash for State Management**: Direct linking and navigation
-5. **Preferred Organisms Integration**: User-specific filtering
-6. **Lazy Tab Loading**: Performance optimization
-7. **Show One/Show All Toggle**: Focus on selected dataset
-8. **Beta Feature Indicators**: Experimental feature flagging
-
----
-
-## Date
-
-2026-07-18 (Updated: 2026-07-19)
-
-## Status
-
-Backend structure confirmed - ready for Phase 1 implementation
-
-## Scope: Phase 1 vs Phase 2
-
-**Phase 1 (This Iteration):**
-
-- Display UserDatasets alongside DataSources in table
-- Source type icons and filtering
-- Button generation with parameterized URLs
-- Basic metadata (display name, summary, organism, attribution)
-- **NO Publications** for UserDatasets
-
-**Phase 2 (Future):**
-
-- Add Publications table support for UserDatasets
-- Additional features TBD
-
----
-
-## Architecture Decision: Separate Processing Functions
-
-**Decision**: UserDatasets and DataSources will have **separate processing functions** rather than forcing them into the same backend API structure.
-
-**Rationale**:
-
-- **Maintainability**: Each data source owns its structure
-- **Robustness**: Avoids brittle coupling between two different sources
-- **Separation of concerns**: Frontend explicitly handles differences
-- **Flexibility**: Backend can evolve UD structure independently
-
-**Implementation**:
-
-- `getDatasourceRecords()` - processes DataSource responses (References table)
-- `getUserDatasetRecords()` - processes UserDataset responses (ExploreWdkSearches table)
-- Both return normalized `DatasourceRecord[]` shape
-- Merge normalized results client-side
-
----
-
-## UserDataset Backend Structure (CONFIRMED)
-
-### Required Attributes (CONFIRMED)
-
-```javascript
-"attributes": {
-  "display_name": "My RNA Seq Experiment",                     // User-friendly display text
-  "ref_organism_formatted": "<i>Plasmodium falciparum</i> 3D7", // Formatted organism (HTML)
-  "dataset_id": "EDAUD_53f554ec6a",                           // Primary key (also used as dataset_name)
-  "summary": "RNA sequencing analysis of...",                  // Description for tooltip
-  "is_public": true,                                           // Public vs private indicator
-  "primary_contact_name": "User et al 2024",                   // Attribution/contact
-  "ref_organism": "Plasmodium falciparum 3D7"                 // Clean organism for preference matching
+```json
+{
+  "records": [
+    {
+      "displayName": "test",
+      "attributes": {
+        "name": "test",
+        "ref_organism_formatted": "<i>Plasmodium falciparum</i> 3D7",
+        "dataset_id": "EDAUD_5BM5MtFs0l0YZ",
+        "summary": "test",
+        "is_public": "Private",
+        "primary_contact_name": "",
+        "ref_organism": "Plasmodium falciparum 3D7"
+      },
+      "tables": {
+        "ExploreWebsiteSearches": [
+          {
+            "question_name": "GenesByRNASeqUserDataset",
+            "dataset_id_param": "rna_seq_dataset",
+            "dataset_id": "EDAUD_5BM5MtFs0l0YZ",
+            "record_type": "TranscriptRecordClasses.TranscriptRecordClass"
+          }
+        ]
+      }
+    }
+  ]
 }
 ```
 
-**Field Mapping (UserDataset → DataSource equivalent):**
+### Critical Backend Details
 
-- `display_name` → `display_name` ✓ (same)
-- `ref_organism_formatted` → `organism_prefix` (HTML formatted display)
-- `dataset_id` → Both `dataset_id` and `dataset_name` (no separate name field)
-- `summary` → `summary` ✓ (same)
-- `is_public` → Used to determine public vs private icon
-- `primary_contact_name` → `short_attribution` (appended to display_name)
-- `ref_organism` → Used for organism preference matching (replaces Version table)
+1. **`is_public`**: STRING (`"Private"`/`"Public"`) - must convert to boolean
+2. **Table name**: `ExploreWebsiteSearches` (not `ExploreWdkSearches`)
+3. **`question_name`**: No namespace prefix in response
+4. **`dataset_id`**: Has `EDAUD_` prefix everywhere
+5. **Question params**: Strip `EDAUD_` prefix when building parameter URLs
 
-**Notes:**
+---
 
-- `dataset_id` is the **only primary key** - no separate `dataset_name` field
-- `ref_organism` attribute **replaces Version table** for preference filtering
-- `build_number_introduced` **not needed** for UserDatasets
-- `description` **not needed** (unused in current code)
+## Field Mapping
 
-### Required Tables
+### UserDataset → DatasourceRecord
 
-#### ExploreWdkSearches Table
-
-UserDatasets provide an `ExploreWdkSearches` table (parallel to DataSources' `References` table):
-
-```javascript
-"ExploreWdkSearches": [
-  {
-    "question_name": "GeneQuestions.GenesByRnaSeqUserDataset",  // Generic question with namespace
-    "dataset_id_param": "rna_seq_dataset",                       // Parameter name for this question
-    "dataset_id": "EDAUD_53f554ec6a",                           // Actual dataset ID (with EDAUD_ prefix)
-    "record_type": "TranscriptRecordClasses.TranscriptRecordClass",
-    "url": "",          // Not used by frontend
-    "description": "",  // Not used by frontend
-    "order": ""         // Not used by frontend
-  }
-  // One object per available search type (e.g., Fold Change, Diff Expr)
-  // dataset_id duplicated in each (it's the primary key)
-]
+```typescript
+{
+  dataset_name: record.attributes.dataset_id,  // Use dataset_id as name
+  display_name: record.displayName + " (" + record.attributes.primary_contact_name + ")",
+  organism_prefix: record.attributes.ref_organism_formatted,
+  dataset_id: record.attributes.dataset_id,
+  summary: record.attributes.summary,
+  build_number_introduced: "",  // Empty for UserDatasets
+  publications: [],             // Empty in Phase 1
+  searches: /* computed from categories */,
+  isPreferred: /* check ref_organism against preferences */,
+  source: 'userdataset',
+  is_public: record.attributes.is_public === 'Public',  // Convert string to boolean
+  dataset_id_param: /* varies by search category */
+}
 ```
 
-#### Publications Table
-
-**NOT INCLUDED IN PHASE 1** - Will be added in Phase 2.
-
-For Phase 1, UserDatasets will have:
-
-- `publications: []` (empty array) in the normalized record structure
-- No publication links shown in tooltips
-
-### Key Differences from DataSources References Table
-
-| Aspect               | DataSources (References)                          | UserDatasets (ExploreWdkSearches)                           |
-| -------------------- | ------------------------------------------------- | ----------------------------------------------------------- |
-| **Table Name**       | `References`                                      | `ExploreWdkSearches`                                        |
-| **Question Field**   | `target_name`                                     | `question_name`                                             |
-| **Question Pattern** | Dataset-specific: `GenesByRnaSeq_RSRC123_DiffExp` | Generic: `GenesByRnaSeqUserDataset`                         |
-| **Parameters**       | None (baked into question name)                   | `dataset_id_param` + `dataset_id`                           |
-| **URL Pattern**      | `#GenesByRnaSeq_RSRC123_DiffExp`                  | `#GenesByRnaSeqUserDataset?param.rna_seq_dataset=EDAUD_123` |
-
-### Processing Approach
-
-1. **Extract questions from table** - similar to `getInternalQuestions()` but from ExploreWdkSearches
-2. **Strip namespace** - `GeneQuestions.GenesByRnaSeqUserDataset` → `GenesByRnaSeqUserDataset`
-3. **Map to categories via ontology** - same as DataSources
-4. **Build parameterized URLs** - append `?param.{dataset_id_param}={dataset_id}`
-
 ---
 
-## Requirements Summary (ANSWERED)
+## Implementation Tasks
 
-### 1. UserDataset Backend Integration ✓
+### Phase 1: Type Definitions
 
-- **Yes**, UserDatasets have a similar References table structure
-- **Yes**, there is a parallel question: `"UserDatasetsByCategory"`
-- UserDatasets are WDK records, accessed the same way as DataSources
-
-### 2. UserDataset Metadata ✓
-
-- **Conceptually similar** to DataSources but with different backend structure
-- Required semantic fields (exact attribute names TBD):
-  - `publications`: Optional (can be empty or have values)
-  - `short_attribution`: Yes, UserDatasets have this
-  - `build_number_introduced`: **No** - won't be used for UserDatasets (no "NEW" badge)
-  - `is_public`: **Yes** - UserDatasets include this field
-  - `organism_prefix`: Backend provides appropriate value ("Unspecified" for phenotype UDs)
-  - Note: `organism_prefix` should really be named `organism_formatted` (contains HTML)
-- **Same categories**: Both dataset categories (RNA-Seq, Phenotype) AND search categories (Fold Change, Diff Expr)
-- **Version table**: Required - provides clean organism string for preference matching (not HTML formatted)
-
-### 3. Question Associations ✓
-
-- UserDatasets link to **shared generic questions**
-- Pattern: `"GenesByUserDataset_{SearchCategory}"` (e.g., `"GenesByUserDataset_DifferentialExpression"`)
-- UserDataset ID passed as **parameter** to the question
-- References table contains generic question names (not dataset-specific)
-
-### 4. Display Requirements ✓
-
-- **Mixed in same table** - UserDatasets and DataSources appear together
-- **New source type column** (icon-only, first column):
-  - Internal datasets: Site logo/favicon
-  - Public UserDatasets: Globe icon
-  - Private UserDatasets: Lock icon
-- **Filter checkboxes** at top of table:
-  - Serve dual purpose: filtering + legend
-  - Three checkboxes with icon + label
-  - All checked by default
-
-### 5. Filtering/Preferences ✓
-
-- **Organism preferences** apply conditionally:
-  - If `organism_prefix` is specific organism → apply preferences
-  - If `organism_prefix` is "Multiple organisms" or "Unspecified" → always show
-- Applies to both DataSources and UserDatasets
-
-### 6. Permissions/Ownership ✓
-
-- **Backend handles permissions**: Only returns UserDatasets the user should see
-- `is_public` field indicates public vs private
-- No frontend permission logic needed
-
----
-
-## Field Usage Analysis
-
-### Fields Actually Used in Display
-
-**Critical Fields (MUST have):**
-
-1. `dataset_name` - Identifier for linking to questions
-2. `display_name` - Display text
-3. `organism_prefix` - Organism info (can be HTML)
-4. `dataset_id` - Unique ID for record linking
-5. `summary` - Description for tooltip
-6. `short_attribution` - Appended to display name
-
-**Tables (MUST have):**
-
-1. `References` (DataSources) / `ExploreWdkSearches` (UserDatasets) - Links to search questions (CRITICAL)
-2. `Publications` - Can be empty array
-3. ~~`Version`~~ - No longer needed! UserDatasets use `organism` attribute instead
-
-**Optional/Conditional:**
-
-- `build_number_introduced` - Only for DataSources (for "NEW" badge)
-- `is_public` - Only for UserDatasets (for icon type)
-- `description` - Fetched but never used, can omit
-
-**Computed Fields (don't provide):**
-
-- `searches` - Derived from category metadata
-- `isPreferred` - Computed from Version table
-
-### DataSource vs UserDataset Field Mapping
-
-| Field                     | DataSource                 | UserDataset                 |
-| ------------------------- | -------------------------- | --------------------------- |
-| `dataset_name`            | ✓                          | ✓                           |
-| `display_name`            | ✓                          | ✓                           |
-| `organism_prefix`         | ✓                          | ✓ (can be "Unspecified")    |
-| `dataset_id`              | ✓                          | ✓ (format: UUID)            |
-| `summary`                 | ✓                          | ✓                           |
-| `build_number_introduced` | ✓                          | ✗ (skip)                    |
-| `short_attribution`       | ✓                          | ✓                           |
-| `publications`            | ✓                          | ✓ (can be empty)            |
-| `is_public`               | ✗                          | ✓ (boolean)                 |
-| `source`                  | ✓ (computed: 'datasource') | ✓ (computed: 'userdataset') |
-
----
-
-## Implementation Plan
-
-### Phase 1: Update Type Definitions
-
-**File**: `packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx`
-
-**Task 1.1**: Extend `DatasourceRecord` type (around line 72)
+**File**: `InternalGeneDataset.tsx` (line ~72)
 
 ```typescript
 type DatasourceRecord = {
@@ -469,15 +162,16 @@ type DatasourceRecord = {
   searches: string;
   isPreferred: boolean;
   source: 'datasource' | 'userdataset'; // NEW
-  is_public?: boolean; // NEW - only for userdatasets
+  is_public?: boolean; // NEW
+  dataset_id_param?: string; // NEW
 };
 ```
 
 ---
 
-### Phase 2: Add State for Source Type Filtering
+### Phase 2: Filter State
 
-**Task 2.1**: Add filter state (after line 191)
+**File**: `InternalGeneDataset.tsx` (after line ~191)
 
 ```typescript
 const [showDataSources, setShowDataSources] = useState(true);
@@ -487,87 +181,54 @@ const [showPrivateUserDatasets, setShowPrivateUserDatasets] = useState(true);
 
 ---
 
-### Phase 3: Fetch UserDatasets from Backend
+### Phase 3: Backend Integration
 
-**Task 3.1**: Modify `useWdkService` hook (around lines 140-182)
-
-- Fetch both DataSources and UserDatasets in parallel using `Promise.all()`
-- Query: `"UserDatasetsByCategory"` (TBD exact name) with `dataset_category` parameter
-- Create separate REPORT_CONFIG for UserDatasets
+#### Task 3.1: Parallel WDK Queries
 
 ```typescript
-const USERDATASET_REPORT_CONFIG = {
-  attributes: [
-    'name', // IMPORTANT: Request "name", response provides both displayName and attributes.name
-    'ref_organism_formatted',
-    'dataset_id',
-    'summary',
-    'is_public', // IMPORTANT: Will be STRING "Private" or "Public", not boolean
-    'primary_contact_name',
-    'ref_organism',
-  ],
-  tables: ['ExploreWebsiteSearches'], // IMPORTANT: "Website" not "Wdk"!
-  pagination: { offset: 0, numRecords: -1 },
-};
-
 const [datasourceAnswer, userdatasetAnswer] = await Promise.all([
   wdkService.getAnswerJson(
     getAnswerSpec(datasetCategory, 'DatasourcesByCategory'),
-    DATASOURCE_REPORT_CONFIG // Existing config
+    DATASOURCE_REPORT_CONFIG
   ),
   wdkService.getAnswerJson(
     getAnswerSpec(datasetCategory, 'UserDatasetsByCategory'),
-    USERDATASET_REPORT_CONFIG // New config for UserDatasets
+    USERDATASET_REPORT_CONFIG
   ),
 ]);
 ```
 
-**Task 3.2**: Create `getUserDatasetInternalQuestions()` function (parallel to `getInternalQuestions()`)
-
-- Extracts questions from `ExploreWdkSearches` table instead of `References`
-- Returns array of UserDataset question records
+#### Task 3.2: Extract UserDataset Questions
 
 ```typescript
 interface UserDatasetQuestionRecord {
-  question_name: string; // e.g., "GeneQuestions.GenesByRnaSeqUserDataset"
-  dataset_id_param: string; // e.g., "rna_seq_dataset"
-  dataset_id: string; // e.g., "EDAUD_53f554ec6a"
-  record_type: string; // e.g., "TranscriptRecordClasses.TranscriptRecordClass"
-  dataset_name: string; // From parent record attributes
+  question_name: string;
+  dataset_id_param: string;
+  dataset_id: string;
+  record_type: string;
+  dataset_name: string;
 }
 
 function getUserDatasetInternalQuestions(
   records: UserDatasetRecord[]
 ): UserDatasetQuestionRecord[] {
   return records.flatMap((record) => {
-    const exploreSearches = record.tables?.ExploreWdkSearches;
-
+    const exploreSearches = record.tables?.ExploreWebsiteSearches;
     if (!Array.isArray(exploreSearches)) {
-      throw new Error(
-        `ExploreWdkSearches table missing for UserDataset ${record.id}`
-      );
+      throw new Error(`ExploreWebsiteSearches table missing for UserDataset`);
     }
-
     return exploreSearches.map((search) => ({
       question_name: search.question_name,
       dataset_id_param: search.dataset_id_param,
       dataset_id: search.dataset_id,
       record_type: search.record_type,
-      dataset_name: record.attributes.dataset_name,
+      dataset_name: record.attributes.dataset_id, // Use dataset_id as name
     }));
   });
 }
 ```
 
-**Task 3.3**: Create `getUserDatasetRecords()` function (parallel to `getDatasourceRecords()`)
-
-- Maps UserDataset response fields to normalized `DatasourceRecord[]` shape
-- Returns records with `source: 'userdataset'`
-- Extracts `is_public` field for icon determination
-- Sets `build_number_introduced` to empty string (no NEW badge for UDs)
-- Uses ExploreWdkSearches instead of References
-- **Uses `dataset_id` as `dataset_name`** (UserDatasets have no separate dataset_name)
-- Uses `organism` attribute for preference filtering (no Version table)
+#### Task 3.3: Create getUserDatasetRecords()
 
 ```typescript
 function getUserDatasetRecords(
@@ -579,77 +240,40 @@ function getUserDatasetRecords(
   preferredOrganisms: OrganismPreference,
   buildNumber: string
 ): DatasourceRecord[] {
-  // Key differences from getDatasourceRecords:
-  // 1. dataset_name = dataset_id (no separate name field)
-  // 2. Use organism attribute for isPreferred (not Version table)
-  // 3. Extract is_public attribute
+  // Process similar to getDatasourceRecords but:
+  // 1. dataset_name = dataset_id
+  // 2. Use ref_organism for isPreferred (not Version table)
+  // 3. Convert is_public string to boolean
   // 4. Set source: 'userdataset'
-  // 5. Set build_number_introduced to empty string
-  // 6. Set publications to empty array (Phase 1 - no Publications table)
-  // 7. Store dataset_id_param for URL generation (varies by category)
+  // 5. Set build_number_introduced to empty
+  // 6. Set publications to empty array
+  // 7. Store dataset_id_param for URL generation
 }
 ```
 
-**Task 3.4**: Keep existing `getDatasourceRecords()` function (lines 643-722)
-
-- Add `source: 'datasource'` to returned records
-- Otherwise unchanged
-
-**Task 3.5**: Merge normalized record arrays
+#### Task 3.4: Merge Records
 
 ```typescript
-const datasourceRecords = getDatasourceRecords(
-  datasourceAnswer.records,
-  datasourceInternalQuestions,
-  questionNamesByDatasetAndCategory,
-  displayCategoryOrder,
-  displayCategoriesByName,
-  preferredOrganisms,
-  buildNumber
-);
-
-const userdatasetRecords = getUserDatasetRecords(
-  userdatasetAnswer.records,
-  userdatasetInternalQuestions,
-  questionNamesByDatasetAndCategory,
-  displayCategoryOrder,
-  displayCategoriesByName,
-  preferredOrganisms,
-  buildNumber
-);
-
 const allRecords = [...datasourceRecords, ...userdatasetRecords];
 ```
 
 ---
 
-### Phase 4: Update Button URL Generation
+### Phase 4: Button URL Generation
 
-**Task 4.1**: Update `DatasourceRecord` type to include parameter info
-
-```typescript
-type DatasourceRecord = {
-  // ... existing fields ...
-  source: 'datasource' | 'userdataset';
-  is_public?: boolean;
-  dataset_id_param?: string; // NEW - only for UserDatasets (e.g., "rna_seq_dataset")
-};
-```
-
-**Task 4.2**: Create new helper function `getCategorySearchUrl()`
+#### Task 4.1: URL Helper Function
 
 ```typescript
 function getCategorySearchUrl(
   questionName: string,
-  datasetId: string, // Will be "EDAUD_5BM5MtFs0l0YZ" from backend
+  datasetId: string,
   source: 'datasource' | 'userdataset',
-  datasetIdParam: string | undefined, // Parameter name for UserDatasets
+  datasetIdParam: string | undefined,
   internalSearchName: string
 ): string {
   const baseUrl = `${internalSearchName}#${questionName}`;
   if (source === 'userdataset' && datasetIdParam) {
     // CRITICAL: Strip EDAUD_ prefix for question parameters
-    // Backend provides dataset_id with prefix, but param URL needs it without
     const paramValue = datasetId.replace(/^EDAUD_/, '');
     return `${baseUrl}?param.${datasetIdParam}=${paramValue}`;
   }
@@ -657,10 +281,7 @@ function getCategorySearchUrl(
 }
 ```
 
-**Task 4.3**: Update button Link generation (lines 389-410)
-
-- Use new helper to generate URLs
-- Pass `source`, `dataset_id`, and `dataset_id_param` from row data
+#### Task 4.2: Update Button Rendering
 
 ```typescript
 renderCell: ({ row }) => {
@@ -676,7 +297,7 @@ renderCell: ({ row }) => {
         questionName,
         dataset_id,
         source,
-        dataset_id_param, // NEW - parameter name for UserDatasets
+        dataset_id_param,
         internalSearchName
       );
       return (
@@ -691,40 +312,54 @@ renderCell: ({ row }) => {
 
 ---
 
-### Phase 5: Add Source Type Column with Icons
+### Phase 5: Source Type Column
 
-**Task 5.1**: Add new column definition (as first column, before Organism)
+#### Task 5.1: Import Required Icons
+
+```typescript
+import { projectId } from '@veupathdb/web-common/lib/config';
+import LockIcon from '@material-ui/icons/Lock';
+import PublicIcon from '@material-ui/icons/Public';
+```
+
+#### Task 5.2: Column Definition (first column)
 
 ```typescript
 {
   key: 'source',
-  name: '',  // No header text
+  name: '',
   width: '50px',
   sortable: false,
   renderCell: ({ row }) => {
     if (row.source === 'datasource') {
-      return <SiteLogo alt="Internal Dataset" />;
+      return (
+        <img
+          src={`/images/${projectId}/favicon.jpg`}
+          alt="Internal Dataset"
+          style={{ width: '20px', height: '20px', objectFit: 'contain' }}
+        />
+      );
     } else if (row.is_public) {
-      return <GlobeIcon alt="Public User Dataset" />;
+      return <PublicIcon style={{ width: '20px', height: '20px' }} />;
     } else {
-      return <LockIcon alt="Private User Dataset" />;
+      return <LockIcon style={{ width: '20px', height: '20px' }} />;
     }
   }
 }
 ```
 
-**Task 5.2**: Implement/find icons
+#### Icon Implementation Notes
 
-- Research site logo/favicon path (user will provide if needed)
-- Implement or import Globe icon component
-- Implement or import Lock icon component
-- Ensure consistent sizing (e.g., 20x20px or 24x24px)
+- **Internal Dataset**: Site favicon at `/images/${projectId}/favicon.jpg` (e.g., PlasmoDB, ToxoDB)
+- **Public User Dataset**: `PublicIcon` from `@material-ui/icons/Public` (globe icon)
+- **Private User Dataset**: `LockIcon` from `@material-ui/icons/Lock`
+- All sized consistently to 20x20px
 
 ---
 
-### Phase 6: Add Filter Checkboxes UI
+### Phase 6: Filter Checkboxes
 
-**Task 6.1**: Add filter checkbox section (before table, around line 260)
+#### Task 6.1: Checkbox UI (before table, ~line 260)
 
 ```typescript
 <div className="wdk-InternalGeneDatasetForm__SourceFilters">
@@ -734,7 +369,11 @@ renderCell: ({ row }) => {
       checked={showDataSources}
       onChange={(e) => setShowDataSources(e.target.checked)}
     />
-    <SiteLogo /> Internal Datasets
+    <img
+      src={`/images/${projectId}/favicon.jpg`}
+      alt="Internal Dataset"
+      style={{ width: '20px', height: '20px', objectFit: 'contain' }}
+    /> Internal Datasets
   </label>
   <label>
     <input
@@ -742,7 +381,7 @@ renderCell: ({ row }) => {
       checked={showPublicUserDatasets}
       onChange={(e) => setShowPublicUserDatasets(e.target.checked)}
     />
-    <GlobeIcon /> Public User Datasets
+    <PublicIcon style={{ width: '20px', height: '20px' }} /> Public User Datasets
   </label>
   <label>
     <input
@@ -750,28 +389,20 @@ renderCell: ({ row }) => {
       checked={showPrivateUserDatasets}
       onChange={(e) => setShowPrivateUserDatasets(e.target.checked)}
     />
-    <LockIcon /> Private User Datasets
+    <LockIcon style={{ width: '20px', height: '20px' }} /> Private User Datasets
   </label>
 </div>
 ```
 
-**Task 6.2**: Implement source type filtering
-
-- Update `getFilteredDatasourceRecords()` (lines 550-568) or create wrapper
-- Apply filters based on checkbox state
+#### Task 6.2: Filtering Logic
 
 ```typescript
 const sourceFilteredRecords = allRecords.filter((record) => {
-  if (record.source === 'datasource') {
-    return showDataSources;
-  } else if (record.is_public) {
-    return showPublicUserDatasets;
-  } else {
-    return showPrivateUserDatasets;
-  }
+  if (record.source === 'datasource') return showDataSources;
+  else if (record.is_public) return showPublicUserDatasets;
+  else return showPrivateUserDatasets;
 });
 
-// Then apply existing organism and other filters
 const filteredRecords = getFilteredDatasourceRecords(
   sourceFilteredRecords
   /* other params */
@@ -780,9 +411,7 @@ const filteredRecords = getFilteredDatasourceRecords(
 
 ---
 
-### Phase 7: Update Organism Preference Filtering
-
-**Task 7.1**: Modify organism filtering logic (around line 565)
+### Phase 7: Organism Filtering
 
 ```typescript
 const isPreferredDataset = (record) => {
@@ -793,7 +422,6 @@ const isPreferredDataset = (record) => {
   ) {
     return true;
   }
-
   // Apply existing organism preference filtering
   return existingIsPreferredLogic(record);
 };
@@ -801,33 +429,22 @@ const isPreferredDataset = (record) => {
 
 ---
 
-### Phase 8: Handle Dataset Record Links
-
-**Task 8.1**: Update dataset record page links (around line 372)
+### Phase 8: Record Links
 
 ```typescript
 const recordUrl =
   row.source === 'datasource'
     ? `/record/dataset/${dataset_id}`
-    : `/record/userdataset/EDAUD_${dataset_id}`;
+    : `/record/userdataset/${dataset_id}`; // Already has EDAUD_ prefix
 
 <Link to={recordUrl}>{safeHtml(display_name)}</Link>;
 ```
 
 ---
 
-### Phase 9: Update Styling
+### Phase 9: Styling
 
-**Task 9.1**: Add SCSS for new UI elements
-
-- File: `InternalGeneDataset.scss`
-- Add styles for:
-  - `.wdk-InternalGeneDatasetForm__SourceFilters` (filter checkbox section)
-  - Source type column (narrow width, centered icons)
-  - Icon sizing and alignment
-  - Filter checkbox layout and spacing
-
-**Example SCSS**:
+**File**: `InternalGeneDataset.scss`
 
 ```scss
 .wdk-InternalGeneDatasetForm__SourceFilters {
@@ -842,10 +459,6 @@ const recordUrl =
     gap: 0.5rem;
     cursor: pointer;
 
-    input[type='checkbox'] {
-      margin-right: 0.25rem;
-    }
-
     svg,
     img {
       width: 20px;
@@ -853,169 +466,68 @@ const recordUrl =
     }
   }
 }
-
-// Source column icon styling
-.source-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  svg,
-  img {
-    width: 20px;
-    height: 20px;
-  }
-}
 ```
 
 ---
 
-### Phase 10: Testing & Edge Cases
+### Phase 10: Testing
 
-**Task 10.1**: Test scenarios
-
-- Page with only DataSources (no UserDatasets)
-- Page with only UserDatasets (no DataSources)
+- Page with only DataSources
+- Page with only UserDatasets
 - Mixed datasets
-- All filter combinations (8 total: 2^3)
-- Organism preference filtering with multi-organism datasets
-- Button clicks for both source types (verify URL parameters)
-- Dataset record page links for both types
-- Empty states and warnings
-
-**Task 10.2**: Handle empty states
-
-- No datasets match category
-- No datasets match filters
-- Update warning messages (e.g., OrganismPreferencesWarning)
+- All 8 filter combinations (2^3)
+- Organism preference filtering
+- Button URL parameters (verify EDAUD\_ stripped)
+- Record page links
+- Empty states
 
 ---
 
-### Phase 11: Documentation & Cleanup
+## Critical Implementation Notes
 
-**Task 11.1**: Update this planning document with:
+### ID Format Handling
 
-- Final implementation decisions
-- Any deviations from plan
-- Technical debt or future improvements
+- **Backend provides**: `EDAUD_5BM5MtFs0l0YZ` everywhere
+- **Record page URLs**: Use as-is → `/record/userdataset/EDAUD_5BM5MtFs0l0YZ`
+- **Question parameters**: Strip prefix → `?param.rna_seq_dataset=5BM5MtFs0l0YZ`
 
-**Task 11.2**: Code comments
+### String vs Boolean Conversion
 
-- Document the source type filtering logic
-- Explain UserDataset parameter passing pattern
-- Note any complex transformations
+```typescript
+// Backend returns string
+"is_public": "Private"  // or "Public"
 
----
+// Convert to boolean
+is_public: record.attributes.is_public === 'Public'
+```
 
-## Key Technical Details
+### Table Name
 
-### WDK Endpoints and Questions
+Use `ExploreWebsiteSearches` (not `ExploreWdkSearches`)
 
-**DataSources:**
+### Question Names
 
-- Question: `"DatasourcesByCategory"`
-- Endpoint: (legacy format)
+Backend returns without namespace prefix:
 
-**UserDatasets:**
-
-- Question: `"UserDatasetsByCategory"`
-- Endpoint: `POST /service/record-types/userdataset/searches/UserDatasetsByCategory/reports/standard`
-- Both use same `dataset_category` parameter
-
-### UserDataset Backend Response Structure (CONFIRMED)
-
-**Request attribute name:** `"name"` (not `"display_name"`)
-**Response provides:** `displayName` property + `attributes.name`
-
-**Critical Response Details:**
-
-1. **`is_public`** is a **STRING**: `"Private"` or `"Public"` (NOT boolean!)
-
-   - Must convert to boolean: `record.attributes.is_public === 'Public'`
-
-2. **Table name**: `"ExploreWebsiteSearches"` (not "ExploreWdkSearches")
-
-3. **`question_name`**: NO namespace prefix in response
-
-   - Just `"GenesByRNASeqUserDataset"` (not `"GeneQuestions.GenesByRNASeqUserDataset"`)
-
-4. **`dataset_id`** in attributes: Has `EDAUD_` prefix (e.g., `"EDAUD_5BM5MtFs0l0YZ"`)
-
-5. **`dataset_id`** in ExploreWebsiteSearches: Also has `EDAUD_` prefix
-
-6. **Backend-provided URL** in ExploreWebsiteSearches: Uses UUID without prefix
-   - Example: `?param.rna_seq_dataset=5BM5MtFs0l0YZ` (NOT `EDAUD_5BM5MtFs0l0YZ`)
-
-### UserDataset ID Formats and Usage
-
-- **VDI ID**: Plain UUID (e.g., `5BM5MtFs0l0YZ`)
-- **WDK Record ID**: Prefixed with `EDAUD_` (e.g., `EDAUD_5BM5MtFs0l0YZ`)
-
-**Where to use which format:**
-
-- **Backend response**: Provides `EDAUD_` prefix in `dataset_id` fields
-- **Record page URLs**: Use full `EDAUD_` prefix → `/record/userdataset/EDAUD_5BM5MtFs0l0YZ`
-- **Question parameters**: Strip `EDAUD_` prefix → `?param.rna_seq_dataset=5BM5MtFs0l0YZ`
-  - Use `.replace(/^EDAUD_/, '')` to strip prefix for URL parameters
-
-### Question URL Patterns
-
-- **DataSources**: `{internalSearchName}#{datasetSpecificQuestionName}`
-  - Example: `GenesByRnaSeq#GenesByRnaSeq_RSRC123_DifferentialExpression`
-- **UserDatasets**: `{internalSearchName}#{genericQuestionName}?param.dataset_id={wdkId}`
-  - Example: `GenesByRnaSeq#GenesByUserDataset_DifferentialExpression?param.dataset_id=EDAUD_abc123`
-
-### Generic Questions
-
-- Pattern: `GenesByUserDataset_{SearchCategory}`
-- Examples:
-  - `GenesByUserDataset_DifferentialExpression`
-  - `GenesByUserDataset_FoldChange`
-  - `GenesByUserDataset_WGCNA`
-
-### Categories
-
-- **Dataset Categories**: RNA-Seq, Phenotype, etc. (determines which internal question page)
-- **Search Categories**: Fold Change, Differential Expression, etc. (determines button types)
-- UserDatasets use same categories as DataSources for both
-
-### Organism Prefix Special Values
-
-- Specific organism: `<i>Eimeria media</i> PL19_A22` (HTML formatted)
-- Multi-organism: `Multiple organisms`
-- Unknown organism: `Unspecified`
-- Multi-organism and Unspecified datasets bypass organism preference filtering
+- Just `"GenesByRNASeqUserDataset"`
+- Not `"GeneQuestions.GenesByRNASeqUserDataset"`
 
 ---
 
-## Dependencies/Unknowns
+## Testing Curl Command
 
-### Backend Structure - CONFIRMED ✓
-
-1. ✓ **ExploreWdkSearches table** - Confirmed structure with question_name, dataset_id_param, dataset_id, record_type
-2. ✓ **Generic questions** - Question names are generic (e.g., GenesByRnaSeqUserDataset), not dataset-specific
-3. ✓ **Parameter passing** - Uses dataset_id_param field to specify which parameter name
-4. ✓ **dataset_id format** - Already includes EDAUD\_ prefix in response
-5. ✓ **One row per search type** - Multiple rows with duplicated dataset_id (it's the PK)
-
-### Still To Confirm with Backend
-
-1. **UserDatasetsByCategory question name** - Exact WDK question name
-2. **REPORT_CONFIG for UserDatasets** - Which attributes and tables to request
-3. **Attribute field names** - Exact names for display_name, organism_prefix, summary, etc.
-4. **is_public field location** - Which attribute contains this boolean
-5. **Version table structure** - Confirm organism field exists for preference filtering
-6. **Publications table structure** - Confirm same structure as DataSources
-
-### To Resolve (Frontend)
-
-1. **Site logo/favicon path** - User will provide
-2. **Icon library** - Determine if globe/lock icons exist or need creation
-3. ~~**Parameter name**~~ - ✓ Confirmed: parameter names vary per question type (dataset_id_param field)
-
-### Design Decisions Made
-
-- ✓ **Separate processing functions** - Not forcing UDs into same backend API as DataSources
-- ✓ **Client-side normalization** - Two functions return common `DatasourceRecord` shape
-- ✓ **Backend independence** - UD structure can evolve without affecting DataSource code
-- ✓ **Version table required** - Provides clean organism strings for matching (not HTML formatted)
+```bash
+curl -X POST 'https://plasmodb.org/plasmo/service/record-types/userdataset/searches/UserDatasetsByCategory/reports/standard' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer YOUR_TOKEN' \
+  -d '{
+    "searchConfig": {
+      "parameters": { "dataset_category": "RNASeq" }
+    },
+    "reportConfig": {
+      "attributes": ["name", "ref_organism_formatted", "dataset_id", "summary", "is_public", "primary_contact_name", "ref_organism"],
+      "tables": ["ExploreWebsiteSearches"],
+      "pagination": { "offset": 0, "numRecords": 10 }
+    }
+  }'
+```

--- a/USERDATASET_INTEGRATION_PLAN.md
+++ b/USERDATASET_INTEGRATION_PLAN.md
@@ -266,24 +266,34 @@ Backend structure confirmed - ready for Phase 1 implementation
 
 ## UserDataset Backend Structure (CONFIRMED)
 
-### Required Attributes
+### Required Attributes (CONFIRMED)
 
 ```javascript
 "attributes": {
-  "dataset_id": "EDAUD_53f554ec6a",                           // Primary key (also used as dataset_name)
   "display_name": "My RNA Seq Experiment",                     // User-friendly display text
-  "organism_prefix": "<i>Plasmodium falciparum</i> 3D7",      // Formatted organism (HTML)
-  "organism": "Plasmodium falciparum 3D7",                    // Clean organism for preference matching
+  "ref_organism_formatted": "<i>Plasmodium falciparum</i> 3D7", // Formatted organism (HTML)
+  "dataset_id": "EDAUD_53f554ec6a",                           // Primary key (also used as dataset_name)
   "summary": "RNA sequencing analysis of...",                  // Description for tooltip
-  "short_attribution": "User et al 2024",                      // Appended to display_name
-  "is_public": true                                            // Public vs private indicator
+  "is_public": true,                                           // Public vs private indicator
+  "primary_contact_name": "User et al 2024",                   // Attribution/contact
+  "ref_organism": "Plasmodium falciparum 3D7"                 // Clean organism for preference matching
 }
 ```
+
+**Field Mapping (UserDataset → DataSource equivalent):**
+
+- `display_name` → `display_name` ✓ (same)
+- `ref_organism_formatted` → `organism_prefix` (HTML formatted display)
+- `dataset_id` → Both `dataset_id` and `dataset_name` (no separate name field)
+- `summary` → `summary` ✓ (same)
+- `is_public` → Used to determine public vs private icon
+- `primary_contact_name` → `short_attribution` (appended to display_name)
+- `ref_organism` → Used for organism preference matching (replaces Version table)
 
 **Notes:**
 
 - `dataset_id` is the **only primary key** - no separate `dataset_name` field
-- `organism` attribute **replaces Version table** for preference filtering
+- `ref_organism` attribute **replaces Version table** for preference filtering
 - `build_number_introduced` **not needed** for UserDatasets
 - `description` **not needed** (unused in current code)
 
@@ -488,15 +498,15 @@ const [showPrivateUserDatasets, setShowPrivateUserDatasets] = useState(true);
 ```typescript
 const USERDATASET_REPORT_CONFIG = {
   attributes: [
+    'name', // IMPORTANT: Request "name", response provides both displayName and attributes.name
+    'ref_organism_formatted',
     'dataset_id',
-    'display_name',
-    'organism_prefix',
-    'organism',
     'summary',
-    'short_attribution',
-    'is_public',
+    'is_public', // IMPORTANT: Will be STRING "Private" or "Public", not boolean
+    'primary_contact_name',
+    'ref_organism',
   ],
-  tables: ['ExploreWdkSearches'], // No Publications in Phase 1
+  tables: ['ExploreWebsiteSearches'], // IMPORTANT: "Website" not "Wdk"!
   pagination: { offset: 0, numRecords: -1 },
 };
 
@@ -631,15 +641,17 @@ type DatasourceRecord = {
 ```typescript
 function getCategorySearchUrl(
   questionName: string,
-  datasetId: string,
+  datasetId: string, // Will be "EDAUD_5BM5MtFs0l0YZ" from backend
   source: 'datasource' | 'userdataset',
   datasetIdParam: string | undefined, // Parameter name for UserDatasets
   internalSearchName: string
 ): string {
   const baseUrl = `${internalSearchName}#${questionName}`;
   if (source === 'userdataset' && datasetIdParam) {
-    // dataset_id already includes EDAUD_ prefix from backend
-    return `${baseUrl}?param.${datasetIdParam}=${datasetId}`;
+    // CRITICAL: Strip EDAUD_ prefix for question parameters
+    // Backend provides dataset_id with prefix, but param URL needs it without
+    const paramValue = datasetId.replace(/^EDAUD_/, '');
+    return `${baseUrl}?param.${datasetIdParam}=${paramValue}`;
   }
   return baseUrl;
 }
@@ -897,19 +909,54 @@ const recordUrl =
 
 ## Key Technical Details
 
-### WDK Questions
+### WDK Endpoints and Questions
 
-- **DataSources**: `"DatasourcesByCategory"`
-- **UserDatasets**: `"UserDatasetsByCategory"`
+**DataSources:**
+
+- Question: `"DatasourcesByCategory"`
+- Endpoint: (legacy format)
+
+**UserDatasets:**
+
+- Question: `"UserDatasetsByCategory"`
+- Endpoint: `POST /service/record-types/userdataset/searches/UserDatasetsByCategory/reports/standard`
 - Both use same `dataset_category` parameter
 
-### UserDataset ID Formats
+### UserDataset Backend Response Structure (CONFIRMED)
 
-- **VDI ID**: Plain UUID (e.g., `abc123def456`)
-- **WDK Record ID**: Prefixed with `EDAUD_` (e.g., `EDAUD_abc123def456`)
-- Use `EDAUD_` prefix for:
-  - Record page URLs: `/record/userdataset/EDAUD_{id}`
-  - Question parameters: `?param.dataset_id=EDAUD_{id}`
+**Request attribute name:** `"name"` (not `"display_name"`)
+**Response provides:** `displayName` property + `attributes.name`
+
+**Critical Response Details:**
+
+1. **`is_public`** is a **STRING**: `"Private"` or `"Public"` (NOT boolean!)
+
+   - Must convert to boolean: `record.attributes.is_public === 'Public'`
+
+2. **Table name**: `"ExploreWebsiteSearches"` (not "ExploreWdkSearches")
+
+3. **`question_name`**: NO namespace prefix in response
+
+   - Just `"GenesByRNASeqUserDataset"` (not `"GeneQuestions.GenesByRNASeqUserDataset"`)
+
+4. **`dataset_id`** in attributes: Has `EDAUD_` prefix (e.g., `"EDAUD_5BM5MtFs0l0YZ"`)
+
+5. **`dataset_id`** in ExploreWebsiteSearches: Also has `EDAUD_` prefix
+
+6. **Backend-provided URL** in ExploreWebsiteSearches: Uses UUID without prefix
+   - Example: `?param.rna_seq_dataset=5BM5MtFs0l0YZ` (NOT `EDAUD_5BM5MtFs0l0YZ`)
+
+### UserDataset ID Formats and Usage
+
+- **VDI ID**: Plain UUID (e.g., `5BM5MtFs0l0YZ`)
+- **WDK Record ID**: Prefixed with `EDAUD_` (e.g., `EDAUD_5BM5MtFs0l0YZ`)
+
+**Where to use which format:**
+
+- **Backend response**: Provides `EDAUD_` prefix in `dataset_id` fields
+- **Record page URLs**: Use full `EDAUD_` prefix → `/record/userdataset/EDAUD_5BM5MtFs0l0YZ`
+- **Question parameters**: Strip `EDAUD_` prefix → `?param.rna_seq_dataset=5BM5MtFs0l0YZ`
+  - Use `.replace(/^EDAUD_/, '')` to strip prefix for URL parameters
 
 ### Question URL Patterns
 

--- a/USERDATASET_INTEGRATION_PLAN.md
+++ b/USERDATASET_INTEGRATION_PLAN.md
@@ -1,0 +1,974 @@
+# UserDataset Integration Plan for InternalGeneDataset.tsx
+
+## Context
+
+### What is InternalGeneDataset.tsx?
+
+The `InternalGeneDataset.tsx` component implements a two-level question architecture:
+
+- **Internal Questions** (stub/catalog layer): Don't execute queries themselves, but show available datasets
+- **Real Questions** (execution layer): Actual parameterized searches pre-configured with specific dataset IDs
+
+### Current State
+
+- Component displays a catalog of **DataSource records** (recently upgraded from Dataset records)
+- DataSources come from backend/workflow system
+- Backend provides:
+  - Dataset metadata (name, organism, publications, etc.)
+  - References table linking to real questions
+  - Structured data populating `DatasourceRecord` and `InternalQuestionRecord`
+
+### New Requirement: UserDatasets
+
+- **UserDatasets** are user-provided data (not from workflow)
+- Conceptually similar to DataSource/Dataset but with differences
+- Need to support querying UserDatasets alongside DataSources
+
+---
+
+## Key Architecture Components (Current Implementation)
+
+### Data Flow
+
+1. Internal question identified by `datasetCategory` and `datasetSubtype` properties
+2. Queries **"DatasourcesByCategory"** to get available datasets
+3. Each dataset has a `References` table listing valid real questions
+4. Ontology tree provides category metadata (Differential Expression, Fold Change, etc.)
+5. Buttons generated dynamically for each valid dataset-category-question combination
+
+### Key Data Structures
+
+**InternalQuestionRecord** (lines 64-70):
+
+```typescript
+{
+  target_name: string,    // Real question name
+  dataset_id: string,
+  target_type: string,
+  dataset_name: string,
+  record_type: string
+}
+```
+
+**Note**: Name is confusing - this represents the _real_ questions that can be used with a dataset, not the internal question itself. Extracted from dataset's References table.
+
+**DatasourceRecord** (lines 72-82):
+
+```typescript
+{
+  dataset_name: string,
+  display_name: string,
+  organism_prefix: string,
+  dataset_id: string,
+  summary: string,
+  build_number_introduced: string,
+  publications: LinkAttributeValue[],
+  searches: string,        // Computed: space-separated category abbreviations
+  isPreferred: boolean     // Based on organism preferences
+}
+```
+
+This is the UI representation of a dataset row in the table.
+
+### Backend Query
+
+Currently queries: **"DatasourcesByCategory"** question with `dataset_category` parameter (lines 570-598)
+
+---
+
+## Critical Questions to Answer Before Implementation
+
+### 1. UserDataset Backend Integration
+
+- Does a UserDataset have a similar References table structure?
+- Is there a parallel question like "UserDatasetsByCategory"?
+- Or do UserDatasets need to be fetched via a different WDK mechanism entirely?
+
+### 2. UserDataset Metadata Differences
+
+- What fields will UserDatasets have vs. DataSources?
+  - Will publications field apply?
+  - Will build_number_introduced apply?
+  - Any UserDataset-specific fields needed?
+- Will UserDatasets have the same category-based organization?
+
+### 3. Question Associations
+
+- Will UserDatasets link to _existing_ real questions, or new UserDataset-specific questions?
+- How will the References/question mapping work?
+- Will the naming pattern be similar: `GenesBy_{DataType}_{DatasetName}_{SearchCategory}`?
+
+### 4. Display Requirements
+
+- Should UserDatasets appear in the same table as DataSources, or separately?
+- Any visual distinction needed (badge, icon, different styling)?
+- Should there be a toggle to show/hide UserDatasets?
+
+### 5. Filtering/Preferences
+
+- Should organism preferences apply to UserDatasets?
+- Any UserDataset-specific filtering needed?
+- Should the "NEW" badge logic apply to UserDatasets?
+
+### 6. Permissions/Ownership
+
+- Are UserDatasets user-specific or shared?
+- Any access control considerations?
+- Should the UI show ownership information?
+
+---
+
+## Component File Location
+
+`packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx`
+
+---
+
+## Next Steps
+
+1. Answer the critical questions above
+2. Explore UserDataset backend API/WDK structure
+3. Design data structure changes needed
+4. Plan UI changes (table columns, visual distinctions)
+5. Implement backend integration
+6. Test with real UserDataset data
+
+---
+
+## Detailed Architecture Analysis
+
+### Complete Data Flow (Current)
+
+**Phase 1: Initialization** (lines 103-138)
+
+- Extract Redux state: questions, ontology, recordClasses, preferredOrganisms
+- Get internal question metadata via `getTableQuestionMetadata()`
+
+**Phase 2: Data Loading** (lines 140-182)
+
+```typescript
+useWdkService(async (wdkService) => {
+  1. getAnswerJson() → Queries "DatasourcesByCategory"
+  2. getInternalQuestions() → Extracts question references
+  3. getDisplayCategoryMetadata() → Processes ontology tree
+  4. getDatasourceRecords() → Transforms into UI-ready records
+})
+```
+
+**Phase 3: Processing Internal Questions** (lines 599-641)
+
+- Function: `getInternalQuestions()`
+- Extracts question references from References table
+- Filters by `target_type === 'question'` and matching `record_type`
+
+**Phase 4: Category Metadata from Ontology** (lines 724-799)
+
+- Function: `getDisplayCategoryMetadata()`
+- Traverses ontology tree to find category nodes
+- Builds mapping: `questionNamesByDatasetAndCategory`
+- Extracts display metadata: `displayCategoriesByName`
+
+**Phase 5: Transform to UI Records** (lines 643-722)
+
+- Function: `getDatasourceRecords()`
+- Converts dataset records to table rows
+- Computes `searches` field (available category abbreviations)
+- Adds `isPreferred` based on organism preferences
+
+### Button Generation (lines 382-426)
+
+```typescript
+renderCell: (cellProps) => {
+  displayCategoryOrder.map((categoryName) => {
+    const categorySearchName = getCategorySearchName(
+      questionNamesByDatasetAndCategory,
+      datasetName,
+      categoryName
+    );
+
+    if (categorySearchName) {
+      return (
+        <Link to={`${internalSearchName}#${categorySearchName}`}>
+          {displayCategoriesByName[categoryName].shortDisplayName}
+        </Link>
+      );
+    }
+  });
+};
+```
+
+### Key Integration Points
+
+- **WDK Service**: `useWdkService` hook for async data fetching
+- **Plugin System**: Component registered via `pluginConfig.tsx`
+- **Preferred Organisms**: `@veupathdb/preferred-organisms` package
+- **Ontology Tree**: Category metadata and question organization
+
+---
+
+## Design Patterns Used
+
+1. **Two-Level Question Architecture**: Separation of catalog vs. execution
+2. **Ontology-Driven UI**: Categories from tree structure, not hardcoded
+3. **Dataset-Question References via Database**: Dynamic associations
+4. **URL Hash for State Management**: Direct linking and navigation
+5. **Preferred Organisms Integration**: User-specific filtering
+6. **Lazy Tab Loading**: Performance optimization
+7. **Show One/Show All Toggle**: Focus on selected dataset
+8. **Beta Feature Indicators**: Experimental feature flagging
+
+---
+
+## Date
+
+2026-07-18 (Updated: 2026-07-19)
+
+## Status
+
+Backend structure confirmed - ready for Phase 1 implementation
+
+## Scope: Phase 1 vs Phase 2
+
+**Phase 1 (This Iteration):**
+
+- Display UserDatasets alongside DataSources in table
+- Source type icons and filtering
+- Button generation with parameterized URLs
+- Basic metadata (display name, summary, organism, attribution)
+- **NO Publications** for UserDatasets
+
+**Phase 2 (Future):**
+
+- Add Publications table support for UserDatasets
+- Additional features TBD
+
+---
+
+## Architecture Decision: Separate Processing Functions
+
+**Decision**: UserDatasets and DataSources will have **separate processing functions** rather than forcing them into the same backend API structure.
+
+**Rationale**:
+
+- **Maintainability**: Each data source owns its structure
+- **Robustness**: Avoids brittle coupling between two different sources
+- **Separation of concerns**: Frontend explicitly handles differences
+- **Flexibility**: Backend can evolve UD structure independently
+
+**Implementation**:
+
+- `getDatasourceRecords()` - processes DataSource responses (References table)
+- `getUserDatasetRecords()` - processes UserDataset responses (ExploreWdkSearches table)
+- Both return normalized `DatasourceRecord[]` shape
+- Merge normalized results client-side
+
+---
+
+## UserDataset Backend Structure (CONFIRMED)
+
+### Required Attributes
+
+```javascript
+"attributes": {
+  "dataset_id": "EDAUD_53f554ec6a",                           // Primary key (also used as dataset_name)
+  "display_name": "My RNA Seq Experiment",                     // User-friendly display text
+  "organism_prefix": "<i>Plasmodium falciparum</i> 3D7",      // Formatted organism (HTML)
+  "organism": "Plasmodium falciparum 3D7",                    // Clean organism for preference matching
+  "summary": "RNA sequencing analysis of...",                  // Description for tooltip
+  "short_attribution": "User et al 2024",                      // Appended to display_name
+  "is_public": true                                            // Public vs private indicator
+}
+```
+
+**Notes:**
+
+- `dataset_id` is the **only primary key** - no separate `dataset_name` field
+- `organism` attribute **replaces Version table** for preference filtering
+- `build_number_introduced` **not needed** for UserDatasets
+- `description` **not needed** (unused in current code)
+
+### Required Tables
+
+#### ExploreWdkSearches Table
+
+UserDatasets provide an `ExploreWdkSearches` table (parallel to DataSources' `References` table):
+
+```javascript
+"ExploreWdkSearches": [
+  {
+    "question_name": "GeneQuestions.GenesByRnaSeqUserDataset",  // Generic question with namespace
+    "dataset_id_param": "rna_seq_dataset",                       // Parameter name for this question
+    "dataset_id": "EDAUD_53f554ec6a",                           // Actual dataset ID (with EDAUD_ prefix)
+    "record_type": "TranscriptRecordClasses.TranscriptRecordClass",
+    "url": "",          // Not used by frontend
+    "description": "",  // Not used by frontend
+    "order": ""         // Not used by frontend
+  }
+  // One object per available search type (e.g., Fold Change, Diff Expr)
+  // dataset_id duplicated in each (it's the primary key)
+]
+```
+
+#### Publications Table
+
+**NOT INCLUDED IN PHASE 1** - Will be added in Phase 2.
+
+For Phase 1, UserDatasets will have:
+
+- `publications: []` (empty array) in the normalized record structure
+- No publication links shown in tooltips
+
+### Key Differences from DataSources References Table
+
+| Aspect               | DataSources (References)                          | UserDatasets (ExploreWdkSearches)                           |
+| -------------------- | ------------------------------------------------- | ----------------------------------------------------------- |
+| **Table Name**       | `References`                                      | `ExploreWdkSearches`                                        |
+| **Question Field**   | `target_name`                                     | `question_name`                                             |
+| **Question Pattern** | Dataset-specific: `GenesByRnaSeq_RSRC123_DiffExp` | Generic: `GenesByRnaSeqUserDataset`                         |
+| **Parameters**       | None (baked into question name)                   | `dataset_id_param` + `dataset_id`                           |
+| **URL Pattern**      | `#GenesByRnaSeq_RSRC123_DiffExp`                  | `#GenesByRnaSeqUserDataset?param.rna_seq_dataset=EDAUD_123` |
+
+### Processing Approach
+
+1. **Extract questions from table** - similar to `getInternalQuestions()` but from ExploreWdkSearches
+2. **Strip namespace** - `GeneQuestions.GenesByRnaSeqUserDataset` → `GenesByRnaSeqUserDataset`
+3. **Map to categories via ontology** - same as DataSources
+4. **Build parameterized URLs** - append `?param.{dataset_id_param}={dataset_id}`
+
+---
+
+## Requirements Summary (ANSWERED)
+
+### 1. UserDataset Backend Integration ✓
+
+- **Yes**, UserDatasets have a similar References table structure
+- **Yes**, there is a parallel question: `"UserDatasetsByCategory"`
+- UserDatasets are WDK records, accessed the same way as DataSources
+
+### 2. UserDataset Metadata ✓
+
+- **Conceptually similar** to DataSources but with different backend structure
+- Required semantic fields (exact attribute names TBD):
+  - `publications`: Optional (can be empty or have values)
+  - `short_attribution`: Yes, UserDatasets have this
+  - `build_number_introduced`: **No** - won't be used for UserDatasets (no "NEW" badge)
+  - `is_public`: **Yes** - UserDatasets include this field
+  - `organism_prefix`: Backend provides appropriate value ("Unspecified" for phenotype UDs)
+  - Note: `organism_prefix` should really be named `organism_formatted` (contains HTML)
+- **Same categories**: Both dataset categories (RNA-Seq, Phenotype) AND search categories (Fold Change, Diff Expr)
+- **Version table**: Required - provides clean organism string for preference matching (not HTML formatted)
+
+### 3. Question Associations ✓
+
+- UserDatasets link to **shared generic questions**
+- Pattern: `"GenesByUserDataset_{SearchCategory}"` (e.g., `"GenesByUserDataset_DifferentialExpression"`)
+- UserDataset ID passed as **parameter** to the question
+- References table contains generic question names (not dataset-specific)
+
+### 4. Display Requirements ✓
+
+- **Mixed in same table** - UserDatasets and DataSources appear together
+- **New source type column** (icon-only, first column):
+  - Internal datasets: Site logo/favicon
+  - Public UserDatasets: Globe icon
+  - Private UserDatasets: Lock icon
+- **Filter checkboxes** at top of table:
+  - Serve dual purpose: filtering + legend
+  - Three checkboxes with icon + label
+  - All checked by default
+
+### 5. Filtering/Preferences ✓
+
+- **Organism preferences** apply conditionally:
+  - If `organism_prefix` is specific organism → apply preferences
+  - If `organism_prefix` is "Multiple organisms" or "Unspecified" → always show
+- Applies to both DataSources and UserDatasets
+
+### 6. Permissions/Ownership ✓
+
+- **Backend handles permissions**: Only returns UserDatasets the user should see
+- `is_public` field indicates public vs private
+- No frontend permission logic needed
+
+---
+
+## Field Usage Analysis
+
+### Fields Actually Used in Display
+
+**Critical Fields (MUST have):**
+
+1. `dataset_name` - Identifier for linking to questions
+2. `display_name` - Display text
+3. `organism_prefix` - Organism info (can be HTML)
+4. `dataset_id` - Unique ID for record linking
+5. `summary` - Description for tooltip
+6. `short_attribution` - Appended to display name
+
+**Tables (MUST have):**
+
+1. `References` (DataSources) / `ExploreWdkSearches` (UserDatasets) - Links to search questions (CRITICAL)
+2. `Publications` - Can be empty array
+3. ~~`Version`~~ - No longer needed! UserDatasets use `organism` attribute instead
+
+**Optional/Conditional:**
+
+- `build_number_introduced` - Only for DataSources (for "NEW" badge)
+- `is_public` - Only for UserDatasets (for icon type)
+- `description` - Fetched but never used, can omit
+
+**Computed Fields (don't provide):**
+
+- `searches` - Derived from category metadata
+- `isPreferred` - Computed from Version table
+
+### DataSource vs UserDataset Field Mapping
+
+| Field                     | DataSource                 | UserDataset                 |
+| ------------------------- | -------------------------- | --------------------------- |
+| `dataset_name`            | ✓                          | ✓                           |
+| `display_name`            | ✓                          | ✓                           |
+| `organism_prefix`         | ✓                          | ✓ (can be "Unspecified")    |
+| `dataset_id`              | ✓                          | ✓ (format: UUID)            |
+| `summary`                 | ✓                          | ✓                           |
+| `build_number_introduced` | ✓                          | ✗ (skip)                    |
+| `short_attribution`       | ✓                          | ✓                           |
+| `publications`            | ✓                          | ✓ (can be empty)            |
+| `is_public`               | ✗                          | ✓ (boolean)                 |
+| `source`                  | ✓ (computed: 'datasource') | ✓ (computed: 'userdataset') |
+
+---
+
+## Implementation Plan
+
+### Phase 1: Update Type Definitions
+
+**File**: `packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx`
+
+**Task 1.1**: Extend `DatasourceRecord` type (around line 72)
+
+```typescript
+type DatasourceRecord = {
+  dataset_name: string;
+  display_name: string;
+  organism_prefix: string;
+  dataset_id: string;
+  summary: string;
+  build_number_introduced: string;
+  publications: LinkAttributeValue[];
+  searches: string;
+  isPreferred: boolean;
+  source: 'datasource' | 'userdataset'; // NEW
+  is_public?: boolean; // NEW - only for userdatasets
+};
+```
+
+---
+
+### Phase 2: Add State for Source Type Filtering
+
+**Task 2.1**: Add filter state (after line 191)
+
+```typescript
+const [showDataSources, setShowDataSources] = useState(true);
+const [showPublicUserDatasets, setShowPublicUserDatasets] = useState(true);
+const [showPrivateUserDatasets, setShowPrivateUserDatasets] = useState(true);
+```
+
+---
+
+### Phase 3: Fetch UserDatasets from Backend
+
+**Task 3.1**: Modify `useWdkService` hook (around lines 140-182)
+
+- Fetch both DataSources and UserDatasets in parallel using `Promise.all()`
+- Query: `"UserDatasetsByCategory"` (TBD exact name) with `dataset_category` parameter
+- Create separate REPORT_CONFIG for UserDatasets
+
+```typescript
+const USERDATASET_REPORT_CONFIG = {
+  attributes: [
+    'dataset_id',
+    'display_name',
+    'organism_prefix',
+    'organism',
+    'summary',
+    'short_attribution',
+    'is_public',
+  ],
+  tables: ['ExploreWdkSearches'], // No Publications in Phase 1
+  pagination: { offset: 0, numRecords: -1 },
+};
+
+const [datasourceAnswer, userdatasetAnswer] = await Promise.all([
+  wdkService.getAnswerJson(
+    getAnswerSpec(datasetCategory, 'DatasourcesByCategory'),
+    DATASOURCE_REPORT_CONFIG // Existing config
+  ),
+  wdkService.getAnswerJson(
+    getAnswerSpec(datasetCategory, 'UserDatasetsByCategory'),
+    USERDATASET_REPORT_CONFIG // New config for UserDatasets
+  ),
+]);
+```
+
+**Task 3.2**: Create `getUserDatasetInternalQuestions()` function (parallel to `getInternalQuestions()`)
+
+- Extracts questions from `ExploreWdkSearches` table instead of `References`
+- Returns array of UserDataset question records
+
+```typescript
+interface UserDatasetQuestionRecord {
+  question_name: string; // e.g., "GeneQuestions.GenesByRnaSeqUserDataset"
+  dataset_id_param: string; // e.g., "rna_seq_dataset"
+  dataset_id: string; // e.g., "EDAUD_53f554ec6a"
+  record_type: string; // e.g., "TranscriptRecordClasses.TranscriptRecordClass"
+  dataset_name: string; // From parent record attributes
+}
+
+function getUserDatasetInternalQuestions(
+  records: UserDatasetRecord[]
+): UserDatasetQuestionRecord[] {
+  return records.flatMap((record) => {
+    const exploreSearches = record.tables?.ExploreWdkSearches;
+
+    if (!Array.isArray(exploreSearches)) {
+      throw new Error(
+        `ExploreWdkSearches table missing for UserDataset ${record.id}`
+      );
+    }
+
+    return exploreSearches.map((search) => ({
+      question_name: search.question_name,
+      dataset_id_param: search.dataset_id_param,
+      dataset_id: search.dataset_id,
+      record_type: search.record_type,
+      dataset_name: record.attributes.dataset_name,
+    }));
+  });
+}
+```
+
+**Task 3.3**: Create `getUserDatasetRecords()` function (parallel to `getDatasourceRecords()`)
+
+- Maps UserDataset response fields to normalized `DatasourceRecord[]` shape
+- Returns records with `source: 'userdataset'`
+- Extracts `is_public` field for icon determination
+- Sets `build_number_introduced` to empty string (no NEW badge for UDs)
+- Uses ExploreWdkSearches instead of References
+- **Uses `dataset_id` as `dataset_name`** (UserDatasets have no separate dataset_name)
+- Uses `organism` attribute for preference filtering (no Version table)
+
+```typescript
+function getUserDatasetRecords(
+  records: UserDatasetRecord[],
+  internalQuestions: UserDatasetQuestionRecord[],
+  questionNamesByDatasetAndCategory: Record<string, Record<string, string>>,
+  displayCategoryOrder: string[],
+  displayCategoriesByName: Record<string, DisplayCategory>,
+  preferredOrganisms: OrganismPreference,
+  buildNumber: string
+): DatasourceRecord[] {
+  // Key differences from getDatasourceRecords:
+  // 1. dataset_name = dataset_id (no separate name field)
+  // 2. Use organism attribute for isPreferred (not Version table)
+  // 3. Extract is_public attribute
+  // 4. Set source: 'userdataset'
+  // 5. Set build_number_introduced to empty string
+  // 6. Set publications to empty array (Phase 1 - no Publications table)
+  // 7. Store dataset_id_param for URL generation (varies by category)
+}
+```
+
+**Task 3.4**: Keep existing `getDatasourceRecords()` function (lines 643-722)
+
+- Add `source: 'datasource'` to returned records
+- Otherwise unchanged
+
+**Task 3.5**: Merge normalized record arrays
+
+```typescript
+const datasourceRecords = getDatasourceRecords(
+  datasourceAnswer.records,
+  datasourceInternalQuestions,
+  questionNamesByDatasetAndCategory,
+  displayCategoryOrder,
+  displayCategoriesByName,
+  preferredOrganisms,
+  buildNumber
+);
+
+const userdatasetRecords = getUserDatasetRecords(
+  userdatasetAnswer.records,
+  userdatasetInternalQuestions,
+  questionNamesByDatasetAndCategory,
+  displayCategoryOrder,
+  displayCategoriesByName,
+  preferredOrganisms,
+  buildNumber
+);
+
+const allRecords = [...datasourceRecords, ...userdatasetRecords];
+```
+
+---
+
+### Phase 4: Update Button URL Generation
+
+**Task 4.1**: Update `DatasourceRecord` type to include parameter info
+
+```typescript
+type DatasourceRecord = {
+  // ... existing fields ...
+  source: 'datasource' | 'userdataset';
+  is_public?: boolean;
+  dataset_id_param?: string; // NEW - only for UserDatasets (e.g., "rna_seq_dataset")
+};
+```
+
+**Task 4.2**: Create new helper function `getCategorySearchUrl()`
+
+```typescript
+function getCategorySearchUrl(
+  questionName: string,
+  datasetId: string,
+  source: 'datasource' | 'userdataset',
+  datasetIdParam: string | undefined, // Parameter name for UserDatasets
+  internalSearchName: string
+): string {
+  const baseUrl = `${internalSearchName}#${questionName}`;
+  if (source === 'userdataset' && datasetIdParam) {
+    // dataset_id already includes EDAUD_ prefix from backend
+    return `${baseUrl}?param.${datasetIdParam}=${datasetId}`;
+  }
+  return baseUrl;
+}
+```
+
+**Task 4.3**: Update button Link generation (lines 389-410)
+
+- Use new helper to generate URLs
+- Pass `source`, `dataset_id`, and `dataset_id_param` from row data
+
+```typescript
+renderCell: ({ row }) => {
+  const { dataset_name, dataset_id, source, dataset_id_param } = row;
+  return displayCategoryOrder.map((categoryName) => {
+    const questionName = getCategorySearchName(
+      questionNamesByDatasetAndCategory,
+      dataset_name,
+      categoryName
+    );
+    if (questionName) {
+      const url = getCategorySearchUrl(
+        questionName,
+        dataset_id,
+        source,
+        dataset_id_param, // NEW - parameter name for UserDatasets
+        internalSearchName
+      );
+      return (
+        <Link key={categoryName} to={url}>
+          {displayCategoriesByName[categoryName].shortDisplayName}
+        </Link>
+      );
+    }
+  });
+};
+```
+
+---
+
+### Phase 5: Add Source Type Column with Icons
+
+**Task 5.1**: Add new column definition (as first column, before Organism)
+
+```typescript
+{
+  key: 'source',
+  name: '',  // No header text
+  width: '50px',
+  sortable: false,
+  renderCell: ({ row }) => {
+    if (row.source === 'datasource') {
+      return <SiteLogo alt="Internal Dataset" />;
+    } else if (row.is_public) {
+      return <GlobeIcon alt="Public User Dataset" />;
+    } else {
+      return <LockIcon alt="Private User Dataset" />;
+    }
+  }
+}
+```
+
+**Task 5.2**: Implement/find icons
+
+- Research site logo/favicon path (user will provide if needed)
+- Implement or import Globe icon component
+- Implement or import Lock icon component
+- Ensure consistent sizing (e.g., 20x20px or 24x24px)
+
+---
+
+### Phase 6: Add Filter Checkboxes UI
+
+**Task 6.1**: Add filter checkbox section (before table, around line 260)
+
+```typescript
+<div className="wdk-InternalGeneDatasetForm__SourceFilters">
+  <label>
+    <input
+      type="checkbox"
+      checked={showDataSources}
+      onChange={(e) => setShowDataSources(e.target.checked)}
+    />
+    <SiteLogo /> Internal Datasets
+  </label>
+  <label>
+    <input
+      type="checkbox"
+      checked={showPublicUserDatasets}
+      onChange={(e) => setShowPublicUserDatasets(e.target.checked)}
+    />
+    <GlobeIcon /> Public User Datasets
+  </label>
+  <label>
+    <input
+      type="checkbox"
+      checked={showPrivateUserDatasets}
+      onChange={(e) => setShowPrivateUserDatasets(e.target.checked)}
+    />
+    <LockIcon /> Private User Datasets
+  </label>
+</div>
+```
+
+**Task 6.2**: Implement source type filtering
+
+- Update `getFilteredDatasourceRecords()` (lines 550-568) or create wrapper
+- Apply filters based on checkbox state
+
+```typescript
+const sourceFilteredRecords = allRecords.filter((record) => {
+  if (record.source === 'datasource') {
+    return showDataSources;
+  } else if (record.is_public) {
+    return showPublicUserDatasets;
+  } else {
+    return showPrivateUserDatasets;
+  }
+});
+
+// Then apply existing organism and other filters
+const filteredRecords = getFilteredDatasourceRecords(
+  sourceFilteredRecords
+  /* other params */
+);
+```
+
+---
+
+### Phase 7: Update Organism Preference Filtering
+
+**Task 7.1**: Modify organism filtering logic (around line 565)
+
+```typescript
+const isPreferredDataset = (record) => {
+  // Always show multi-organism or unspecified datasets
+  if (
+    record.organism_prefix === 'Multiple organisms' ||
+    record.organism_prefix === 'Unspecified'
+  ) {
+    return true;
+  }
+
+  // Apply existing organism preference filtering
+  return existingIsPreferredLogic(record);
+};
+```
+
+---
+
+### Phase 8: Handle Dataset Record Links
+
+**Task 8.1**: Update dataset record page links (around line 372)
+
+```typescript
+const recordUrl =
+  row.source === 'datasource'
+    ? `/record/dataset/${dataset_id}`
+    : `/record/userdataset/EDAUD_${dataset_id}`;
+
+<Link to={recordUrl}>{safeHtml(display_name)}</Link>;
+```
+
+---
+
+### Phase 9: Update Styling
+
+**Task 9.1**: Add SCSS for new UI elements
+
+- File: `InternalGeneDataset.scss`
+- Add styles for:
+  - `.wdk-InternalGeneDatasetForm__SourceFilters` (filter checkbox section)
+  - Source type column (narrow width, centered icons)
+  - Icon sizing and alignment
+  - Filter checkbox layout and spacing
+
+**Example SCSS**:
+
+```scss
+.wdk-InternalGeneDatasetForm__SourceFilters {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+
+  label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+
+    input[type='checkbox'] {
+      margin-right: 0.25rem;
+    }
+
+    svg,
+    img {
+      width: 20px;
+      height: 20px;
+    }
+  }
+}
+
+// Source column icon styling
+.source-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  svg,
+  img {
+    width: 20px;
+    height: 20px;
+  }
+}
+```
+
+---
+
+### Phase 10: Testing & Edge Cases
+
+**Task 10.1**: Test scenarios
+
+- Page with only DataSources (no UserDatasets)
+- Page with only UserDatasets (no DataSources)
+- Mixed datasets
+- All filter combinations (8 total: 2^3)
+- Organism preference filtering with multi-organism datasets
+- Button clicks for both source types (verify URL parameters)
+- Dataset record page links for both types
+- Empty states and warnings
+
+**Task 10.2**: Handle empty states
+
+- No datasets match category
+- No datasets match filters
+- Update warning messages (e.g., OrganismPreferencesWarning)
+
+---
+
+### Phase 11: Documentation & Cleanup
+
+**Task 11.1**: Update this planning document with:
+
+- Final implementation decisions
+- Any deviations from plan
+- Technical debt or future improvements
+
+**Task 11.2**: Code comments
+
+- Document the source type filtering logic
+- Explain UserDataset parameter passing pattern
+- Note any complex transformations
+
+---
+
+## Key Technical Details
+
+### WDK Questions
+
+- **DataSources**: `"DatasourcesByCategory"`
+- **UserDatasets**: `"UserDatasetsByCategory"`
+- Both use same `dataset_category` parameter
+
+### UserDataset ID Formats
+
+- **VDI ID**: Plain UUID (e.g., `abc123def456`)
+- **WDK Record ID**: Prefixed with `EDAUD_` (e.g., `EDAUD_abc123def456`)
+- Use `EDAUD_` prefix for:
+  - Record page URLs: `/record/userdataset/EDAUD_{id}`
+  - Question parameters: `?param.dataset_id=EDAUD_{id}`
+
+### Question URL Patterns
+
+- **DataSources**: `{internalSearchName}#{datasetSpecificQuestionName}`
+  - Example: `GenesByRnaSeq#GenesByRnaSeq_RSRC123_DifferentialExpression`
+- **UserDatasets**: `{internalSearchName}#{genericQuestionName}?param.dataset_id={wdkId}`
+  - Example: `GenesByRnaSeq#GenesByUserDataset_DifferentialExpression?param.dataset_id=EDAUD_abc123`
+
+### Generic Questions
+
+- Pattern: `GenesByUserDataset_{SearchCategory}`
+- Examples:
+  - `GenesByUserDataset_DifferentialExpression`
+  - `GenesByUserDataset_FoldChange`
+  - `GenesByUserDataset_WGCNA`
+
+### Categories
+
+- **Dataset Categories**: RNA-Seq, Phenotype, etc. (determines which internal question page)
+- **Search Categories**: Fold Change, Differential Expression, etc. (determines button types)
+- UserDatasets use same categories as DataSources for both
+
+### Organism Prefix Special Values
+
+- Specific organism: `<i>Eimeria media</i> PL19_A22` (HTML formatted)
+- Multi-organism: `Multiple organisms`
+- Unknown organism: `Unspecified`
+- Multi-organism and Unspecified datasets bypass organism preference filtering
+
+---
+
+## Dependencies/Unknowns
+
+### Backend Structure - CONFIRMED ✓
+
+1. ✓ **ExploreWdkSearches table** - Confirmed structure with question_name, dataset_id_param, dataset_id, record_type
+2. ✓ **Generic questions** - Question names are generic (e.g., GenesByRnaSeqUserDataset), not dataset-specific
+3. ✓ **Parameter passing** - Uses dataset_id_param field to specify which parameter name
+4. ✓ **dataset_id format** - Already includes EDAUD\_ prefix in response
+5. ✓ **One row per search type** - Multiple rows with duplicated dataset_id (it's the PK)
+
+### Still To Confirm with Backend
+
+1. **UserDatasetsByCategory question name** - Exact WDK question name
+2. **REPORT_CONFIG for UserDatasets** - Which attributes and tables to request
+3. **Attribute field names** - Exact names for display_name, organism_prefix, summary, etc.
+4. **is_public field location** - Which attribute contains this boolean
+5. **Version table structure** - Confirm organism field exists for preference filtering
+6. **Publications table structure** - Confirm same structure as DataSources
+
+### To Resolve (Frontend)
+
+1. **Site logo/favicon path** - User will provide
+2. **Icon library** - Determine if globe/lock icons exist or need creation
+3. ~~**Parameter name**~~ - ✓ Confirmed: parameter names vary per question type (dataset_id_param field)
+
+### Design Decisions Made
+
+- ✓ **Separate processing functions** - Not forcing UDs into same backend API as DataSources
+- ✓ **Client-side normalization** - Two functions return common `DatasourceRecord` shape
+- ✓ **Backend independence** - UD structure can evolve without affecting DataSource code
+- ✓ **Version table required** - Provides clean organism strings for matching (not HTML formatted)

--- a/packages/libs/wdk-client/src/Components/Shared/CommonResultTable.tsx
+++ b/packages/libs/wdk-client/src/Components/Shared/CommonResultTable.tsx
@@ -30,6 +30,10 @@ interface CommonResultTableProps<R> {
   children?: any;
   showCount?: boolean;
   searchBoxHeader?: string;
+  // Applied alongside the search query filter (not in place of `rows`), so
+  // rows it excludes are reflected in the Mesa row count/"No Results" state
+  // rather than in `emptyResultMessage`.
+  filterPredicate?: (row: R) => boolean;
 }
 
 export interface ColumnSettings<Row> extends MesaColumn<Row> {
@@ -152,12 +156,20 @@ export class CommonResultTable<R = Record<string, any>> extends Component<
       sort: { columnKey: sortColumnKey, direction: sortDirection },
     } = getUiState(this.state);
 
-    const filteredState = searchQuery
-      ? MesaState.filterRows(
-          this.state,
-          simpleFilterPredicateFactory(searchQuery)
-        )
-      : this.state;
+    const { filterPredicate } = this.props;
+    const searchPredicate = searchQuery
+      ? simpleFilterPredicateFactory(searchQuery)
+      : null;
+
+    const filteredState =
+      searchPredicate || filterPredicate
+        ? MesaState.filterRows(
+            this.state,
+            (row: R) =>
+              (!searchPredicate || searchPredicate(row as any)) &&
+              (!filterPredicate || filterPredicate(row))
+          )
+        : this.state;
 
     const allRows = MesaState.getRows(filteredState);
     const filteredRows = MesaState.getFilteredRows(filteredState);

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
@@ -28,12 +28,11 @@
     margin-top: 1.5rem;
     margin-bottom: 0.25rem;
     padding: 0.5rem;
-    background-color: #f6f6f6;
 
     label {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 0.35rem;
       cursor: pointer;
       font-size: 110%;
 

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
@@ -48,6 +48,10 @@
     background-color: #f6f6f6;
     padding: 0.5rem;
 
+    > div > div {
+      margin-right: 0.5rem;
+    }
+
     span {
       padding: 0 0.25rem;
     }
@@ -145,8 +149,7 @@
     -ms-filter: "progid:DXImageTransform.Microsoft.Shadow(Strength=1, Direction=135, Color='#eeeeee')";
   }
 
-  .bttn-cyan.bttn-active,
-  .bttn-cyan.bttn-legend {
+  .bttn-cyan.bttn-active {
     background-color: #0d5a6e;
     background-image: none;
   }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
@@ -93,13 +93,14 @@
   .bttn {
     cursor: pointer;
     font-family: Arial, Helvetica, sans-serif;
-    padding: 2px 0px;
-    font-size: 10px;
-    line-height: 15px;
+    padding: 3px 0px;
+    font-size: 11px;
+    line-height: 17px;
     width: 36px;
     display: inline-block;
     text-align: center;
     color: #000000;
+    font-weight: bold;
     border-radius: 4px;
     border: 1px solid #cccccc;
     -moz-border-radius: 4px;
@@ -125,13 +126,13 @@
 
   .bttn-cyan {
     color: #ffffff;
-    border: 1px solid #2f96b4;
-    background-color: #2f96b4;
-    background-image: linear-gradient(to bottom, #5bc0de, #2f96b4);
-    background-image: -moz-linear-gradient(to bottom, #5bc0de, #2f96b4);
-    background-image: -o-linear-gradient(to bottom, #5bc0de, #2f96b4);
-    background-image: -webkit-linear-gradient(top, #5bc0de, #2f96b4);
-    -ms-filter: 'progid:DXImageTransform.Microsoft.Gradient(startColorStr=#5bc0de, endColorStr=#2f96b4)';
+    border: 1px solid #1a7a94;
+    background-color: #1a7a94;
+    background-image: linear-gradient(to bottom, #2f96b4, #1a7a94);
+    background-image: -moz-linear-gradient(to bottom, #2f96b4, #1a7a94);
+    background-image: -o-linear-gradient(to bottom, #2f96b4, #1a7a94);
+    background-image: -webkit-linear-gradient(top, #2f96b4, #1a7a94);
+    -ms-filter: 'progid:DXImageTransform.Microsoft.Gradient(startColorStr=#2f96b4, endColorStr=#1a7a94)';
   }
 
   .bttn:active,
@@ -142,6 +143,12 @@
     -moz-box-shadow: 1px 1px 0 #dddddd;
     -webkit-box-shadow: 1px 1px 0 #dddddd;
     -ms-filter: "progid:DXImageTransform.Microsoft.Shadow(Strength=1, Direction=135, Color='#eeeeee')";
+  }
+
+  .bttn-cyan.bttn-active,
+  .bttn-cyan.bttn-legend {
+    background-color: #0d5a6e;
+    background-image: none;
   }
 
   .bttn:active,

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
@@ -22,6 +22,27 @@
     }
   }
 
+  &SourceFilters {
+    display: flex;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+    padding: 0.5rem;
+    background-color: #f6f6f6;
+
+    label {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      cursor: pointer;
+
+      svg,
+      img {
+        width: 20px;
+        height: 20px;
+      }
+    }
+  }
+
   .wdk-InternalGeneDatasetFormLegend {
     display: flex;
     background-color: #f6f6f6;
@@ -44,13 +65,21 @@
 
   tr.DataRow {
     .DataCell:nth-child(1) {
+      text-align: center;
       > button {
         font-weight: bold;
         text-align: right;
         width: 100%;
       }
     }
-    .DataCell:nth-child(3) {
+    .DataCell:nth-child(2) {
+      > button {
+        font-weight: bold;
+        text-align: right;
+        width: 100%;
+      }
+    }
+    .DataCell:nth-child(4) {
       text-align: center;
       white-space: nowrap;
       div {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
@@ -25,7 +25,8 @@
   &SourceFilters {
     display: flex;
     gap: 1.5rem;
-    margin-bottom: 1rem;
+    margin-top: 1.5rem;
+    margin-bottom: 0.25rem;
     padding: 0.5rem;
     background-color: #f6f6f6;
 
@@ -34,11 +35,12 @@
       align-items: center;
       gap: 0.5rem;
       cursor: pointer;
+      font-size: 110%;
 
       svg,
       img {
-        width: 20px;
-        height: 20px;
+        width: 22px;
+        height: 22px;
       }
     }
   }
@@ -70,13 +72,17 @@
   tr.DataRow {
     .DataCell:nth-child(1) {
       text-align: center;
-      > button {
-        font-weight: bold;
-        text-align: right;
-        width: 100%;
-      }
     }
     .DataCell:nth-child(2) {
+      text-align: center;
+      white-space: nowrap;
+      div {
+        display: inline-block;
+        width: 36px;
+        margin: 0 2px;
+      }
+    }
+    .DataCell:nth-child(3) {
       > button {
         font-weight: bold;
         text-align: right;
@@ -84,12 +90,10 @@
       }
     }
     .DataCell:nth-child(4) {
-      text-align: center;
-      white-space: nowrap;
-      div {
-        display: inline-block;
-        width: 36px;
-        margin: 0 2px;
+      > button {
+        font-weight: bold;
+        text-align: right;
+        width: 100%;
       }
     }
   }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -349,7 +349,7 @@ function InternalGeneDatasetContent(props: Props) {
             onChange={(e) => setShowDataSources(e.target.checked)}
           />
           <img
-            src="/favicon.ico"
+            src={`/images/${projectId}/favicon.ico`}
             alt="VEuPathDB curated dataset"
             style={{ width: '20px', height: '20px', objectFit: 'contain' }}
           />
@@ -443,7 +443,7 @@ function InternalGeneDatasetContent(props: Props) {
               if (row.source === 'datasource') {
                 return (
                   <img
-                    src="/favicon.ico"
+                    src={`/images/${projectId}/favicon.ico`}
                     alt=""
                     title="VEuPathDB curated dataset"
                     style={{

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -60,7 +60,7 @@ import './InternalGeneDataset.scss';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import LockIcon from '@material-ui/icons/Lock';
 import PublicIcon from '@material-ui/icons/Public';
-import { projectId } from '@veupathdb/web-common/lib/config';
+import { projectId, webAppUrl } from '@veupathdb/web-common/lib/config';
 
 const cx = makeClassNameHelper('wdk-InternalGeneDatasetForm');
 
@@ -349,7 +349,7 @@ function InternalGeneDatasetContent(props: Props) {
             onChange={(e) => setShowDataSources(e.target.checked)}
           />
           <img
-            src={`/images/${projectId}/favicon.ico`}
+            src={`${webAppUrl}/images/${projectId}/favicon.ico`}
             alt="VEuPathDB curated dataset"
             style={{ width: '20px', height: '20px', objectFit: 'contain' }}
           />
@@ -443,7 +443,7 @@ function InternalGeneDatasetContent(props: Props) {
               if (row.source === 'datasource') {
                 return (
                   <img
-                    src={`/images/${projectId}/favicon.ico`}
+                    src={`${webAppUrl}/images/${projectId}/favicon.ico`}
                     alt=""
                     title="VEuPathDB curated dataset"
                     style={{

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -398,10 +398,10 @@ function InternalGeneDatasetContent(props: Props) {
           />
           <img
             src={`${webAppUrl}/images/${projectId}/favicon.ico`}
-            alt="VEuPathDB curated dataset"
+            alt="VEuPathDB workflow dataset"
             style={{ width: '20px', height: '20px', objectFit: 'contain' }}
           />
-          {' VEuPathDB curated datasets'}
+          {' VEuPathDB workflow datasets'}
         </label>
         <label>
           <input
@@ -447,7 +447,7 @@ function InternalGeneDatasetContent(props: Props) {
                   <img
                     src={`${webAppUrl}/images/${projectId}/favicon.ico`}
                     alt=""
-                    title="VEuPathDB curated dataset"
+                    title="VEuPathDB workflow dataset"
                     style={{
                       width: '20px',
                       height: '20px',

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -265,6 +265,15 @@ function InternalGeneDatasetContent(props: Props) {
   const [showPublicUserDatasets, setShowPublicUserDatasets] = useState(true);
   const [showPrivateUserDatasets, setShowPrivateUserDatasets] = useState(true);
 
+  const sourceTypeFilterPredicate = useCallback(
+    (record: DatasourceRecord) => {
+      if (record.source === 'datasource') return showDataSources;
+      else if (record.is_public) return showPublicUserDatasets;
+      else return showPrivateUserDatasets;
+    },
+    [showDataSources, showPublicUserDatasets, showPrivateUserDatasets]
+  );
+
   const selectedDataSetRecord = useMemo(
     () =>
       getSelectedDataSetRecord(
@@ -282,10 +291,7 @@ function InternalGeneDatasetContent(props: Props) {
         displayCategoriesByName,
         showingOneRecord,
         selectedDataSetRecord,
-        preferredOrganismsEnabled,
-        showDataSources,
-        showPublicUserDatasets,
-        showPrivateUserDatasets
+        preferredOrganismsEnabled
       ),
     [
       datasourceRecords,
@@ -293,9 +299,6 @@ function InternalGeneDatasetContent(props: Props) {
       showingOneRecord,
       selectedDataSetRecord,
       preferredOrganismsEnabled,
-      showDataSources,
-      showPublicUserDatasets,
-      showPrivateUserDatasets,
     ]
   );
 
@@ -434,6 +437,7 @@ function InternalGeneDatasetContent(props: Props) {
         }
         showCount={true}
         rows={filteredDatasourceRecords}
+        filterPredicate={sourceTypeFilterPredicate}
         columns={[
           {
             key: 'source',
@@ -717,33 +721,24 @@ function getFilteredDatasourceRecords(
     | undefined,
   showingOneRecord: boolean,
   selectedDataSetRecord: DatasourceRecord | undefined,
-  preferredOrganismsEnabled: boolean,
-  showDataSources: boolean,
-  showPublicUserDatasets: boolean,
-  showPrivateUserDatasets: boolean
+  preferredOrganismsEnabled: boolean
 ) {
   if (!datasourceRecords || !questionNamesByDatasetAndCategory) {
     return undefined;
   }
 
-  // First apply source type filtering (always)
-  const sourceFiltered = datasourceRecords.filter((record) => {
-    if (record.source === 'datasource') return showDataSources;
-    else if (record.is_public) return showPublicUserDatasets;
-    else return showPrivateUserDatasets;
-  });
-
-  // Then apply other filters
   if (showingOneRecord) {
-    return sourceFiltered.filter((record) => record === selectedDataSetRecord);
+    return datasourceRecords.filter(
+      (record) => record === selectedDataSetRecord
+    );
   }
 
   // Apply organism preference filtering if enabled
   if (preferredOrganismsEnabled) {
-    return sourceFiltered.filter(({ isPreferred }) => isPreferred);
+    return datasourceRecords.filter(({ isPreferred }) => isPreferred);
   }
 
-  return sourceFiltered;
+  return datasourceRecords;
 }
 
 function getAnswerSpec(datasetCategory: string) {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -60,6 +60,7 @@ import './InternalGeneDataset.scss';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import LockIcon from '@material-ui/icons/Lock';
 import PublicIcon from '@material-ui/icons/Public';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import { projectId, webAppUrl } from '@veupathdb/web-common/lib/config';
 
 const cx = makeClassNameHelper('wdk-InternalGeneDatasetForm');
@@ -519,7 +520,13 @@ function InternalGeneDatasetContent(props: Props) {
                       )}
                     </div>
                   </HelpIcon>{' '}
-                  <Link to={recordUrl}>{safeHtml(display_name)}</Link>
+                  {safeHtml(display_name)}
+                  <Link
+                    to={recordUrl}
+                    style={{ marginLeft: '0.5em', verticalAlign: 'middle' }}
+                  >
+                    <OpenInNewIcon style={{ fontSize: '16px' }} />
+                  </Link>
                   {build_number_introduced === buildNumber && (
                     <span className={cx('NewDataset')}></span>
                   )}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -78,28 +78,6 @@ type UserDatasetQuestionRecord = {
   dataset_name: string;
 };
 
-type UserDatasetRecord = {
-  displayName: string;
-  attributes: {
-    name: string;
-    ref_organism_formatted: string;
-    dataset_id: string;
-    summary: string;
-    is_public: string;
-    primary_contact_name: string;
-    owner_name: string;
-    ref_organism: string;
-  };
-  tables?: {
-    ExploreWebsiteSearches?: Array<{
-      question_name: string;
-      dataset_id_param: string;
-      dataset_id: string;
-      record_class: string;
-    }>;
-  };
-};
-
 type DatasourceRecord = {
   dataset_name: string;
   display_name: string;

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -342,39 +342,6 @@ function InternalGeneDatasetContent(props: Props) {
         headerText={`Identify ${outputRecordClass.displayNamePlural} based on ${internalQuestion.displayName}`}
         isBeta={internalQuestion.isBeta}
       />
-      <div className={cx('SourceFilters')}>
-        <label>
-          <input
-            type="checkbox"
-            checked={showDataSources}
-            onChange={(e) => setShowDataSources(e.target.checked)}
-          />
-          <img
-            src={`${webAppUrl}/images/${projectId}/favicon.ico`}
-            alt="VEuPathDB curated dataset"
-            style={{ width: '20px', height: '20px', objectFit: 'contain' }}
-          />
-          {' VEuPathDB curated datasets'}
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={showPublicUserDatasets}
-            onChange={(e) => setShowPublicUserDatasets(e.target.checked)}
-          />
-          <PublicIcon style={{ width: '20px', height: '20px' }} />
-          {' Public User Datasets'}
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={showPrivateUserDatasets}
-            onChange={(e) => setShowPrivateUserDatasets(e.target.checked)}
-          />
-          <LockIcon style={{ width: '20px', height: '20px' }} />
-          {' Private User Datasets'}
-        </label>
-      </div>
       <div className={cx('Legend')}>
         <span style={{ fontWeight: 'bold', fontSize: '13px' }}>Legend:</span>
         <div style={{ display: 'flex', flexWrap: 'wrap', rowGap: '1rem' }}>
@@ -421,6 +388,39 @@ function InternalGeneDatasetContent(props: Props) {
             </Tooltip>
           ))}
         </div>
+      </div>
+      <div className={cx('SourceFilters')}>
+        <label>
+          <input
+            type="checkbox"
+            checked={showDataSources}
+            onChange={(e) => setShowDataSources(e.target.checked)}
+          />
+          <img
+            src={`${webAppUrl}/images/${projectId}/favicon.ico`}
+            alt="VEuPathDB curated dataset"
+            style={{ width: '20px', height: '20px', objectFit: 'contain' }}
+          />
+          {' VEuPathDB curated datasets'}
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showPublicUserDatasets}
+            onChange={(e) => setShowPublicUserDatasets(e.target.checked)}
+          />
+          <PublicIcon style={{ width: '20px', height: '20px' }} />
+          {' Public User Datasets'}
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showPrivateUserDatasets}
+            onChange={(e) => setShowPrivateUserDatasets(e.target.checked)}
+          />
+          <LockIcon style={{ width: '20px', height: '20px' }} />
+          {' Private User Datasets'}
+        </label>
       </div>
       <InternalGeneDatasetTable
         searchBoxHeader="Filter Datasets:"
@@ -470,6 +470,56 @@ function InternalGeneDatasetContent(props: Props) {
                 );
               }
             },
+          },
+          {
+            key: 'searches',
+            name: 'Choose a Search',
+            sortable: false,
+            renderCell: (cellProps: any) => (
+              <>
+                {displayCategoryOrder.map((categoryName) => {
+                  const { dataset_name, dataset_id, source, dataset_id_param } =
+                    cellProps.row;
+                  const categorySearchName = getCategorySearchName(
+                    questionNamesByDatasetAndCategory,
+                    dataset_name,
+                    categoryName
+                  );
+
+                  return (
+                    <div key={categoryName}>
+                      {categorySearchName && (
+                        <Link
+                          className={
+                            categorySearchName === searchName
+                              ? 'bttn bttn-cyan bttn-active'
+                              : 'bttn bttn-cyan'
+                          }
+                          to={getCategorySearchUrl(
+                            categorySearchName,
+                            dataset_id,
+                            source,
+                            dataset_id_param,
+                            internalSearchName
+                          )}
+                          onClick={makeLinkClickHandler(
+                            submissionMetadata,
+                            categorySearchName,
+                            searchName,
+                            setSelectedSearch
+                          )}
+                        >
+                          {
+                            displayCategoriesByName[categoryName]
+                              .shortDisplayName
+                          }
+                        </Link>
+                      )}
+                    </div>
+                  );
+                })}
+              </>
+            ),
           },
           {
             key: 'organism_prefix',
@@ -533,56 +583,6 @@ function InternalGeneDatasetContent(props: Props) {
                 </div>
               );
             },
-          },
-          {
-            key: 'searches',
-            name: 'Choose a Search',
-            sortable: false,
-            renderCell: (cellProps: any) => (
-              <>
-                {displayCategoryOrder.map((categoryName) => {
-                  const { dataset_name, dataset_id, source, dataset_id_param } =
-                    cellProps.row;
-                  const categorySearchName = getCategorySearchName(
-                    questionNamesByDatasetAndCategory,
-                    dataset_name,
-                    categoryName
-                  );
-
-                  return (
-                    <div key={categoryName}>
-                      {categorySearchName && (
-                        <Link
-                          className={
-                            categorySearchName === searchName
-                              ? 'bttn bttn-cyan bttn-active'
-                              : 'bttn bttn-cyan'
-                          }
-                          to={getCategorySearchUrl(
-                            categorySearchName,
-                            dataset_id,
-                            source,
-                            dataset_id_param,
-                            internalSearchName
-                          )}
-                          onClick={makeLinkClickHandler(
-                            submissionMetadata,
-                            categorySearchName,
-                            searchName,
-                            setSelectedSearch
-                          )}
-                        >
-                          {
-                            displayCategoriesByName[categoryName]
-                              .shortDisplayName
-                          }
-                        </Link>
-                      )}
-                    </div>
-                  );
-                })}
-              </>
-            ),
           },
         ]}
         initialSortColumnKey="organism_prefix"

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -58,6 +58,9 @@ import { PageLoading } from '../common/PageLoading';
 
 import './InternalGeneDataset.scss';
 import { CSSProperties } from '@material-ui/core/styles/withStyles';
+import LockIcon from '@material-ui/icons/Lock';
+import PublicIcon from '@material-ui/icons/Public';
+import { projectId } from '@veupathdb/web-common/lib/config';
 
 const cx = makeClassNameHelper('wdk-InternalGeneDatasetForm');
 
@@ -67,6 +70,36 @@ type InternalQuestionRecord = {
   target_type: string;
   dataset_name: string;
   record_type: string;
+};
+
+type UserDatasetQuestionRecord = {
+  question_name: string;
+  dataset_id_param: string;
+  dataset_id: string;
+  record_class: string;
+  dataset_name: string;
+};
+
+type UserDatasetRecord = {
+  displayName: string;
+  attributes: {
+    name: string;
+    ref_organism_formatted: string;
+    dataset_id: string;
+    summary: string;
+    is_public: string;
+    primary_contact_name: string;
+    owner_name: string;
+    ref_organism: string;
+  };
+  tables?: {
+    ExploreWebsiteSearches?: Array<{
+      question_name: string;
+      dataset_id_param: string;
+      dataset_id: string;
+      record_class: string;
+    }>;
+  };
 };
 
 type DatasourceRecord = {
@@ -79,6 +112,9 @@ type DatasourceRecord = {
   publications: LinkAttributeValue[];
   searches: string;
   isPreferred: boolean;
+  source: 'datasource' | 'userdataset';
+  is_public?: boolean;
+  dataset_id_param?: string;
 };
 
 type DisplayCategory = {
@@ -120,8 +156,9 @@ function InternalGeneDatasetContent(props: Props) {
 
   const { recordClass, shouldChangeDocumentTitle, submissionMetadata } = props;
 
-  const [selectedSearch, setSelectedSearch] =
-    useState<string | undefined>(searchNameAnchorTag);
+  const [selectedSearch, setSelectedSearch] = useState<string | undefined>(
+    searchNameAnchorTag
+  );
 
   useEffect(() => {
     setSelectedSearch(searchNameAnchorTag);
@@ -143,24 +180,56 @@ function InternalGeneDatasetContent(props: Props) {
         return undefined;
       }
 
-      const answer = await wdkService.getAnswerJson(
-        getAnswerSpec(datasetCategory),
-        REPORT_CONFIG
-      );
+      // Fetch both DataSources and UserDatasets in parallel
+      const [datasourceAnswer, userdatasetAnswer] = await Promise.all([
+        wdkService.getAnswerJson(getAnswerSpec(datasetCategory), REPORT_CONFIG),
+        wdkService.getAnswerJson(
+          getUserDatasetAnswerSpec(datasetCategory),
+          USERDATASET_REPORT_CONFIG
+        ),
+      ]);
 
+      // Process DataSources
       const internalQuestions = getInternalQuestions(
-        answer,
+        datasourceAnswer,
         outputRecordClass.fullName
       );
+
+      // Process UserDatasets
+      const userdatasetInternalQuestions =
+        getUserDatasetInternalQuestions(userdatasetAnswer);
+
+      // Merge questions from both sources
+      const allInternalQuestions = [
+        ...internalQuestions,
+        ...userdatasetInternalQuestions.map((udq) => ({
+          target_name: udq.question_name,
+          dataset_id: udq.dataset_id,
+          target_type: 'question',
+          dataset_name: udq.dataset_name,
+          record_type: udq.record_class,
+        })),
+      ];
+
       const displayCategoryMetadata = getDisplayCategoryMetadata(
         ontology,
-        internalQuestions
+        allInternalQuestions
       );
+
       const datasourceRecords = getDatasourceRecords(
-        answer,
+        datasourceAnswer,
         displayCategoryMetadata,
         preferredOrganisms
       );
+
+      const userdatasetRecords = getUserDatasetRecords(
+        userdatasetAnswer,
+        displayCategoryMetadata,
+        preferredOrganisms
+      );
+
+      // Merge all records
+      const allRecords = [...datasourceRecords, ...userdatasetRecords];
 
       return {
         questionNamesByDatasetAndCategory:
@@ -168,7 +237,7 @@ function InternalGeneDatasetContent(props: Props) {
         displayCategoriesByName:
           displayCategoryMetadata.displayCategoriesByName,
         displayCategoryOrder: displayCategoryMetadata.displayCategoryOrder,
-        datasourceRecords,
+        datasourceRecords: allRecords,
       };
     },
     [
@@ -191,6 +260,10 @@ function InternalGeneDatasetContent(props: Props) {
   const [showingOneRecord, updateShowingOneRecord] =
     useState(showingRecordToggle);
 
+  const [showDataSources, setShowDataSources] = useState(true);
+  const [showPublicUserDatasets, setShowPublicUserDatasets] = useState(true);
+  const [showPrivateUserDatasets, setShowPrivateUserDatasets] = useState(true);
+
   const selectedDataSetRecord = useMemo(
     () =>
       getSelectedDataSetRecord(
@@ -208,7 +281,10 @@ function InternalGeneDatasetContent(props: Props) {
         displayCategoriesByName,
         showingOneRecord,
         selectedDataSetRecord,
-        preferredOrganismsEnabled
+        preferredOrganismsEnabled,
+        showDataSources,
+        showPublicUserDatasets,
+        showPrivateUserDatasets
       ),
     [
       datasourceRecords,
@@ -216,6 +292,9 @@ function InternalGeneDatasetContent(props: Props) {
       showingOneRecord,
       selectedDataSetRecord,
       preferredOrganismsEnabled,
+      showDataSources,
+      showPublicUserDatasets,
+      showPrivateUserDatasets,
     ]
   );
 
@@ -262,6 +341,39 @@ function InternalGeneDatasetContent(props: Props) {
         headerText={`Identify ${outputRecordClass.displayNamePlural} based on ${internalQuestion.displayName}`}
         isBeta={internalQuestion.isBeta}
       />
+      <div className={cx('SourceFilters')}>
+        <label>
+          <input
+            type="checkbox"
+            checked={showDataSources}
+            onChange={(e) => setShowDataSources(e.target.checked)}
+          />
+          <img
+            src="/favicon.ico"
+            alt="VEuPathDB curated dataset"
+            style={{ width: '20px', height: '20px', objectFit: 'contain' }}
+          />
+          {' VEuPathDB curated datasets'}
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showPublicUserDatasets}
+            onChange={(e) => setShowPublicUserDatasets(e.target.checked)}
+          />
+          <PublicIcon style={{ width: '20px', height: '20px' }} />
+          {' Public User Datasets'}
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showPrivateUserDatasets}
+            onChange={(e) => setShowPrivateUserDatasets(e.target.checked)}
+          />
+          <LockIcon style={{ width: '20px', height: '20px' }} />
+          {' Private User Datasets'}
+        </label>
+      </div>
       <div className={cx('Legend')}>
         <span style={{ fontWeight: 'bold', fontSize: '13px' }}>Legend:</span>
         <div style={{ display: 'flex', flexWrap: 'wrap', rowGap: '1rem' }}>
@@ -320,12 +432,44 @@ function InternalGeneDatasetContent(props: Props) {
           ) as any
         }
         showCount={true}
-        rows={
-          showingOneRecord || preferredOrganismsEnabled
-            ? filteredDatasourceRecords
-            : datasourceRecords
-        }
+        rows={filteredDatasourceRecords}
         columns={[
+          {
+            key: 'source',
+            name: ' ',
+            width: '50px',
+            sortable: false,
+            renderCell: ({ row }: any) => {
+              if (row.source === 'datasource') {
+                return (
+                  <img
+                    src="/favicon.ico"
+                    alt=""
+                    title="VEuPathDB curated dataset"
+                    style={{
+                      width: '20px',
+                      height: '20px',
+                      objectFit: 'contain',
+                    }}
+                  />
+                );
+              } else if (row.is_public) {
+                return (
+                  <PublicIcon
+                    style={{ width: '20px', height: '20px' }}
+                    titleAccess="Public User Dataset"
+                  />
+                );
+              } else {
+                return (
+                  <LockIcon
+                    style={{ width: '20px', height: '20px' }}
+                    titleAccess="Private User Dataset"
+                  />
+                );
+              }
+            },
+          },
           {
             key: 'organism_prefix',
             name: 'Organism',
@@ -347,7 +491,13 @@ function InternalGeneDatasetContent(props: Props) {
                 summary,
                 publications,
                 build_number_introduced,
+                source,
               }: DatasourceRecord = cellProps.row;
+
+              const recordUrl =
+                source === 'datasource'
+                  ? `/record/dataset/${dataset_id}`
+                  : `/record/userdataset/${dataset_id}`;
 
               return (
                 <div>
@@ -369,9 +519,7 @@ function InternalGeneDatasetContent(props: Props) {
                       )}
                     </div>
                   </HelpIcon>{' '}
-                  <Link to={`/record/dataset/${dataset_id}`}>
-                    {safeHtml(display_name)}
-                  </Link>
+                  <Link to={recordUrl}>{safeHtml(display_name)}</Link>
                   {build_number_introduced === buildNumber && (
                     <span className={cx('NewDataset')}></span>
                   )}
@@ -386,10 +534,11 @@ function InternalGeneDatasetContent(props: Props) {
             renderCell: (cellProps: any) => (
               <>
                 {displayCategoryOrder.map((categoryName) => {
-                  const datasetName = cellProps.row.dataset_name;
+                  const { dataset_name, dataset_id, source, dataset_id_param } =
+                    cellProps.row;
                   const categorySearchName = getCategorySearchName(
                     questionNamesByDatasetAndCategory,
-                    datasetName,
+                    dataset_name,
                     categoryName
                   );
 
@@ -402,8 +551,13 @@ function InternalGeneDatasetContent(props: Props) {
                               ? 'bttn bttn-cyan bttn-active'
                               : 'bttn bttn-cyan'
                           }
-                          key={categoryName}
-                          to={`${internalSearchName}#${categorySearchName}`}
+                          to={getCategorySearchUrl(
+                            categorySearchName,
+                            dataset_id,
+                            source,
+                            dataset_id_param,
+                            internalSearchName
+                          )}
                           onClick={makeLinkClickHandler(
                             submissionMetadata,
                             categorySearchName,
@@ -556,15 +710,33 @@ function getFilteredDatasourceRecords(
     | undefined,
   showingOneRecord: boolean,
   selectedDataSetRecord: DatasourceRecord | undefined,
-  preferredOrganismsEnabled: boolean
+  preferredOrganismsEnabled: boolean,
+  showDataSources: boolean,
+  showPublicUserDatasets: boolean,
+  showPrivateUserDatasets: boolean
 ) {
-  return !datasourceRecords || !questionNamesByDatasetAndCategory
-    ? undefined
-    : !showingOneRecord
-    ? datasourceRecords.filter(
-        ({ isPreferred }) => !preferredOrganismsEnabled || isPreferred
-      )
-    : datasourceRecords.filter((record) => record === selectedDataSetRecord);
+  if (!datasourceRecords || !questionNamesByDatasetAndCategory) {
+    return undefined;
+  }
+
+  // First apply source type filtering (always)
+  const sourceFiltered = datasourceRecords.filter((record) => {
+    if (record.source === 'datasource') return showDataSources;
+    else if (record.is_public) return showPublicUserDatasets;
+    else return showPrivateUserDatasets;
+  });
+
+  // Then apply other filters
+  if (showingOneRecord) {
+    return sourceFiltered.filter((record) => record === selectedDataSetRecord);
+  }
+
+  // Apply organism preference filtering if enabled
+  if (preferredOrganismsEnabled) {
+    return sourceFiltered.filter(({ isPreferred }) => isPreferred);
+  }
+
+  return sourceFiltered;
 }
 
 function getAnswerSpec(datasetCategory: string) {
@@ -595,6 +767,35 @@ const REPORT_CONFIG = {
     numRecords: -1,
   },
 };
+
+const USERDATASET_REPORT_CONFIG = {
+  attributes: [
+    'name',
+    'ref_organism_formatted',
+    'dataset_id',
+    'summary',
+    'is_public',
+    'primary_contact_name',
+    'owner_name',
+    'ref_organism',
+  ],
+  tables: ['ExploreWebsiteSearches'],
+  pagination: {
+    offset: 0,
+    numRecords: -1,
+  },
+};
+
+function getUserDatasetAnswerSpec(datasetCategory: string) {
+  return {
+    searchName: 'UserDatasetsByCategory',
+    searchConfig: {
+      parameters: {
+        dataset_category: datasetCategory,
+      },
+    },
+  };
+}
 
 function getInternalQuestions(answer: Answer, outputRecordClassName: string) {
   return answer.records
@@ -638,6 +839,26 @@ function getInternalQuestions(answer: Answer, outputRecordClassName: string) {
         record_type: reference.record_type,
       };
     });
+}
+
+function getUserDatasetInternalQuestions(
+  answer: Answer
+): UserDatasetQuestionRecord[] {
+  return answer.records.flatMap((record: any) => {
+    const exploreSearches = record.tables?.ExploreWebsiteSearches;
+    if (!Array.isArray(exploreSearches)) {
+      throw new Error(
+        `ExploreWebsiteSearches table missing for UserDataset ${record.attributes.dataset_id}`
+      );
+    }
+    return exploreSearches.map((search: any) => ({
+      question_name: search.question_name,
+      dataset_id_param: search.dataset_id_param,
+      dataset_id: search.dataset_id,
+      record_class: search.record_class,
+      dataset_name: record.attributes.dataset_id,
+    }));
+  });
 }
 
 function getDatasourceRecords(
@@ -717,6 +938,70 @@ function getDatasourceRecords(
           )
           .join(' '),
         isPreferred: isPreferredDataset(datasetRecord, preferredOrganismsSet),
+        source: 'datasource' as const,
+      };
+    });
+}
+
+function getUserDatasetRecords(
+  answer: Answer,
+  {
+    displayCategoriesByName,
+    displayCategoryOrder,
+    questionNamesByDatasetAndCategory,
+  }: ReturnType<typeof getDisplayCategoryMetadata>,
+  preferredOrganisms: string[]
+): DatasourceRecord[] {
+  const preferredOrganismsSet = new Set(preferredOrganisms);
+
+  return answer.records
+    .filter(
+      ({ attributes: { dataset_id } }: any) =>
+        Object.keys(questionNamesByDatasetAndCategory[`${dataset_id}`] || {})
+          .length > 0
+    )
+    .map((userDatasetRecord: any) => {
+      const attrs = userDatasetRecord.attributes;
+
+      // Check if organism is preferred (for UserDatasets, check ref_organism attribute)
+      const organism = attrs.ref_organism || 'Unspecified';
+      const organismFormatted = attrs.ref_organism_formatted || 'Unspecified';
+      const isPreferred =
+        organism === 'Multiple organisms' ||
+        organism === 'Unspecified' ||
+        preferredOrganismsSet.has(organism);
+
+      const contactName = attrs.primary_contact_name || attrs.owner_name;
+
+      return {
+        dataset_name: attrs.dataset_id,
+        display_name: `${userDatasetRecord.displayName}${
+          contactName ? ` (${contactName})` : ''
+        }`,
+        organism_prefix: organismFormatted,
+        dataset_id: attrs.dataset_id,
+        summary: attrs.summary,
+        build_number_introduced: '',
+        publications: [],
+        searches: displayCategoryOrder
+          .filter((categoryName) =>
+            getCategorySearchName(
+              questionNamesByDatasetAndCategory,
+              `${attrs.dataset_id}`,
+              categoryName
+            )
+          )
+          .map(
+            (categoryName) =>
+              displayCategoriesByName[categoryName].shortDisplayName
+          )
+          .join(' '),
+        isPreferred,
+        source: 'userdataset' as const,
+        is_public: attrs.is_public === 'Public',
+        dataset_id_param:
+          userDatasetRecord.tables?.ExploreWebsiteSearches?.[0]
+            ?.dataset_id_param,
       };
     });
 }
@@ -727,10 +1012,13 @@ function getDisplayCategoryMetadata(
 ) {
   const datasetNamesByQuestion = internalQuestions.reduce(
     (memo, { target_name, dataset_name }) => {
-      memo[target_name] = dataset_name;
+      if (!memo[target_name]) {
+        memo[target_name] = [];
+      }
+      memo[target_name].push(dataset_name);
       return memo;
     },
-    {} as Record<string, string>
+    {} as Record<string, string[]>
   );
 
   // Dataset Name => Category Name => Search URL Segment
@@ -753,27 +1041,34 @@ function getDisplayCategoryMetadata(
     if (
       scope.includes('webservice') &&
       targetType === 'search' &&
-      datasetNamesByQuestion[questionName] &&
       searchCategoryNode
     ) {
-      const datasetName = datasetNamesByQuestion[questionName];
-      const categoryName = getPropertyValue('name', searchCategoryNode) || '';
+      const questionNameWithoutPrefix = questionName.replace(/[^.]*\./, '');
+      const datasetNames = datasetNamesByQuestion[questionName] || [];
 
-      questionNamesByDatasetAndCategory[datasetName] = {
-        ...questionNamesByDatasetAndCategory[datasetName],
-        [categoryName]: questionName.replace(/[^.]*\./, ''),
-      };
+      if (datasetNames.length > 0) {
+        const categoryName = getPropertyValue('name', searchCategoryNode) || '';
 
-      displayCategoriesByName[categoryName] = displayCategoriesByName[
-        categoryName
-      ] || {
-        description: getPropertyValue('description', searchCategoryNode) || '',
-        displayName:
-          getPropertyValue('EuPathDB alternative term', searchCategoryNode) ||
-          '',
-        shortDisplayName:
-          getPropertyValue('shortDisplayName', searchCategoryNode) || '',
-      };
+        // Add this category to all datasets that use this question
+        datasetNames.forEach((datasetName) => {
+          questionNamesByDatasetAndCategory[datasetName] = {
+            ...questionNamesByDatasetAndCategory[datasetName],
+            [categoryName]: questionNameWithoutPrefix,
+          };
+        });
+
+        displayCategoriesByName[categoryName] = displayCategoriesByName[
+          categoryName
+        ] || {
+          description:
+            getPropertyValue('description', searchCategoryNode) || '',
+          displayName:
+            getPropertyValue('EuPathDB alternative term', searchCategoryNode) ||
+            '',
+          shortDisplayName:
+            getPropertyValue('shortDisplayName', searchCategoryNode) || '',
+        };
+      }
     }
 
     const nextSearchCategoryNode = searchCategoryNode
@@ -806,6 +1101,23 @@ function getCategorySearchName(
   categoryName: string
 ) {
   return questionNamesByDatasetAndCategory[datasetName][categoryName];
+}
+
+function getCategorySearchUrl(
+  questionName: string,
+  datasetId: string,
+  source: 'datasource' | 'userdataset',
+  datasetIdParam: string | undefined,
+  internalSearchName: string
+): string {
+  if (source === 'userdataset' && datasetIdParam) {
+    // Strip EDAUD_ prefix for question parameters
+    const paramValue = datasetId.replace(/^EDAUD_/, '');
+    // For UserDatasets with parameters, format as: catalogPage?params#questionName
+    return `${internalSearchName}?param.${datasetIdParam}=${paramValue}#${questionName}`;
+  }
+  // For DataSources, format as: catalogPage#questionName
+  return `${internalSearchName}#${questionName}`;
 }
 
 function makeLinkClickHandler(

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -4,7 +4,6 @@ import React, {
   useState,
   useEffect,
   useCallback,
-  useRef,
 } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation, useHistory } from 'react-router';
@@ -17,7 +16,6 @@ import {
 } from '@veupathdb/wdk-client/lib/Components';
 import { TabbedDisplay, Tooltip } from '@veupathdb/coreui';
 import { CommonResultTable as InternalGeneDatasetTable } from '@veupathdb/wdk-client/lib/Components/Shared/CommonResultTable';
-import { useIsRefOverflowingVertically } from '@veupathdb/wdk-client/lib/Hooks/Overflow';
 import QuestionController, {
   useSetSearchDocumentTitle,
   Props,
@@ -57,7 +55,6 @@ import { isPreferredDataset } from '../../util/preferredOrganisms';
 import { PageLoading } from '../common/PageLoading';
 
 import './InternalGeneDataset.scss';
-import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import LockIcon from '@material-ui/icons/Lock';
 import PublicIcon from '@material-ui/icons/Public';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
@@ -1143,28 +1140,5 @@ function makeLinkClickHandler(
 }
 
 function OrganismCell(props: { value: string }) {
-  const containerRef = useRef<HTMLElement>(null);
-  const [isExpanded, setIsExpanded] = useState(false);
-  const maxHeight: CSSProperties['maxHeight'] = isExpanded
-    ? 'fit-content'
-    : '2.5em';
-  const isOverflowingV = useIsRefOverflowingVertically(containerRef);
-  return (
-    <>
-      {safeHtml(
-        props.value,
-        { ref: containerRef, style: { maxHeight, overflow: 'hidden' } },
-        'div'
-      )}
-      {isOverflowingV && (
-        <button
-          type="button"
-          className="link"
-          onClick={() => setIsExpanded((v) => !v)}
-        >
-          {isExpanded ? 'Read less' : 'Read more'}
-        </button>
-      )}
-    </>
-  );
+  return safeHtml(props.value, undefined, 'div');
 }


### PR DESCRIPTION

<img width="1771" height="560" alt="2026-07-21_07-42" src="https://github.com/user-attachments/assets/1636a890-121f-4167-ae54-165c16985063" />

  **Integrated UserDatasets (user-uploaded data) alongside DataSources (curated data) in the InternalGeneDataset component.**

  Changes

  - Parallel data fetching: Fetch both DataSources and UserDatasets via Promise.all
  - Source type column: Added icon column showing site favicon (internal), globe (public UD), or lock (private UD)
  - Filter checkboxes: Added filters to show/hide each source type
  - Array-based question mapping: Changed datasetNamesByQuestion from Record<string, string> to Record<string, string[]> to support multiple datasets
   sharing the same question name
  - Parameterized URLs: UserDatasets use query params (?param.dataset=value#question) vs DataSources hash-only URLs
  - UserDataset processing: Added getUserDatasetRecords() and getUserDatasetInternalQuestions() to normalize UserDataset responses into common
  DatasourceRecord shape

  Technical Notes

  - UserDatasets share generic question names while DataSources have unique ones
  - EDAUD_ prefix kept in record URLs, stripped for question parameters
  - Backend returns is_public as string, converted to boolean client-side
