### PR TITLE
move source-type checkboxes into table toolbar, standardize casing

### DIFF
--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.scss
@@ -11,11 +11,17 @@
     margin-bottom: 0.25em;
   }
 
+  .TableToolbar-Children {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem 2rem;
+  }
+
   .wdk-RealTimeSearchBoxContainer {
     display: flex;
     align-items: center;
     white-space: nowrap;
-    margin-right: 0.5rem;
 
     span {
       margin-right: 1em;
@@ -24,9 +30,8 @@
 
   &SourceFilters {
     display: flex;
+    flex-wrap: wrap;
     gap: 1.5rem;
-    margin-top: 1.5rem;
-    margin-bottom: 0.25rem;
     padding: 0.5rem;
 
     label {

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/questions/InternalGeneDataset.tsx
@@ -367,41 +367,8 @@ function InternalGeneDatasetContent(props: Props) {
           ))}
         </div>
       </div>
-      <div className={cx('SourceFilters')}>
-        <label>
-          <input
-            type="checkbox"
-            checked={showDataSources}
-            onChange={(e) => setShowDataSources(e.target.checked)}
-          />
-          <img
-            src={`${webAppUrl}/images/${projectId}/favicon.ico`}
-            alt="VEuPathDB workflow dataset"
-            style={{ width: '20px', height: '20px', objectFit: 'contain' }}
-          />
-          {' VEuPathDB workflow datasets'}
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={showPublicUserDatasets}
-            onChange={(e) => setShowPublicUserDatasets(e.target.checked)}
-          />
-          <PublicIcon style={{ width: '20px', height: '20px' }} />
-          {' Public User Datasets'}
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={showPrivateUserDatasets}
-            onChange={(e) => setShowPrivateUserDatasets(e.target.checked)}
-          />
-          <LockIcon style={{ width: '20px', height: '20px' }} />
-          {' Private User Datasets'}
-        </label>
-      </div>
       <InternalGeneDatasetTable
-        searchBoxHeader="Filter Datasets:"
+        searchBoxHeader="Filter datasets:"
         emptyResultMessage={
           (
             <OrganismPreferencesWarning
@@ -566,7 +533,41 @@ function InternalGeneDatasetContent(props: Props) {
         ]}
         initialSortColumnKey="organism_prefix"
         fixedTableHeader
-      ></InternalGeneDatasetTable>
+      >
+        <div className={cx('SourceFilters')}>
+          <label>
+            <input
+              type="checkbox"
+              checked={showDataSources}
+              onChange={(e) => setShowDataSources(e.target.checked)}
+            />
+            <img
+              src={`${webAppUrl}/images/${projectId}/favicon.ico`}
+              alt="VEuPathDB curated dataset"
+              style={{ width: '20px', height: '20px', objectFit: 'contain' }}
+            />
+            {' VEuPathDB curated datasets'}
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={showPublicUserDatasets}
+              onChange={(e) => setShowPublicUserDatasets(e.target.checked)}
+            />
+            <PublicIcon style={{ width: '20px', height: '20px' }} />
+            {' Public user datasets'}
+          </label>
+          <label>
+            <input
+              type="checkbox"
+              checked={showPrivateUserDatasets}
+              onChange={(e) => setShowPrivateUserDatasets(e.target.checked)}
+            />
+            <LockIcon style={{ width: '20px', height: '20px' }} />
+            {' Private user datasets'}
+          </label>
+        </div>
+      </InternalGeneDatasetTable>
       {showingRecordToggle && (
         <div
           className={cx('RecordToggle')}


### PR DESCRIPTION
Move the VEuPathDB curated/Public user/Private user dataset checkboxes into the CommonResultTable children slot so they sit in the Mesa toolbar next to the search box instead of as a separate block above the table. Also standardizes label casing across the toolbar ("Filter datasets:", "Public/Private user datasets") and widens the gap between the search box and the checkbox group.


<img width="1455" height="567" alt="image" src="https://github.com/user-attachments/assets/79e11630-a889-4467-a769-e181c18b3644" />
