### PR TITLE
Streamline DE notebook entity counts for performance

### DIFF
--- a/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
+++ b/packages/libs/eda/src/lib/core/components/computations/groupCounts.ts
@@ -4,8 +4,7 @@ import { LabeledRange } from '../../api/DataClient/types';
 import { VariableDescriptor } from '../../types/variable';
 import { Variable } from '../../types/study';
 import { DifferentialExpressionMethod } from '../../types/apps';
-import { useStudyMetadata } from '../../hooks/workspace';
-import { useEntityCounts } from '../../hooks/entityCounts';
+import { useRootEntityCount } from '../../hooks/entityCounts';
 
 function makeGroupFilter(
   variable: VariableDescriptor,
@@ -100,8 +99,6 @@ export function useGroupCounts({
   valueVariable,
   comparatorVariableType,
 }: UseGroupCountsParams): GroupCounts {
-  const { rootEntity } = useStudyMetadata();
-
   const filtersWithFloor = useMemo(() => {
     const floorFilter = makeExpressionValueRangeFilter(method, valueVariable);
     if (floorFilter == null) return filters;
@@ -129,14 +126,11 @@ export function useGroupCounts({
     [filtersWithFloor, groupBFilter]
   );
 
-  const groupACounts = useEntityCounts(groupAFilters);
-  const groupBCounts = useEntityCounts(groupBFilters);
+  const groupACounts = useRootEntityCount(groupAFilters);
+  const groupBCounts = useRootEntityCount(groupBFilters);
 
-  const rootEntityId = rootEntity.id;
-  const groupACount =
-    groupAFilter != null ? groupACounts.value?.[rootEntityId] : undefined;
-  const groupBCount =
-    groupBFilter != null ? groupBCounts.value?.[rootEntityId] : undefined;
+  const groupACount = groupAFilter != null ? groupACounts.value : undefined;
+  const groupBCount = groupBFilter != null ? groupBCounts.value : undefined;
   const groupACountPending = groupAFilter != null && groupACounts.pending;
   const groupBCountPending = groupBFilter != null && groupBCounts.pending;
 

--- a/packages/libs/eda/src/lib/core/hooks/entityCounts.ts
+++ b/packages/libs/eda/src/lib/core/hooks/entityCounts.ts
@@ -11,10 +11,10 @@ import { useCachedPromise } from './cachedPromise';
 
 export type EntityCounts = Record<string, number>;
 
-// Shared by useEntityCounts and useRootEntityCount. Fetches a count per given
-// entity, in parallel; the returned promise is pending until all of them resolve,
-// so callers should only pass the entities they actually need counts for.
-function useEntityCountsForEntities(
+// Fetches a count per given entity, in parallel; the returned promise is
+// pending until all of them resolve, so callers should only pass the
+// entities they actually need counts for.
+export function useSpecificEntityCounts(
   filters: Filter[] | undefined,
   entities: StudyEntity[]
 ) {
@@ -52,7 +52,7 @@ function useEntityCountsForEntities(
 
 export function useEntityCounts(filters?: Filter[]) {
   const entities = useStudyEntities();
-  return useEntityCountsForEntities(filters, entities);
+  return useSpecificEntityCounts(filters, entities);
 }
 
 // Counts only the root entity, instead of fanning out a request per entity in
@@ -61,6 +61,6 @@ export function useEntityCounts(filters?: Filter[]) {
 // entity's count resolves, even if only one is ever read.
 export function useRootEntityCount(filters?: Filter[]) {
   const { rootEntity } = useStudyMetadata();
-  const result = useEntityCountsForEntities(filters, [rootEntity]);
+  const result = useSpecificEntityCounts(filters, [rootEntity]);
   return { ...result, value: result.value?.[rootEntity.id] };
 }

--- a/packages/libs/eda/src/lib/core/hooks/entityCounts.ts
+++ b/packages/libs/eda/src/lib/core/hooks/entityCounts.ts
@@ -6,14 +6,20 @@ import {
 } from './workspace';
 import { useDebounce } from '../hooks/debouncing';
 import { isStubEntity, STUB_ENTITY } from './study';
+import { StudyEntity } from '../types/study';
 import { useCachedPromise } from './cachedPromise';
 
 export type EntityCounts = Record<string, number>;
 
-export function useEntityCounts(filters?: Filter[]) {
+// Shared by useEntityCounts and useRootEntityCount. Fetches a count per given
+// entity, in parallel; the returned promise is pending until all of them resolve,
+// so callers should only pass the entities they actually need counts for.
+function useEntityCountsForEntities(
+  filters: Filter[] | undefined,
+  entities: StudyEntity[]
+) {
   const subsettingClient = useSubsettingClient();
   const { id, rootEntity } = useStudyMetadata();
-  const entities = useStudyEntities();
 
   // debounce to prevent a back end call for each click on a filter checkbox
   const debouncedFilters = useDebounce(filters, 2000);
@@ -42,4 +48,19 @@ export function useEntityCounts(filters?: Filter[]) {
   // count-based spinners - no data integrity issues, just potentially more spinning
   // during the debounce window
   return { ...result, pending: result.pending || stalePending };
+}
+
+export function useEntityCounts(filters?: Filter[]) {
+  const entities = useStudyEntities();
+  return useEntityCountsForEntities(filters, entities);
+}
+
+// Counts only the root entity, instead of fanning out a request per entity in
+// the study. Use this whenever the root entity's count is all that's needed
+// (e.g. sample-count gating) - useEntityCounts stays pending until every
+// entity's count resolves, even if only one is ever read.
+export function useRootEntityCount(filters?: Filter[]) {
+  const { rootEntity } = useStudyMetadata();
+  const result = useEntityCountsForEntities(filters, [rootEntity]);
+  return { ...result, value: result.value?.[rootEntity.id] };
 }

--- a/packages/libs/eda/src/lib/notebook/cells/ComputeNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/cells/ComputeNotebookCell.tsx
@@ -1,5 +1,5 @@
 import { Loading } from '@veupathdb/wdk-client/lib/Components';
-import { useEntityCounts } from '../../core/hooks/entityCounts';
+import { useSpecificEntityCounts } from '../../core/hooks/entityCounts';
 import { useDataClient, useStudyMetadata } from '../../core/hooks/workspace';
 import { isEqual } from 'lodash';
 import { RunComputeButton } from '../../core/components/computations/RunComputeButton';
@@ -95,8 +95,15 @@ export function ComputeNotebookCell(
     2000
   );
 
-  const totalCountsResult = useEntityCounts();
-  const filteredCountsResult = useEntityCounts(debouncedFilters);
+  const { rootEntity } = useStudyMetadata();
+
+  // Notebook computation plugins only ever gate/configure on the root
+  // (sample) entity's count, so fetch just the root entity here instead of
+  // fanning out over every entity in the study via useEntityCounts.
+  const totalCountsResult = useSpecificEntityCounts(undefined, [rootEntity]);
+  const filteredCountsResult = useSpecificEntityCounts(debouncedFilters, [
+    rootEntity,
+  ]);
   const plugin = plugins[computation.descriptor.type];
   if (plugin == null) throw new Error('Computation plugin not found.');
 
@@ -152,7 +159,6 @@ export function ComputeNotebookCell(
     computation.descriptor.configuration
   );
 
-  const { rootEntity } = useStudyMetadata();
   const pluginCountGating = plugin.getCountWarning?.(
     {
       root: {

--- a/packages/libs/eda/src/lib/notebook/cells/SubsettingNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/cells/SubsettingNotebookCell.tsx
@@ -1,9 +1,15 @@
 import { useMemo, useState } from 'react';
-import { useEntityCounts } from '../../core/hooks/entityCounts';
+import { Filter } from '../../core/types/filter';
+import { StudyEntity } from '../../core/types/study';
+import {
+  useEntityCounts,
+  useRootEntityCount,
+} from '../../core/hooks/entityCounts';
 import {
   useGetDefaultVariableDescriptor,
   useStudyEntities,
 } from '../../core/hooks/workspace';
+import { AnalysisState } from '../../core';
 import { VariableLinkConfig } from '../../core/components/VariableLink';
 import FilterChipList from '../../core/components/FilterChipList';
 import Subsetting from '../../workspace/Subsetting';
@@ -40,34 +46,40 @@ export function SubsettingNotebookCell(
   }, []);
 
   const entities = useStudyEntities();
-  const totalCountsResult = useEntityCounts();
-  const filteredCountsResult = useEntityCounts(
-    analysisState.analysis?.descriptor.subset.descriptor
+  const filters = analysisState.analysis?.descriptor.subset.descriptor;
+
+  // Cheap: only the root entity's count, so the subtitle doesn't have to wait
+  // on (or pay for) a count of every entity in the study.
+  const totalRootCount = useRootEntityCount();
+  const filteredRootCount = useRootEntityCount(filters);
+
+  const [panelState, setPanelState] = useState<'open' | 'closed'>(
+    cell.initialPanelState ?? 'open'
   );
 
   const subTitle = useMemo(() => {
-    if (filteredCountsResult.pending || totalCountsResult.pending)
+    if (filteredRootCount.pending || totalRootCount.pending)
       return 'Please wait...';
     const rootEntity = entities[0];
     if (
       !rootEntity ||
-      filteredCountsResult.value == null ||
-      totalCountsResult.value == null
+      filteredRootCount.value == null ||
+      totalRootCount.value == null
     )
       return undefined;
-    const filteredCount = filteredCountsResult.value[rootEntity.id];
-    const totalCount = totalCountsResult.value[rootEntity.id];
-    if (filteredCount == null || totalCount == null) return undefined;
-    const entityLabel = makeEntityDisplayName(rootEntity, totalCount !== 1);
-    if (filteredCount === totalCount)
-      return `${totalCount.toLocaleString()} ${entityLabel}`;
-    return `${filteredCount.toLocaleString()} of ${totalCount.toLocaleString()} ${entityLabel}`;
+    const entityLabel = makeEntityDisplayName(
+      rootEntity,
+      totalRootCount.value !== 1
+    );
+    if (filteredRootCount.value === totalRootCount.value)
+      return `${totalRootCount.value.toLocaleString()} ${entityLabel}`;
+    return `${filteredRootCount.value.toLocaleString()} of ${totalRootCount.value.toLocaleString()} ${entityLabel}`;
   }, [
     entities,
-    filteredCountsResult.pending,
-    filteredCountsResult.value,
-    totalCountsResult.pending,
-    totalCountsResult.value,
+    filteredRootCount.pending,
+    filteredRootCount.value,
+    totalRootCount.pending,
+    totalRootCount.value,
   ]);
 
   return (
@@ -76,40 +88,79 @@ export function SubsettingNotebookCell(
       <ExpandablePanel
         title={cell.title}
         subTitle={subTitle ?? ''}
-        state={cell.initialPanelState ?? 'open'}
+        state={panelState}
+        onStateChange={setPanelState}
         themeRole="primary"
       >
         <div
           className={'NotebookCellContent' + (isDisabled ? ' disabled' : '')}
         >
-          <div>
-            <FilterChipList
-              filters={analysisState.analysis?.descriptor.subset.descriptor}
+          {panelState === 'open' && (
+            <SubsettingPanelBody
+              analysisState={analysisState}
               entities={entities}
-              selectedEntityId={entityId}
-              selectedVariableId={variableId}
-              removeFilter={(filter) => {
-                analysisState.setFilters((filters) =>
-                  filters.filter(
-                    (f) =>
-                      f.entityId !== filter.entityId ||
-                      f.variableId !== filter.variableId
-                  )
-                );
-              }}
+              filters={filters}
+              entityId={entityId}
+              variableId={variableId}
               variableLinkConfig={variableLinkConfig}
             />
-          </div>
-          <Subsetting
-            analysisState={analysisState}
-            entityId={entityId ?? ''}
-            variableId={variableId ?? ''}
-            totalCounts={totalCountsResult.value}
-            filteredCounts={filteredCountsResult.value}
-            variableLinkConfig={variableLinkConfig}
-          />
+          )}
         </div>
       </ExpandablePanel>
+    </>
+  );
+}
+
+// Only mounted while the panel is expanded. Unlike the subtitle above, the
+// subsetting UI lets the user browse to any entity in the tree, so it needs
+// the full multi-entity count map - which is the expensive fetch we're
+// deferring until it's actually needed.
+function SubsettingPanelBody({
+  analysisState,
+  entities,
+  filters,
+  entityId,
+  variableId,
+  variableLinkConfig,
+}: {
+  analysisState: AnalysisState;
+  entities: StudyEntity[];
+  filters: Filter[] | undefined;
+  entityId: string | undefined;
+  variableId: string | undefined;
+  variableLinkConfig: VariableLinkConfig;
+}) {
+  const totalCountsResult = useEntityCounts();
+  const filteredCountsResult = useEntityCounts(filters);
+
+  return (
+    <>
+      <div>
+        <FilterChipList
+          filters={filters}
+          entities={entities}
+          selectedEntityId={entityId}
+          selectedVariableId={variableId}
+          removeFilter={(filter) => {
+            analysisState.setFilters((filters) =>
+              filters.filter(
+                (f) =>
+                  f.entityId !== filter.entityId ||
+                  f.variableId !== filter.variableId
+              )
+            );
+          }}
+          variableLinkConfig={variableLinkConfig}
+        />
+      </div>
+      <Subsetting
+        analysisState={analysisState}
+        entityId={entityId ?? ''}
+        variableId={variableId ?? ''}
+        totalCounts={totalCountsResult.value}
+        filteredCounts={filteredCountsResult.value}
+        variableLinkConfig={variableLinkConfig}
+      />
     </>
   );
 }

--- a/packages/libs/eda/src/lib/notebook/cells/VisualizationNotebookCell.tsx
+++ b/packages/libs/eda/src/lib/notebook/cells/VisualizationNotebookCell.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useMemo } from 'react';
-import { useEntityCounts } from '../../core/hooks/entityCounts';
-import { useDataClient, useStudyEntities } from '../../core/hooks/workspace';
+import { useSpecificEntityCounts } from '../../core/hooks/entityCounts';
+import {
+  useDataClient,
+  useStudyEntities,
+  useStudyMetadata,
+} from '../../core/hooks/workspace';
 import { useGeoConfig } from '../../core/hooks/geoConfig';
 import { plugins } from '../../core/components/computations/plugins';
 import { PlotContainerStyleOverrides } from '../../core/components/visualizations/VisualizationTypes';
@@ -31,9 +35,17 @@ export function VisualizationNotebookCell(
 
   const entities = useStudyEntities();
   const geoConfigs = useGeoConfig(entities);
-  const totalCountsResult = useEntityCounts();
-  const filteredCountsResult = useEntityCounts(
-    analysis.descriptor.subset.descriptor
+  const { rootEntity } = useStudyMetadata();
+  // The PCA scatterplot and volcano plot notebook visualizations only ever
+  // read/gate on the root (sample) entity's count, so fetch just that entity
+  // instead of fanning out across every entity in the study via useEntityCounts.
+  // This also lets this query share a cache entry (and thus a single backend
+  // request) with the root-only counts fetched by ComputeNotebookCell and
+  // SubsettingNotebookCell.
+  const totalCountsResult = useSpecificEntityCounts(undefined, [rootEntity]);
+  const filteredCountsResult = useSpecificEntityCounts(
+    analysis.descriptor.subset.descriptor,
+    [rootEntity]
   );
   const { enqueueSnackbar } = useSnackbar();
 


### PR DESCRIPTION
### Problem

The Differential Expression and Antibody Array notebooks were fetching sample counts far more aggressively than needed. `useEntityCounts` fans out one backend request *per entity in the study* and only resolves once every single one comes back — but almost every consumer in these notebooks only ever reads the root (sample) entity's count. On datasets where some entities are expensive to count, this made several notebook cells slower than they needed to be, and in a couple of places we were fetching the same data twice.

### Changes

- **New `useRootEntityCount`/`useSpecificEntityCounts` hooks** (`core/hooks/entityCounts.ts`) alongside the existing `useEntityCounts`, so callers can request counts for just the entity (or entities) they actually need instead of the whole study tree.
- **DESeq2/limma group-size gating** (`groupCounts.ts`) now fetches only the root entity's count per comparison group, instead of two full-study fetches.
- **Compute and visualization cells** (PCA setup, DESeq2/limma setup, PCA plot, volcano plot) now request only the root entity's count, since that's all their gating/config logic ever reads.
- **Subsetting cell**: the cheap subtitle ("1,234 of 5,678 samples") now uses the root-only hook. The full multi-entity count (needed by the subsetting UI itself, which lets users browse any entity) is deferred into its own component that only mounts once the panel is actually expanded — so it's no longer fetched at all if the user never opens that section.
- As a side effect, several call sites now share the same cache entry, which also eliminated a case where the root entity's count was being requested twice from two different code paths.

### Impact

No behavior change for users — same counts, same UI. Fewer and cheaper backend requests on notebook load, most noticeably on studies where per-entity counts are slow.
