### PR TITLE
Fix #1809 DE notebook PCA overlay not constrained enough

### DIFF
--- a/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
+++ b/packages/libs/eda/src/lib/core/components/visualizations/implementations/ScatterplotVisualization.tsx
@@ -98,7 +98,10 @@ import {
   DefaultNonHighlightColor,
   DefaultHighlightMarkerStyle,
 } from '@veupathdb/components/lib/types/plots/addOns';
-import { VariablesByInputName } from '../../../utils/data-element-constraints';
+import {
+  VariablesByInputName,
+  ancestorEntitiesForEntityId,
+} from '../../../utils/data-element-constraints';
 import { useRouteMatch } from 'react-router';
 import { Link } from '@veupathdb/wdk-client/lib/Components';
 import PluginError from '../PluginError';
@@ -690,6 +693,27 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
     'yAxisVariable',
     metadataYAxis?.variableSpec.entityId ?? computedYAxisDetails?.entityId
   );
+
+  // Overlay/facet variables must resolve to a single value per output row, so
+  // they can only come from the output entity itself or one of its ancestors.
+  // This matters most when the axes are computed (e.g. notebook PCA plots),
+  // where there's no user-selected axis variable for the usual
+  // dataElementDependencyOrder ancestor restriction to anchor on, leaving
+  // stratification pickers otherwise unrestricted by entity (e.g. able to
+  // pick a per-module WGCNA eigengene variable, which the backend then
+  // rejects because it isn't available on the output entity).
+  const additionalDisabledVariables = useMemo(() => {
+    if (outputEntity == null) return undefined;
+    const allowedEntityIds = new Set(
+      ancestorEntitiesForEntityId(outputEntity.id, entities).map((e) => e.id)
+    );
+    const disabled = entities
+      .filter((e) => !allowedEntityIds.has(e.id))
+      .flatMap((e) =>
+        e.variables.map((v) => ({ entityId: e.id, variableId: v.id }))
+      );
+    return { overlayVariable: disabled, facetVariable: disabled };
+  }, [entities, outputEntity]);
 
   // set a condition to show log scale/plot mode related banner
   const showLogScaleBanner: boolean =
@@ -2256,6 +2280,7 @@ function ScatterplotViz(props: VisualizationProps<Options>) {
             onChange={handleInputVariableChange}
             constraints={dataElementConstraints}
             dataElementDependencyOrder={dataElementDependencyOrder}
+            additionalDisabledVariables={additionalDisabledVariables}
             starredVariables={starredVariables}
             toggleStarredVariable={toggleStarredVariable}
             enableShowMissingnessToggle={

--- a/packages/libs/eda/src/lib/core/utils/data-element-constraints.test.ts
+++ b/packages/libs/eda/src/lib/core/utils/data-element-constraints.test.ts
@@ -1,0 +1,73 @@
+import { ancestorEntitiesForEntityId } from './data-element-constraints';
+import { StudyEntity, StringVariable } from '../types/study';
+
+function makeStringVariable(id: string, isFeatured = false): StringVariable {
+  return {
+    id,
+    providerLabel: id,
+    displayName: id,
+    hideFrom: [],
+    type: 'string',
+    dataShape: 'categorical',
+    distinctValuesCount: 5,
+    isTemporal: false,
+    isFeatured,
+    isMergeKey: false,
+    isMultiValued: false,
+  };
+}
+
+function makeEntity(id: string, variables: StringVariable[]): StudyEntity {
+  return {
+    id,
+    idColumnName: id + '_id',
+    displayName: id,
+    description: '',
+    variables,
+    isManyToOneWithParent: false,
+  };
+}
+
+describe('ancestorEntitiesForEntityId - PCA overlay entity scoping', () => {
+  // Mirrors the real WGCNA/PCA notebook study tree: "Sample" is the root
+  // entity, with the four RNASeq/WGCNA entities as its *children* (not
+  // ancestors). A PCA plot's output entity is Sample, so overlay/facet
+  // variables should only be allowed from Sample itself (no ancestors exist
+  // here, since Sample is the root) -- never from these descendant entities.
+  const hsaprefEigengene = makeEntity('hsapref_eigengene', [
+    makeStringVariable('Module_1'),
+  ]);
+  const hsaprefHtseq = makeEntity('hsapref_htseq', [
+    makeStringVariable('VEUPATHDB_GENE_ID'),
+  ]);
+  const pfal3d7Eigengene = makeEntity('pfal3d7_eigengene', [
+    makeStringVariable('Module_1'),
+  ]);
+  const pfal3d7Htseq = makeEntity('pfal3d7_htseq', [
+    makeStringVariable('VEUPATHDB_GENE_ID'),
+  ]);
+  const sample: StudyEntity = {
+    ...makeEntity('sample', [makeStringVariable('Sex')]),
+    children: [hsaprefEigengene, hsaprefHtseq, pfal3d7Eigengene, pfal3d7Htseq],
+  };
+  const treeEntities = [
+    sample,
+    hsaprefEigengene,
+    hsaprefHtseq,
+    pfal3d7Eigengene,
+    pfal3d7Htseq,
+  ];
+
+  it('resolves only the root entity itself when it is the output entity', () => {
+    const result = ancestorEntitiesForEntityId('sample', treeEntities);
+    expect(result.map((e) => e.id)).toEqual(['sample']);
+  });
+
+  it('resolves an entity and its ancestor(s) when given a child entity', () => {
+    const result = ancestorEntitiesForEntityId(
+      'pfal3d7_eigengene',
+      treeEntities
+    );
+    expect(result.map((e) => e.id)).toEqual(['sample', 'pfal3d7_eigengene']);
+  });
+});


### PR DESCRIPTION
Fixes #1809 

## Root cause

`ScatterplotVisualization.tsx`'s overlay/facet variable pickers rely only on the generic, backend-declared `dataElementConstraints`/`dataElementDependencyOrder` (from the app-overview metadata) to restrict entity scope — the same mechanism that normally works fine for regular scatterplots, because it anchors the "must be ancestor of the selected axis variable" rule off a real, user-selected x/y-axis `VariableDescriptor`.

In the notebook's PCA cell, the x/y axes are **computed** (PC1/PC2) — there's no real selected variable for `xAxisVariable`/`yAxisVariable` for that dependency-order logic to anchor on. So the ancestor restriction silently never engages, leaving the overlay picker free to offer variables from *any* entity in the tree — including the WGCNA Eigengene entities, which are siblings/children of `Sample` (`ENT_8151325d`), not ancestors. Picking one of those (e.g. `VAR_4b0229a0` on `ENT_2caaf3f6`) passes frontend validation but fails backend's `single_tabular_dataset` check, since a per-(sample, module) descendant-entity variable isn't a single value per output row.

This is exactly why DESeq2's "Group variable" *doesn't* have the problem: `differentialExpression.tsx` explicitly restricts `comparatorVariable` to ancestor entities of the (always real, user-selected) `identifierVariable` via `additionalDisabledVariables` — a mechanism `ScatterplotVisualization.tsx` never applied to `overlayVariable`/`facetVariable`.

## Fix

`outputEntity` (already computed correctly for both computed and real axes, via `useOutputEntity`) is now used to restrict `overlayVariable` and `facetVariable` to entities that are the output entity itself or one of its ancestors — mirroring the DE plugin's pattern, using the existing `ancestorEntitiesForEntityId` helper and `InputVariables`' `additionalDisabledVariables` prop. For this study, `outputEntity` = `Sample` (root, no ancestors), so all four WGCNA/expression entities are correctly excluded, leaving only genuine Sample-level clinical variables selectable — matching your "constrain, don't accommodate" preference.

## Testing

New tests pass, and new behaviour confirmed in UI by me (Bob!)