### PR TITLE
Feature ai user comments banner update and client tweaks

### DIFF
--- a/packages/libs/web-common/src/components/Announcements.tsx
+++ b/packages/libs/web-common/src/components/Announcements.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import { groupBy, noop } from 'lodash';
-import { connect, useSelector } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 
 import { Link, IconAlt } from '@veupathdb/wdk-client/lib/Components';
 import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
@@ -10,6 +10,11 @@ import { safeHtml } from '@veupathdb/wdk-client/lib/Utils/ComponentUtils';
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 import { SubscriptionGroup } from '@veupathdb/wdk-client/lib/Service/Mixins/OauthService';
 import { ServiceConfig } from '@veupathdb/wdk-client/lib/Service/ServiceBase';
+import {
+  updateSectionVisibility,
+  updateNavigationCategoryExpansion,
+} from '@veupathdb/wdk-client/lib/Actions/RecordActions';
+import * as Category from '@veupathdb/wdk-client/lib/Utils/CategoryUtils';
 import { makeEdaRoute } from '../routes';
 import { colors, Warning } from '@veupathdb/coreui';
 import Banner, {
@@ -34,6 +39,11 @@ interface AnnouncementRenderProps extends ServiceConfig {
   currentUser: User;
   subscriptionGroups: SubscriptionGroup[] | undefined;
   onClose?: () => void;
+  // Expand (and reveal in the sidebar nav) a collapsed record section by its
+  // anchor id. Needed because the hash-based expand effect in RecordUI only
+  // fires on mount/record change, not when a hash link is clicked on an
+  // already-mounted record page (e.g. this banner).
+  expandRecordSection: (anchor: string) => void;
 }
 
 interface SiteMessage {
@@ -191,8 +201,8 @@ const siteAnnouncements: SiteAnnouncement[] = [
     renderDisplay: ({
       location,
       record,
-      projectId,
       onClose,
+      expandRecordSection,
     }: AnnouncementRenderProps) => {
       if (!location.pathname.startsWith('/record/gene')) return null;
 
@@ -206,14 +216,18 @@ const siteAnnouncements: SiteAnnouncement[] = [
         record.record?.id?.find(({ name }) => name === 'source_id') ?? {};
       if (!geneId) return null;
 
-      const url = `https://pgb.liv.ac.uk/aisum/?db=${projectId}&gene=${geneId}`;
+      const url = '#UserComments';
+      const goToUserComments = () => {
+        expandRecordSection('UserComments');
+        window.location.hash = 'UserComments';
+      };
 
       const bannerProps: BannerProps = {
         type: 'info',
         message: (
           <div style={{ fontSize: '1.2em' }}>
             <b>New:</b>{' '}
-            <a href={url} target="_blank">
+            <a href={url} onClick={() => expandRecordSection('UserComments')}>
               Prototype AI tool
             </a>{' '}
             for summarizing what an open-access publication or uploaded PDF says
@@ -222,9 +236,7 @@ const siteAnnouncements: SiteAnnouncement[] = [
         ),
         primaryActionButtonProps: {
           text: 'Check it out!',
-          onPress: () => {
-            window.open(url, '_blank');
-          },
+          onPress: goToUserComments,
         },
       };
       return (
@@ -1398,6 +1410,33 @@ function Announcements({
   const location = useLocation();
   const data = useWdkService(fetchAnnouncementsData, []);
   const record = useSelector((state: RootState) => state.record);
+  const dispatch = useDispatch();
+
+  // Expand (and reveal in the sidebar nav) a collapsed record section by its
+  // anchor id. Mirrors GeneRecordClasses.GeneRecordClass.jsx's
+  // handleSectionLinkClick: the anchor's href handles the scroll, while this
+  // dispatch opens the CollapsibleSection, since the hash-based effect in
+  // RecordUI only fires on mount/record change, not on in-page hash clicks.
+  const expandRecordSection = useCallback(
+    (anchor: string) => {
+      const parentCategoryIds = Category.getAncestors(
+        record.categoryTree,
+        anchor
+      ).map(Category.getId);
+      dispatch(updateSectionVisibility(anchor, true));
+      dispatch(
+        updateNavigationCategoryExpansion(
+          Array.from(
+            new Set([
+              ...record.navigationCategoriesExpanded,
+              ...parentCategoryIds,
+            ])
+          )
+        )
+      );
+    },
+    [dispatch, record.categoryTree, record.navigationCategoriesExpanded]
+  );
 
   const onCloseFactory = useCallback(
     (id: string) => () => {
@@ -1463,6 +1502,7 @@ function Announcements({
                 currentUser,
                 subscriptionGroups,
                 onClose,
+                expandRecordSection,
               })
             : category !== 'information' || location.pathname === '/'
             ? toElement(announcementData)

--- a/packages/sites/genomics-site/package.json
+++ b/packages/sites/genomics-site/package.json
@@ -102,5 +102,8 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "dependencies": {
+    "diff": "^9.0.0"
+  }
 }

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/common/UserComments.jsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/common/UserComments.jsx
@@ -47,12 +47,14 @@ export function addCommentLink(getLink, getAiLink) {
                 demo. Restore for production (renders regardless of the
                 allowAiAssistedCommentCreation flag):
             <a href={link} style={buttonStyle}>
+              <i className="fa fa-plus" />
               Add a comment <i className="fa fa-comment" />
             </a>
             */}
             {/* AI button is gated: shown only when the feature is enabled. */}
             {allowAiAssistedCommentCreation && (
               <Link to={getAiLink(props)} style={buttonStyle}>
+                <i className="fa fa-plus" />
                 Add AI-assisted comment <span style={betaPillStyle}>Beta</span>
               </Link>
             )}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/userComments/UserCommentShow/AiProvenanceSection.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/userComments/UserCommentShow/AiProvenanceSection.tsx
@@ -1,3 +1,4 @@
+import { gray } from '@veupathdb/coreui/lib/definitions/colors';
 import { AiProvenance } from '../../../types/userCommentTypes';
 import { LazyPubmedPreview } from './LazyPubmedPreview';
 import { Row } from './CommentSectionRow';
@@ -39,7 +40,14 @@ export function AiProvenanceSection({
             <summary style={{ cursor: 'pointer', color: LINK_BLUE }}>
               Show edits to AI-generated text
             </summary>
-            <div style={{ marginTop: '6px' }}>
+            <div
+              style={{
+                marginTop: '6px',
+                border: `1px solid ${gray[400]}`,
+                borderRadius: 7,
+                padding: '10px 14px',
+              }}
+            >
               <div style={{ fontWeight: 600, fontSize: '14px' }}>Headline</div>
               <div style={{ marginBottom: '8px' }}>
                 <TextDiff before={originalHeadline} after={headline} />

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/userComments/UserCommentShow/AiProvenanceSection.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/userComments/UserCommentShow/AiProvenanceSection.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
 import { AiProvenance } from '../../../types/userCommentTypes';
 import { LazyPubmedPreview } from './LazyPubmedPreview';
 import { Row } from './CommentSectionRow';
+import { TextDiff } from './TextDiff';
 
 const GREY = '#888';
 const LINK_BLUE = '#336f99';
 
 interface Props {
   aiProvenance: AiProvenance;
+  // The published (possibly author-edited) headline/content, diffed against
+  // aiProvenance.originalHeadline/originalContent.
+  headline: string;
+  content: string;
 }
 
 // AI provenance shown below the comment content (the headline + content stay the
@@ -15,7 +19,11 @@ interface Props {
 // Rendered as labelled rows in the same style as the other references, with the
 // source under the standard "PubMed Article(s)" heading so AI and human comments
 // match.
-export function AiProvenanceSection({ aiProvenance }: Props): JSX.Element {
+export function AiProvenanceSection({
+  aiProvenance,
+  headline,
+  content,
+}: Props): JSX.Element {
   const { isEdited, source, originalHeadline, originalContent } = aiProvenance;
 
   const howSentence = isEdited
@@ -29,17 +37,17 @@ export function AiProvenanceSection({ aiProvenance }: Props): JSX.Element {
         {isEdited && (
           <details style={{ marginTop: '6px' }}>
             <summary style={{ cursor: 'pointer', color: LINK_BLUE }}>
-              Show original AI-generated text
+              Show edits to AI-generated text
             </summary>
             <div style={{ marginTop: '6px' }}>
-              <div style={{ fontWeight: 600, fontSize: '14px' }}>
-                Original AI-generated headline
+              <div style={{ fontWeight: 600, fontSize: '14px' }}>Headline</div>
+              <div style={{ marginBottom: '8px' }}>
+                <TextDiff before={originalHeadline} after={headline} />
               </div>
-              <div style={{ marginBottom: '8px' }}>{originalHeadline}</div>
-              <div style={{ fontWeight: 600, fontSize: '14px' }}>
-                Original AI-generated content
+              <div style={{ fontWeight: 600, fontSize: '14px' }}>Content</div>
+              <div>
+                <TextDiff before={originalContent} after={content} />
               </div>
-              <div style={{ whiteSpace: 'pre-wrap' }}>{originalContent}</div>
             </div>
           </details>
         )}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/userComments/UserCommentShow/TextDiff.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/userComments/UserCommentShow/TextDiff.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { diffWords } from 'diff';
+import { green, red } from '@veupathdb/coreui/lib/definitions/colors';
+
+interface Props {
+  before: string;
+  after: string;
+}
+
+// Inline word-level diff between the AI-generated original and the
+// author-edited, published text. Additions are highlighted green; deletions
+// are highlighted red with a strikethrough (unchanged text is left plain),
+// so the original wording is still fully readable alongside the edit.
+export function TextDiff({ before, after }: Props): JSX.Element {
+  const changes = diffWords(before, after);
+
+  return (
+    <span style={{ whiteSpace: 'pre-wrap' }}>
+      {changes.map((change, index) => {
+        if (change.added) {
+          return (
+            <ins
+              key={index}
+              style={{
+                background: green[100],
+                color: green[900],
+                textDecoration: 'none',
+              }}
+            >
+              {change.value}
+            </ins>
+          );
+        }
+        if (change.removed) {
+          return (
+            <del
+              key={index}
+              style={{
+                background: red[100],
+                color: red[900],
+              }}
+            >
+              {change.value}
+            </del>
+          );
+        }
+        return <React.Fragment key={index}>{change.value}</React.Fragment>;
+      })}
+    </span>
+  );
+}

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/userComments/UserCommentShow/UserCommentCard.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/components/userComments/UserCommentShow/UserCommentCard.tsx
@@ -123,7 +123,11 @@ export function UserCommentCard({
 
       <div style={{ marginTop: '12px' }}>
         {comment.aiProvenance != null && (
-          <AiProvenanceSection aiProvenance={comment.aiProvenance} />
+          <AiProvenanceSection
+            aiProvenance={comment.aiProvenance}
+            headline={comment.headline ?? ''}
+            content={comment.content}
+          />
         )}
         <CommentReferences comment={comment} webAppUrl={webAppUrl} />
       </div>

--- a/packages/sites/genomics-site/webapp/wdkCustomization/js/client/controllers/AiGenePublicationAddController.tsx
+++ b/packages/sites/genomics-site/webapp/wdkCustomization/js/client/controllers/AiGenePublicationAddController.tsx
@@ -47,7 +47,7 @@ import { useCachedPromise } from '@veupathdb/eda/lib/core/hooks/cachedPromise';
 import { useDebounce } from '@veupathdb/eda/lib/core/hooks/debouncing';
 
 const POLL_INTERVAL_MS = 1000;
-const PUBMED_PREVIEW_DEBOUNCE_MS = 400;
+const PUBMED_PREVIEW_DEBOUNCE_MS = 1000;
 
 const NAV_GUARD_MESSAGE =
   'You haven’t published this comment yet — leave anyway?';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8923,6 +8923,7 @@ __metadata:
     cytoscape: "npm:^3.15.2"
     cytoscape-dagre: "npm:^1.3.0"
     cytoscape-panzoom: "npm:^2.5.2"
+    diff: "npm:^9.0.0"
     file-loader: "npm:^3.0.1"
     html-webpack-plugin: "npm:^4.5.2"
     ify-loader: "npm:^1.1.0"
@@ -17327,6 +17328,13 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: 10/ec09ec2101934ca5966355a229d77afcad5911c92e2a77413efda5455636c4cf2ce84057e2d7715227a2eeeda04255b849bd3ae3a4dd22eb22e86e76456df069
+  languageName: node
+  linkType: hard
+
+"diff@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "diff@npm:9.0.0"
+  checksum: 10/f8b5e38a6a7ec73d1850ccb7ff19cda1d02502dc0f2c562ada0f40d7211bfb3075c2f3742104619a1f8f47ae333d48a6c77bffb080a2df900db36935080ea4fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1802
(miscellaneous tweaks)

Banner links no longer go to Liverpool and now behave like regular gene page navigation links (auto-expand target sections).

