### PR TITLE
DE notebook - fix incorrect auto-selection locking out valid Gene identifier options in shared-inputs cells

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/InputVariables.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/InputVariables.tsx
@@ -6,6 +6,7 @@ import {
   DataElementConstraintRecord,
   filterConstraints,
   disabledVariablesForInput,
+  jointCandidateEntities,
   VariablesByInputName,
 } from '../../utils/data-element-constraints';
 
@@ -389,6 +390,25 @@ export function InputVariables(props: Props) {
       // Skip inputs whose constraints haven't been resolved yet (disabled === undefined
       // means "unknown", not "unrestricted" — same guard as autoSelectWhenPossible).
       if (disabled == null) continue;
+
+      // If this input shares a same-branch dependency group with another
+      // input (ex. identifierVariable + valueVariable), and more than one
+      // entity could still satisfy every input in that group, the entity
+      // choice is still ambiguous. Auto-selecting a featured variable here
+      // would arbitrarily lock the whole group onto one entity (e.g. the
+      // first one in tree order) before the user gets a chance to choose.
+      const groupIndex = dataElementDependencyOrder?.findIndex((group) =>
+        group.includes(input.name)
+      );
+      if (groupIndex != null && groupIndex !== -1) {
+        const candidates = jointCandidateEntities(
+          dataElementDependencyOrder![groupIndex],
+          entities,
+          disabledVariablesByInputName
+        );
+        if (candidates.size > 1) continue;
+      }
+
       const first = featuredFields.find((field) => {
         const [entityId, variableId] = field.term.split('/');
         if (!disabled.length) return true;

--- a/packages/libs/eda/src/lib/core/utils/data-element-constraints.test.ts
+++ b/packages/libs/eda/src/lib/core/utils/data-element-constraints.test.ts
@@ -1,0 +1,90 @@
+import { jointCandidateEntities } from './data-element-constraints';
+import { StudyEntity, StringVariable } from '../types/study';
+import { VariableDescriptor } from '../types/variable';
+
+function makeStringVariable(id: string, isFeatured = false): StringVariable {
+  return {
+    id,
+    providerLabel: id,
+    displayName: id,
+    hideFrom: [],
+    type: 'string',
+    dataShape: 'categorical',
+    distinctValuesCount: 5,
+    isTemporal: false,
+    isFeatured,
+    isMergeKey: false,
+    isMultiValued: false,
+  };
+}
+
+function makeEntity(id: string, variables: StringVariable[]): StudyEntity {
+  return {
+    id,
+    idColumnName: id + '_id',
+    displayName: id,
+    description: '',
+    variables,
+    isManyToOneWithParent: false,
+  };
+}
+
+// Mirrors the real-world bug: two sibling entities (two independent RNASeq
+// datasets under the same "Sample" parent), each with their own gene
+// identifier variable and their own measurement variable.
+const hsapref = makeEntity('hsapref_htseq', [
+  makeStringVariable('VEUPATHDB_GENE_ID'),
+  makeStringVariable('SEQUENCE_READ_COUNT_SENSE', true),
+]);
+const pfal3d7 = makeEntity('pfal3d7_htseq', [
+  makeStringVariable('VEUPATHDB_GENE_ID'),
+  makeStringVariable('SEQUENCE_READ_COUNT_SENSE', true),
+]);
+const entities = [hsapref, pfal3d7];
+
+describe('jointCandidateEntities', () => {
+  it('returns both sibling entities when neither input has been narrowed yet', () => {
+    const disabledVariablesByInputName: Record<string, VariableDescriptor[]> = {
+      identifierVariable: [],
+      valueVariable: [],
+    };
+
+    const result = jointCandidateEntities(
+      ['identifierVariable', 'valueVariable'],
+      entities,
+      disabledVariablesByInputName
+    );
+
+    expect(result).toEqual(new Set(['hsapref_htseq', 'pfal3d7_htseq']));
+  });
+
+  it('returns a single entity once one input has been narrowed to it', () => {
+    // Simulates identifierVariable already being locked to pfal3d7 (e.g. by
+    // the user), which disables hsapref's variables via the dependency-order
+    // same-branch rule.
+    const disabledVariablesByInputName: Record<string, VariableDescriptor[]> = {
+      identifierVariable: [
+        { entityId: 'hsapref_htseq', variableId: 'VEUPATHDB_GENE_ID' },
+        {
+          entityId: 'hsapref_htseq',
+          variableId: 'SEQUENCE_READ_COUNT_SENSE',
+        },
+      ],
+      valueVariable: [
+        { entityId: 'hsapref_htseq', variableId: 'VEUPATHDB_GENE_ID' },
+        {
+          entityId: 'hsapref_htseq',
+          variableId: 'SEQUENCE_READ_COUNT_SENSE',
+        },
+      ],
+    };
+
+    const result = jointCandidateEntities(
+      ['identifierVariable', 'valueVariable'],
+      entities,
+      disabledVariablesByInputName
+    );
+
+    expect(result).toEqual(new Set(['pfal3d7_htseq']));
+  });
+});

--- a/packages/libs/eda/src/lib/core/utils/data-element-constraints.test.ts
+++ b/packages/libs/eda/src/lib/core/utils/data-element-constraints.test.ts
@@ -87,6 +87,9 @@ describe('jointCandidateEntities', () => {
     );
 
     expect(result).toEqual(new Set(['pfal3d7_htseq']));
+  });
+});
+
 describe('ancestorEntitiesForEntityId - PCA overlay entity scoping', () => {
   // Mirrors the real WGCNA/PCA notebook study tree: "Sample" is the root
   // entity, with the four RNASeq/WGCNA entities as its *children* (not

--- a/packages/libs/eda/src/lib/core/utils/data-element-constraints.ts
+++ b/packages/libs/eda/src/lib/core/utils/data-element-constraints.ts
@@ -230,6 +230,42 @@ function variableConstraintPredicate(
   );
 }
 
+/**
+ * Given a group of input names that share a `dataElementDependencyOrder`
+ * same-branch relationship, returns the set of entity ids that still have
+ * at least one enabled (non-disabled) variable for *every* input in the
+ * group. When this set has more than one member, the entity choice for the
+ * group is still ambiguous — auto-selecting a featured variable for one of
+ * the inputs would arbitrarily lock in one entity over another equally
+ * valid one.
+ */
+export function jointCandidateEntities(
+  inputNames: string[],
+  entities: StudyEntity[],
+  disabledVariablesByInputName: Record<string, VariableDescriptor[] | undefined>
+): Set<string> {
+  return inputNames.reduce<Set<string>>((candidateEntityIds, inputName, i) => {
+    const disabled = disabledVariablesByInputName[inputName] ?? [];
+    const enabledEntityIds = new Set(
+      entities
+        .filter((entity) =>
+          entity.variables.some(
+            (variable) =>
+              variable.type !== 'category' &&
+              !disabled.some(
+                (d) => d.entityId === entity.id && d.variableId === variable.id
+              )
+          )
+        )
+        .map((entity) => entity.id)
+    );
+    if (i === 0) return enabledEntityIds;
+    return new Set(
+      [...candidateEntityIds].filter((id) => enabledEntityIds.has(id))
+    );
+  }, new Set());
+}
+
 export type VariablesByInputName<T extends string = string> = Partial<
   Record<T, VariableDescriptor>
 >;


### PR DESCRIPTION
### The bug

The Differential Expression notebook's "Select Expression Data" cell auto-selects sensible defaults for its inputs (Gene identifier, Measurement type) to save users a click when there's only one reasonable choice. On studies with a single RNASeq dataset this works fine.

On studies with **multiple RNASeq datasets** (e.g. a dual host/pathogen experiment with separate `hsapREF` and `pfal3D7` entities), the auto-selection logic _for featured variables_ picked a default *Measurement type* before the user had chosen which dataset/organism they meant. Because Gene identifier and Measurement type are required to come from the same dataset, that early pick silently eliminated the other dataset's Gene identifier from consideration — leaving users with a single, read-only "only option" dropdown showing the wrong organism's gene, with no way to switch (other than cancelling the measurement type with the :x: button, which is not obvious or desirable). In the reported case, a P. falciparum gene search defaulted to a human reference gene.

This wasn't a data problem or a one-off glitch — the code was doing exactly what it was told. The auto-select-first-featured-variable rule just didn't account for the case where more than one dataset could equally satisfy the selection.

### The fix

Before auto-selecting a value for one input in a linked group (like Gene identifier + Measurement type), we now check whether more than one dataset could still satisfy *every* input in that group. If the choice is genuinely ambiguous, we leave it to the user to pick first — auto-selection only kicks in once there's a single, unambiguous dataset left, which then applies normally.

### Testing

- New unit tests cover the ambiguous (two valid datasets) and resolved (one valid dataset) cases directly.
- Full `eda` package test suite and type-check pass.
- Manually verified against the reported reproduction case: both Gene identifier options now appear, and choosing one correctly narrows Measurement type to the matching dataset.
