### PR TITLE
Add stale module branch switching guidance

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -247,6 +247,18 @@ yarn build-npm-modules
 
 _Using the equivalent `nx` command (`yarn nx build-npm-modules @veupathdb/<package>`) has proven inadequate in this scenario._
 
+=== Switching branches
+
+`lib` package build output (eg `packages/libs/*/lib`) is gitignored, so it is not cleaned up by git when you switch branches. Stale build artifacts left over from a previously checked-out branch can persist alongside (or instead of) the current source, which is especially dangerous for packages that glob a directory at build time (eg `require.context`) since removed/renamed files can still get bundled.
+
+If you see unexplained module resolution errors after switching branches, clean and rebuild the affected package:
+
+[source, shell]
+----
+yarn workspace <package name> clean
+yarn workspace <package name> build-npm-modules
+----
+
 == Notes on individual packages
 
 === EDA dev server


### PR DESCRIPTION
When switching to very old branches (e.g. the production legacy branch) you can get "module not found" errors:

```
[webpack-dev-middleware] ModuleNotFoundError: Module not found: Error: Can't resolve 'dompurify' in '/Users/cristinaaurrecoechea/WORK/localsite/web-monorepo/packages/libs/web-common/lib/components/records'
```

This is coming from the component wrapper system that globs files in `lib` directories at build time. If those git-ignored directories contain "stale" future files, there can be problems with future dependencies not being available. This PR just adds guidance to the developer how to clean up in these circumstances.